### PR TITLE
OCPBUGS-24515: remove regex from console page route path so plugin pages are found

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -11,7 +11,15 @@
     "type": "console.page/route",
     "properties": {
       "exact": false,
-      "path": "/monitoring/(alertrules|alerts|dashboards|graph|query-browser|silences|targets)/",
+      "path": [
+        "/monitoring/alertrules",
+        "/monitoring/alerts",
+        "/monitoring/dashboards",
+        "/monitoring/graph",
+        "/monitoring/query-browser",
+        "/monitoring/silences",
+        "/monitoring/targets"
+      ],
       "component": { "$codeRef": "MonitoringUI" }
     }
   },


### PR DESCRIPTION
The 4.15 console version includes an upgrade to use react router v6 in compatibility mode with v5. In react router v6 regex paths are not longer supported as seen [here](https://reactrouter.com/en/main/start/faq#what-happened-to-regexp-routes-paths). 

This PR splits the regex into multiple console routes so the route can be matched correctly and the pages are visible