### PR TITLE
Improve console extensions including flags

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -9,42 +9,58 @@
   },
   {
     "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
     "properties": {
       "id": "alerting",
-      "name": "Alerting",
+      "name": "%public~Alerting%",
       "href": "/monitoring/alerts",
       "perspective": "admin",
-      "section": "observe"
+      "section": "observe",
+      "startsWith": ["monitoring/alertrules", "monitoring/silences"]
     }
   },
   {
     "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
     "properties": {
       "id": "metrics",
-      "name": "Metrics",
+      "name": "%public~Metrics%",
       "href": "/monitoring/query-browser",
       "perspective": "admin",
-      "section": "observe"
+      "section": "observe",
+      "insertAfter": "alerts"
     }
   },
   {
     "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
     "properties": {
       "id": "dashboards",
-      "name": "Dashboards",
+      "name": "%public~Dashboards%",
       "href": "/monitoring/dashboards",
       "perspective": "admin",
-      "section": "observe"
+      "section": "observe",
+      "insertAfter": "metrics"
     }
   },
   {
     "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
     "properties": {
       "id": "targets",
-      "name": "Targets",
+      "name": "%public~Targets%",
       "href": "/monitoring/targets",
       "perspective": "admin",
-      "section": "observe"
+      "section": "observe",
+      "insertAfter": "dashboards"
     }
   }
 ]


### PR DESCRIPTION
This PR adjusts the extensions to match the original ones that consider flags to hide or show the observe menu and submenus: https://github.com/openshift/console/blob/master/frontend/packages/console-app/console-extensions.json#L1261
It also adds i18n files to provide translations for the menu items, taken from: https://github.com/openshift/console/tree/master/frontend/packages/console-app/locales