### PR TITLE
Revert "Fix i18n namespace for navigation menu entries"

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -22,7 +22,7 @@
     },
     "properties": {
       "id": "alerting",
-      "name": "%plugin__monitoring-plugin~Alerting%",
+      "name": "%public~Alerting%",
       "href": "/monitoring/alerts",
       "perspective": "admin",
       "section": "observe",
@@ -36,7 +36,7 @@
     },
     "properties": {
       "id": "metrics",
-      "name": "%plugin__monitoring-plugin~Metrics%",
+      "name": "%public~Metrics%",
       "href": "/monitoring/query-browser",
       "perspective": "admin",
       "section": "observe",
@@ -50,7 +50,7 @@
     },
     "properties": {
       "id": "dashboards",
-      "name": "%plugin__monitoring-plugin~Dashboards%",
+      "name": "%public~Dashboards%",
       "href": "/monitoring/dashboards",
       "perspective": "admin",
       "section": "observe",
@@ -64,7 +64,7 @@
     },
     "properties": {
       "id": "targets",
-      "name": "%plugin__monitoring-plugin~Targets%",
+      "name": "%public~Targets%",
       "href": "/monitoring/targets",
       "perspective": "admin",
       "section": "observe",


### PR DESCRIPTION
This reverts commit 0f32328ddad72c1ffaa4820f3f4359362a9d1acf (PR https://github.com/openshift/monitoring-plugin/pull/73)