### PR TITLE
add ipv6 nginx configuration

### DIFF
--- a/charts/openshift-console-plugin/templates/configmap.yaml
+++ b/charts/openshift-console-plugin/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
       keepalive_timeout  65;
       server {
         listen              {{ .Values.plugin.port }} ssl;
+        listen              [::]:{{ .Values.plugin.port }} ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;


### PR DESCRIPTION
enables ipv6 in nginx so plugin assets can be loaded in clusters using ipv6