### PR TITLE
OU-308: Revert "fix default nginx path to look for static files"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ FROM registry.redhat.io/ubi8/nginx-120:1-84.1675799502
 
 USER 1001
 
-COPY --from=builder /usr/src/app/dist /opt/app-root/src
+COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before you can deploy the plugin on a cluster, you must build an image and push 
 2. Run the image:
 
    ```sh
-   docker run -it --rm -d -p 9001:8080 quay.io/my-repository/my-plugin:latest
+   docker run -it --rm -d -p 9001:80 quay.io/my-repository/my-plugin:latest
    ```
 
 3. Push the image:


### PR DESCRIPTION
This change should only have been made for building images for local testing, not in the default `Dockerfile`.

This reverts PR https://github.com/openshift/monitoring-plugin/pull/83 and commit 4965ae66e6fa6ed9860e4b931bf7590be7c9a880.