### PR TITLE
After bulk expiring silences, the silences should be deselected

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1929,7 +1929,7 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
 
   const dispatch = useDispatch();
 
-  const { selectedSilences } = React.useContext(SelectedSilencesContext);
+  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
 
   const onClick = () => {
     setInProgress();
@@ -1942,6 +1942,7 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
     )
       .then(() => {
         setNotInProgress();
+        setSelectedSilences(new Set());
         refreshSilences(dispatch);
       })
       .catch((err) => {


### PR DESCRIPTION
This bug was normally not seen because after expiring the silences, they are not displayed on the list page with the default list settings. You could see the bug by changing the list filter to display the expired silences before navigating away from the page.