### PR TITLE
OU-230: Remove checkboxes from the Silenced By list on alert details page

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -510,7 +510,12 @@ const SilenceMatchersList = ({ silence }) => (
   </div>
 );
 
-const SilenceTableRow: React.FC<RowProps<Silence>> = ({ obj }) => {
+type SilenceTableRowProps = {
+  obj: Silence;
+  showCheckbox?: boolean;
+};
+
+const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
   const { createdBy, endsAt, firingAlerts, id, name, startsAt } = obj;
@@ -535,14 +540,16 @@ const SilenceTableRow: React.FC<RowProps<Silence>> = ({ obj }) => {
 
   return (
     <>
-      <td className={tableSilenceClasses[0]}>
-        <Checkbox
-          id={id}
-          isChecked={selectedSilences.has(id)}
-          isDisabled={state === SilenceStates.Expired}
-          onChange={onCheckboxChange}
-        />
-      </td>
+      {showCheckbox && (
+        <td className={tableSilenceClasses[0]}>
+          <Checkbox
+            id={id}
+            isChecked={selectedSilences.has(id)}
+            isDisabled={state === SilenceStates.Expired}
+            onChange={onCheckboxChange}
+          />
+        </td>
+      )}
       <td className={tableSilenceClasses[1]}>
         <div className="co-resource-item">
           <MonitoringResourceIcon resource={SilenceResource} />
@@ -579,6 +586,10 @@ const SilenceTableRow: React.FC<RowProps<Silence>> = ({ obj }) => {
     </>
   );
 };
+
+const SilenceTableRowWithCheckbox: React.FC<RowProps<Silence>> = ({ obj }) => (
+  <SilenceTableRow showCheckbox={true} obj={obj} />
+);
 
 export const alertMessageResources: {
   [labelName: string]: { kind: string; namespaced?: boolean };
@@ -2230,7 +2241,7 @@ const SilencesPage_: React.FC = () => {
                 data={filteredData ?? []}
                 loaded={loaded}
                 loadError={loadError}
-                Row={SilenceTableRow}
+                Row={SilenceTableRowWithCheckbox}
                 unfilteredData={data}
               />
             </div>


### PR DESCRIPTION
These checkboxes don't do anything on this page. They are only used on the main Silences list page.