### PR TITLE
OU-158: Add bulk expire for silences

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -180,5 +180,7 @@
   "Silence": "Silence",
   "Overwriting current silence": "Overwriting current silence",
   "When changes are saved, the currently existing silence will be expired and a new silence with the new configuration will take its place.": "When changes are saved, the currently existing silence will be expired and a new silence with the new configuration will take its place.",
-  "Targets": "Targets"
+  "Targets": "Targets",
+  "Expire {{count}} silence_one": "Expire {{count}} silence",
+  "Expire {{count}} silence_other": "Expire {{count}} silences"
 }

--- a/src/components/_monitoring.scss
+++ b/src/components/_monitoring.scss
@@ -598,3 +598,8 @@ $monitoring-line-height: 18px;
   top: 0;
   z-index: $zindex-modal;
 }
+
+.monitoring__list-page-action-button {
+  margin-bottom: 1rem;
+  margin-right: 1rem;
+}


### PR DESCRIPTION
Adds the ability to bulk expire silences from the silences list page.

Adds a checkbox per row to the silences list for selecting silences as well as a checkbox for selecting / unselecting all of the silences.

If the list is currently filtered, the select all checkbox only selects the currently displayed silences, but unselecting all also unselects any silences that are currently hidden.