### PR TITLE
OU-261: Fix "Overwriting current silence" info alert to have padding

### DIFF
--- a/src/components/silence-form.tsx
+++ b/src/components/silence-form.tsx
@@ -253,9 +253,8 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
         </HelperText>
       </div>
 
-      {Info && <Info />}
-
       <div className="co-m-pane__body">
+        {Info && <Info />}
         <form onSubmit={onSubmit} className="monitoring-silence-alert">
           <div className="co-m-pane__body-group">
             <SectionHeading text={t('Duration')} />


### PR DESCRIPTION
| Before | After|
| - | - |
| ![before](https://github.com/openshift/monitoring-plugin/assets/460802/b4d05373-cace-4340-96d0-963deac5a7f3) | ![after](https://github.com/openshift/monitoring-plugin/assets/460802/72ea0712-7462-4210-ad9c-5b34452ae3af) |

FYI @fkargbo