### PR TITLE
OCPBUGS-29947: upgrade sanitize-html vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "resolutions": {
     "webpack": "^5.76.0",
     "tough-cookie": "^4.1.3",
-    "semver": "^6.3.1"
+    "semver": "^6.3.1",
+    "sanitize-html": "^2.12.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5651,10 +5651,10 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanitize-html@^2.3.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.11.0.tgz#9a6434ee8fcaeddc740d8ae7cd5dd71d3981f8f6"
-  integrity sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==
+sanitize-html@^2.12.1, sanitize-html@^2.3.2:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.13.0.tgz#71aedcdb777897985a4ea1877bf4f895a1170dae"
+  integrity sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
This PR upgrade sanitize-html vulnerable dependency