### PR TITLE
LOG-4581: disable query link for non metric-based alerts

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1181,11 +1181,18 @@ const AlertRulesDetailsPage_: React.FC<AlertRulesDetailsPageProps> = ({ match })
                   )}
                   <dt>{t('Expression')}</dt>
                   <dd>
-                    <Link to={queryBrowserURL(rule?.query, namespace)}>
+                    {/* display a link only if its a metrics based alert */}
+                    {!sourceId || sourceId === 'prometheus' ? (
+                      <Link to={queryBrowserURL(rule?.query, namespace)}>
+                        <CodeBlock>
+                          <CodeBlockCode>{rule?.query}</CodeBlockCode>
+                        </CodeBlock>
+                      </Link>
+                    ) : (
                       <CodeBlock>
                         <CodeBlockCode>{rule?.query}</CodeBlockCode>
                       </CodeBlock>
-                    </Link>
+                    )}
                   </dd>
                 </dl>
               </div>


### PR DESCRIPTION
If the user clicks on the query for a log based alert, is redirected to the metrics. This PR disables the link for non metric based alerts.