### PR TITLE
OU-179: Fix the root cause of externalLabels not present on alerts

### DIFF
--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -71,6 +71,11 @@ export const getAlertsAndRules = (
     return _.filter(g.rules, { type: 'alerting' }).map(addID);
   });
 
+  // Add external labels to all `rules[].alerts[].labels`
+  rules.forEach((rule) => {
+    rule.alerts.forEach((alert) => (alert.labels = { ...rule.labels, ...alert.labels }));
+  });
+
   // Add `rule` object to each alert
   const alerts = _.flatMap(rules, (rule) => rule.alerts.map((a) => ({ rule, ...a })));
 


### PR DESCRIPTION
[OU-179](https://issues.redhat.com//browse/OU-179) Display externalLabels found in GET `/api/prometheus/api/v1/rules` response >> `rules.labels`.

**Related Issue:** 
https://issues.redhat.com/browse/OU-179

**AlertDetailsPage**
External labels are now listed alongside the other labels associated with an alert.
<img width="2200" alt="Screenshot 2023-06-27 at 11 37 38 AM" src="https://github.com/openshift/monitoring-plugin/assets/59589720/291ab486-8fdc-43ea-bbeb-1664ce17f001">

**Search Label** 
The external labels can be pre-populated in the 'label' search field. 
<img width="1440" alt="Search External Label" src="https://github.com/openshift/monitoring-plugin/assets/59589720/ed78e43b-dbb8-4b09-83ec-53ae53989777">

**Silences**
We're able to silence alerts associated with the external label. 
<img width="1440" alt="Create Silences for External Label" src="https://github.com/openshift/monitoring-plugin/assets/59589720/3675c187-971e-48c9-b13c-781ca65721c5">


**To Test:** 
1. Attach an externalLabel to all time-series and alerts leaving the Prometheus instance that monitors core OpenShift Container Platform projects [[docs]](https://docs.openshift.com/container-platform/4.13/monitoring/configuring-the-monitoring-stack.html#attaching-additional-labels-to-your-time-series-and-alerts_configuring-the-monitoring-stack)
2. Go to OpenShift Console UI > Observe > Alerts > AlertsDetailPage should now display the externalLabels (this may take a few minutes to update).