### PR TITLE
OU-370: Split Dashboard Label and Line Chart Queries

### DIFF
--- a/src/components/console/graphs/helpers.ts
+++ b/src/components/console/graphs/helpers.ts
@@ -16,7 +16,7 @@ const getRangeVectorSearchParams = (
   const params = new URLSearchParams();
   params.append('start', `${(endTime - timespan) / 1000}`);
   params.append('end', `${endTime / 1000}`);
-  params.append('step', `${timespan / samples / 1000}`);
+  params.append('step', `${Math.ceil(timespan / samples / 1000)}`);
   return params;
 };
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -52,3 +52,8 @@ export type RootState = {
   k8s: { [key: string]: any };
   observe: ObserveState;
 };
+
+export type TimeRange = {
+  endTime: number;
+  duration: number;
+};


### PR DESCRIPTION
## Description
**Issue:** https://issues.redhat.com/browse/OU-370

Queries with a duration of more than 2 days will time out for certain dashboards due to the large time period of data being queried and the density of the data for those queries. Since we know that the shorter queries don't time out, we can split the larger queries time periods down into durations that won't time out (1 day), and then recombine all the returned data.

However, we can only recombine query types which isn't dependent on other dimensions (labels) or that which is directly dependent on time (line charts). 

## Implementation
The labels query uses a set to keep track of all options for the label across the split queries. The query-browser (line chart) breaks the query down into its needed time chunks, then looks to recombine the data into the original query format, in order to ensure backwards compatibility with query functionality being stored in Redux.