### PR TITLE
targets: filter by target

### DIFF
--- a/src/components/targets.tsx
+++ b/src/components/targets.tsx
@@ -456,6 +456,7 @@ const ListPage: React.FC<ListPageProps> = ({ loaded, loadError, targets }) => {
   const nameFilter: RowFilter = {
     filter: (filter, target: Target) =>
       fuzzyCaseInsensitive(filter.selected?.[0], target.scrapeUrl) ||
+      fuzzyCaseInsensitive(filter.selected?.[0], target.monitor) ||
       fuzzyCaseInsensitive(filter.selected?.[0], target.labels?.namespace),
     items: [],
     type: 'name',
@@ -530,7 +531,7 @@ const ListPage: React.FC<ListPageProps> = ({ loaded, loadError, targets }) => {
           labelFilter="observe-target-labels"
           labelPath="labels"
           loaded={loaded}
-          nameFilterPlaceholder={t('Search by endpoint or namespace...')}
+          nameFilterPlaceholder={t('Search by endpoint, target, or namespace...')}
           nameFilterTitle={t('Text')}
           onFilterChange={onFilterChange}
           rowFilters={rowFilters}


### PR DESCRIPTION
Previously, a user could only filter by the endpoint or namespace. Endpoints are generally the same between components and not useful for filtering, as well as being opaque. Namespaces are useful but not precise. Filtering by the target name (PodMonitor or ServiceMonitor) will be more useful for narrowing down the list.