### PR TITLE
Enable `@typescript-eslint/ban-types` eslint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,7 +28,6 @@ rules:
   # TODO: Rules below are disabled until we have time to refactor away these issues
   react/display-name: off
   react/prop-types: off
-  "@typescript-eslint/ban-types": off
   "@typescript-eslint/no-explicit-any": off
 settings:
   react:

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -355,7 +355,7 @@ const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: string }> = 
   </Popover>
 );
 
-const AlertStateHelp: React.FC<{}> = () => {
+const AlertStateHelp: React.FC = () => {
   const { t } = useTranslation('public');
 
   return (
@@ -389,7 +389,7 @@ const AlertStateHelp: React.FC<{}> = () => {
   );
 };
 
-const SeverityHelp: React.FC<{}> = () => {
+const SeverityHelp: React.FC = () => {
   const { t } = useTranslation('public');
 
   return (
@@ -423,7 +423,7 @@ const SeverityHelp: React.FC<{}> = () => {
   );
 };
 
-const SourceHelp: React.FC<{}> = () => {
+const SourceHelp: React.FC = () => {
   const { t } = useTranslation('public');
 
   return (
@@ -1685,7 +1685,7 @@ const getAdditionalSources = <T extends Alert | Rule>(
   return [];
 };
 
-const AlertsPage_: React.FC<{}> = () => {
+const AlertsPage_: React.FC = () => {
   const { t } = useTranslation('public');
 
   const {
@@ -1874,7 +1874,7 @@ const RuleTableRow: React.FC<RowProps<Rule>> = ({ obj }) => {
   );
 };
 
-const RulesPage_: React.FC<{}> = () => {
+const RulesPage_: React.FC = () => {
   const { t } = useTranslation('public');
 
   const data: Rule[] = useSelector(({ observe }: RootState) => observe.get('rules'));
@@ -1988,7 +1988,7 @@ const RulesPage_: React.FC<{}> = () => {
 };
 const RulesPage = withFallback(RulesPage_);
 
-const CreateSilenceButton: React.FC<{}> = React.memo(() => {
+const CreateSilenceButton: React.FC = React.memo(() => {
   const { t } = useTranslation('public');
 
   return (
@@ -2090,7 +2090,7 @@ const SelectAllCheckbox: React.FC<{ silences: Silence[] }> = ({ silences }) => {
   );
 };
 
-const SilencesPage_: React.FC<{}> = () => {
+const SilencesPage_: React.FC = () => {
   const { t } = useTranslation('public');
 
   const [selectedSilences, setSelectedSilences] = React.useState(new Set());

--- a/src/components/console/console-shared/error/error-boundary.tsx
+++ b/src/components/console/console-shared/error/error-boundary.tsx
@@ -55,6 +55,7 @@ export const withFallback: WithFallback = (WrappedComponent, FallbackComponent) 
   return Component;
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 type WithFallback = <P = {}>(
   Component: React.ComponentType<P>,
   FallbackComponent?: React.ComponentType<any>,

--- a/src/components/console/extensions/types.ts
+++ b/src/components/console/extensions/types.ts
@@ -3,12 +3,14 @@ type ExtensionFlags = Partial<{
   disallowed: string[];
 }>;
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type Extension<P extends {} = any> = {
   type: string;
   properties: P;
   flags?: ExtensionFlags;
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type ExtensionDeclaration<T extends string, P extends {}> = Extension<P> & {
   type: T;
 };

--- a/src/components/console/utils/status-box.tsx
+++ b/src/components/console/utils/status-box.tsx
@@ -59,7 +59,7 @@ const Loading: React.FC<LoadingProps> = ({ className }) => (
 );
 Loading.displayName = 'Loading';
 
-export const LoadingInline: React.FC<{}> = () => <Loading className="co-m-loader--inline" />;
+export const LoadingInline: React.FC = () => <Loading className="co-m-loader--inline" />;
 LoadingInline.displayName = 'LoadingInline';
 
 export const LoadingBox: React.FC<LoadingBoxProps> = ({ className, message }) => (

--- a/src/components/dashboards/index.tsx
+++ b/src/components/dashboards/index.tsx
@@ -457,7 +457,7 @@ export const PollIntervalDropdown: React.FC<TimeDropdownsProps> = ({ namespace }
   );
 };
 
-const TimeDropdowns: React.FC<{}> = React.memo(() => {
+const TimeDropdowns: React.FC = React.memo(() => {
   const namespace = React.useContext(NamespaceContext);
   return (
     <div className="monitoring-dashboards__options">
@@ -467,7 +467,7 @@ const TimeDropdowns: React.FC<{}> = React.memo(() => {
   );
 });
 
-const HeaderTop: React.FC<{}> = React.memo(() => {
+const HeaderTop: React.FC = React.memo(() => {
   const { t } = useTranslation('public');
 
   return (

--- a/src/components/metrics.tsx
+++ b/src/components/metrics.tsx
@@ -74,7 +74,7 @@ import { PrometheusAPIError, RootState } from './types';
 // Stores information about the currently focused query input
 let focusedQuery;
 
-const MetricsActionsMenu: React.FC<{}> = () => {
+const MetricsActionsMenu: React.FC = () => {
   const { t } = useTranslation('public');
 
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
@@ -119,7 +119,7 @@ const MetricsActionsMenu: React.FC<{}> = () => {
   );
 };
 
-export const ToggleGraph: React.FC<{}> = () => {
+export const ToggleGraph: React.FC = () => {
   const { t } = useTranslation('public');
 
   const hideGraphs = useSelector(({ observe }: RootState) => !!observe.get('hideGraphs'));
@@ -566,7 +566,7 @@ const Query: React.FC<{ index: number }> = ({ index }) => {
   );
 };
 
-const QueryBrowserWrapper: React.FC<{}> = () => {
+const QueryBrowserWrapper: React.FC = () => {
   const { t } = useTranslation('public');
 
   const dispatch = useDispatch();
@@ -655,7 +655,7 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
   );
 };
 
-const AddQueryButton: React.FC<{}> = () => {
+const AddQueryButton: React.FC = () => {
   const { t } = useTranslation('public');
 
   const dispatch = useDispatch();
@@ -673,7 +673,7 @@ const AddQueryButton: React.FC<{}> = () => {
   );
 };
 
-const RunQueriesButton: React.FC<{}> = () => {
+const RunQueriesButton: React.FC = () => {
   const { t } = useTranslation('public');
 
   const dispatch = useDispatch();
@@ -686,7 +686,7 @@ const RunQueriesButton: React.FC<{}> = () => {
   );
 };
 
-const QueriesList: React.FC<{}> = () => {
+const QueriesList: React.FC = () => {
   const count = useSelector(
     ({ observe }: RootState) => observe.getIn(['queryBrowser', 'queries']).size,
   );
@@ -715,7 +715,7 @@ const PollIntervalDropdown = () => {
   return <IntervalDropdown interval={interval} setInterval={setInterval} />;
 };
 
-const QueryBrowserPage_: React.FC<{}> = () => {
+const QueryBrowserPage_: React.FC = () => {
   const { t } = useTranslation('public');
 
   const dispatch = useDispatch();

--- a/src/components/query-browser.tsx
+++ b/src/components/query-browser.tsx
@@ -1029,7 +1029,7 @@ export type QueryBrowserProps = {
   filterLabels?: PrometheusLabels;
   fixedEndTime?: number;
   formatSeriesTitle?: FormatSeriesTitle;
-  GraphLink?: React.ComponentType<{}>;
+  GraphLink?: React.ComponentType;
   hideControls?: boolean;
   isStack?: boolean;
   namespace?: string;

--- a/src/components/silence-form.tsx
+++ b/src/components/silence-form.tsx
@@ -91,7 +91,7 @@ const NegativeMatcherHelp = () => {
 
 type SilenceFormProps = RouteComponentProps & {
   defaults: any;
-  Info?: React.ComponentType<{}>;
+  Info?: React.ComponentType;
   title: string;
 };
 

--- a/src/components/targets.tsx
+++ b/src/components/targets.tsx
@@ -552,7 +552,7 @@ const ListPage: React.FC<ListPageProps> = ({ loaded, loadError, targets }) => {
 
 const POLL_INTERVAL = 15 * 1000;
 
-export const TargetsUI: React.FC<{}> = () => {
+export const TargetsUI: React.FC = () => {
   const [error, setError] = React.useState<PrometheusAPIError>();
   const [loaded, setLoaded] = React.useState(false);
   const [targets, setTargets] = React.useState<Target[]>();


### PR DESCRIPTION
Remove some uses of `{}` that don't actually make any difference to the type check being done.