### PR TITLE
Remove unused wrapperClassName prop from QueryBrowser

### DIFF
--- a/src/components/query-browser.tsx
+++ b/src/components/query-browser.tsx
@@ -664,7 +664,6 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   showStackedControl = false,
   timespan,
   units,
-  wrapperClassName,
 }) => {
   const { t } = useTranslation('public');
 
@@ -901,7 +900,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
 
   return (
     <div
-      className={classNames('query-browser__wrapper', wrapperClassName, {
+      className={classNames('query-browser__wrapper', {
         'graph-empty-state': isGraphDataEmpty,
         'graph-empty-state__loaded': isGraphDataEmpty && !updating,
       })}
@@ -1043,7 +1042,6 @@ export type QueryBrowserProps = {
   showStackedControl?: boolean;
   timespan?: number;
   units?: string;
-  wrapperClassName?: string;
 };
 
 type SpanControlsProps = {


### PR DESCRIPTION
This prop was already removed in the web console codebase by https://github.com/openshift/console/pull/12464, so it should also be removed here.