### PR TITLE
OCPBUGS-17650: Fix /monitoring/ redirects

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -2,8 +2,16 @@
   {
     "type": "console.page/route",
     "properties": {
+      "exact": true,
+      "path": "/monitoring",
+      "component": { "$codeRef": "MonitoringUI" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
       "exact": false,
-      "path": "/monitoring/(alertrules|alerts|dashboards|query-browser|silences|targets)/",
+      "path": "/monitoring/(alertrules|alerts|dashboards|graph|query-browser|silences|targets)/",
       "component": { "$codeRef": "MonitoringUI" }
     }
   },


### PR DESCRIPTION
Fix redirect from `/monitoring` to `/monitoring/alerts` and from `/monitoring/graph` to `/monitoring/query-browser`.

The redirects are implemented by the `MonitoringUI` component, but they were missing from `console-extensions.json`, so were never getting to `MonitoringUI`.