### PR TITLE
Disable select all silences checkbox if all silences are expired

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1993,7 +1993,12 @@ const SelectAllCheckbox: React.FC<{ silences: Silence[] }> = ({ silences }) => {
   );
 
   return (
-    <Checkbox id="select-all-silences-checkbox" isChecked={isAllSelected} onChange={onChange} />
+    <Checkbox
+      id="select-all-silences-checkbox"
+      isChecked={isAllSelected}
+      isDisabled={activeSilences.length === 0}
+      onChange={onChange}
+    />
   );
 };
 


### PR DESCRIPTION
If all of the currently visible silences are already expired, disable the checkbox for selecting all silences.

This is better UX because we disable each silence's individual checkbox if it is expired and we should be consistent with that. If in the future we add a bulk action for expired silences, we can change this behavior.