### PR TITLE
Enable react-hooks/exhaustive-deps eslint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,7 +11,7 @@ parser: '@typescript-eslint/parser'
 parserOptions:
   ecmaFeatures:
     jsx: true
-  ecmaVersion: 2016
+  ecmaVersion: 2018
   sourceType: module
 plugins:
   - prettier

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,7 +27,6 @@ rules:
     - error
   # TODO: Rules below are disabled until we have time to refactor away these issues
   react/display-name: off
-  react-hooks/exhaustive-deps: off
   react/prop-types: off
   "@typescript-eslint/ban-types": off
   "@typescript-eslint/no-explicit-any": off

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -514,7 +514,7 @@ const SilenceTableRow: React.FC<RowProps<Silence>> = ({ obj }) => {
         return newSet;
       });
     },
-    [id],
+    [id, setSelectedSilences],
   );
 
   return (
@@ -2001,7 +2001,7 @@ const SelectAllCheckbox: React.FC<{ silences: Silence[] }> = ({ silences }) => {
       const ids = isChecked ? activeSilences.map((s) => s.id) : [];
       setSelectedSilences(new Set(ids));
     },
-    [activeSilences],
+    [activeSilences, setSelectedSilences],
   );
 
   return (
@@ -2093,7 +2093,7 @@ const SilencesPage_: React.FC<Silences> = () => {
         title: '',
       },
     ],
-    [t],
+    [filteredData, t],
   );
 
   return (

--- a/src/components/dashboards/index.tsx
+++ b/src/components/dashboards/index.tsx
@@ -215,6 +215,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
 
   const dispatch = useDispatch();
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const [isError, setIsError] = React.useState(false);
@@ -751,7 +752,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
         setBoard(newBoard);
       }
     },
-    [activePerspective, board, boards, dispatch, namespace],
+    [activePerspective, board, boards, dispatch, history, namespace],
   );
 
   // Display dashboard present in the params or show the first board

--- a/src/components/dashboards/single-stat.tsx
+++ b/src/components/dashboards/single-stat.tsx
@@ -74,6 +74,7 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query, namespace }) 
   const [isLoading, setIsLoading] = React.useState(true);
   const [value, setValue] = React.useState<string>();
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () =>

--- a/src/components/dashboards/table.tsx
+++ b/src/components/dashboards/table.tsx
@@ -75,6 +75,7 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries, namespace }) => 
   const [sortBy, setSortBy] = React.useState<ISortBy>({ index: 0, direction: 'asc' });
   const onSort = (e, index: ISortBy['index'], direction: ISortBy['direction']) =>
     setSortBy({ index, direction });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () => {

--- a/src/components/dashboards/timespan-dropdown.tsx
+++ b/src/components/dashboards/timespan-dropdown.tsx
@@ -48,7 +48,7 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
         dispatch(dashboardsSetEndTime(null, activePerspective));
       }
     },
-    [activePerspective, dispatch],
+    [activePerspective, dispatch, setModalOpen],
   );
 
   const items = {

--- a/src/components/dashboards/useFetchDashboards.ts
+++ b/src/components/dashboards/useFetchDashboards.ts
@@ -10,6 +10,7 @@ import { Board } from './types';
 export const useFetchDashboards = (namespace: string): [Board[], boolean, string] => {
   const { t } = useTranslation('public');
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
   const [boards, setBoards] = React.useState<Board[]>([]);
   const [error, setError] = React.useState<string>();

--- a/src/components/hooks/useIsVisible.ts
+++ b/src/components/hooks/useIsVisible.ts
@@ -4,21 +4,21 @@ export const useIsVisible = (ref) => {
   const [isVisible, setIsVisible] = React.useState(false);
   const [wasEverVisible, setWasEverVisible] = React.useState(false);
 
-  const callback = ([entry]) => {
-    setIsVisible(entry.isIntersecting);
-    if (entry.isIntersecting) {
-      setWasEverVisible(true);
-    }
-  };
-
-  const observer = new IntersectionObserver(callback);
-
   React.useEffect(() => {
+    const callback = ([entry]) => {
+      setIsVisible(entry.isIntersecting);
+      if (entry.isIntersecting) {
+        setWasEverVisible(true);
+      }
+    };
+
+    const observer = new IntersectionObserver(callback);
+
     if (ref?.current) {
       observer.observe(ref.current);
     }
     return () => observer.disconnect();
-  }, [observer, ref]);
+  }, [ref, setIsVisible, setWasEverVisible]);
 
   return [isVisible, wasEverVisible];
 };

--- a/src/components/metrics.tsx
+++ b/src/components/metrics.tsx
@@ -309,6 +309,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
     _.isEmpty(observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries'])),
   );
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () => {

--- a/src/components/promql-expression-input.tsx
+++ b/src/components/promql-expression-input.tsx
@@ -261,6 +261,7 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
 
   const placeholder = t('Expression (press Shift+Enter for newlines)');
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   React.useEffect(() => {

--- a/src/components/query-browser.tsx
+++ b/src/components/query-browser.tsx
@@ -114,6 +114,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(
       setText(formatPrometheusDuration(span));
     }, [span]);
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const debouncedOnChange = React.useCallback(_.debounce(onChange, 400), [onChange]);
 
     const setSpan = (newText: string, isDebounced = false) => {

--- a/src/components/targets.tsx
+++ b/src/components/targets.tsx
@@ -577,6 +577,7 @@ export const TargetsUI: React.FC<{}> = () => {
     kind: referenceForModel(PodMonitorModel),
   });
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () =>


### PR DESCRIPTION
Also changes the eslint `ecmaVersion` to `2018` although this doesn't require any code changes.

These changes align us with the web console code changes made by https://github.com/openshift/console/pull/12821