### PR TITLE
OU-309: consider all metric keys to display all results on dashboards tables

### DIFF
--- a/src/components/dashboards/table.tsx
+++ b/src/components/dashboards/table.tsx
@@ -106,8 +106,7 @@ const Table: React.FC<Props> = ({ customDataSource, panel, pollInterval, queries
             if (response) {
               const id = panel.targets[i].refId;
               response.data.result.forEach(({ metric, value }) => {
-                const label = _.first(Object.keys(metric));
-                const tag = metric[label];
+                const tag = Object.values(metric).join('-');
                 if (!acc[tag]) {
                   acc[tag] = { ...metric };
                 }


### PR DESCRIPTION
In order to display all results from a vector response in the dashboards table, this PR calculates table rows considering all the metric labels