### PR TITLE
Fix so that plugin only handles specific pages under monitoring/

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -3,7 +3,7 @@
     "type": "console.page/route",
     "properties": {
       "exact": false,
-      "path": "/monitoring/",
+      "path": "/monitoring/(alertrules|alerts|dashboards|query-browser|silences|targets)/",
       "component": { "$codeRef": "MonitoringUI" }
     }
   },


### PR DESCRIPTION
This fixes a bug where plugin interferes with the Alertmanager config pages, which also live under monitoring/