### PR TITLE
OCPBUGS-12857: Gracefully Handle NaN values in stacked graphs

### DIFF
--- a/src/components/query-browser.tsx
+++ b/src/components/query-browser.tsx
@@ -499,12 +499,13 @@ const formatSeriesValues = (
   values: PrometheusValue[],
   samples: number,
   span: number,
+  defaultEmptyValue: 0 | null,
 ): GraphDataPoint[] => {
   const newValues = _.map(values, (v) => {
     const y = Number(v[1]);
     return {
       x: new Date(v[0] * 1000),
-      y: Number.isNaN(y) ? null : y,
+      y: Number.isNaN(y) ? defaultEmptyValue : y,
     };
   });
 
@@ -786,14 +787,28 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
         ) {
           setSamples(newSamples);
         } else {
-          const newGraphData = _.map(newResults, (result: PrometheusResult[]) => {
-            return _.map(result, ({ metric, values }): Series => {
-              // If filterLabels is specified, ignore all series that don't match
-              return _.some(filterLabels, (v, k) => _.has(metric, k) && metric[k] !== v)
-                ? []
-                : [metric, formatSeriesValues(values, samples, span)];
-            });
-          });
+          const newGraphData = _.map(
+            newResults,
+            (result: PrometheusResult[], queryIndex: number) => {
+              return _.map(result, ({ metric, values }): Series => {
+                // If filterLabels is specified, ignore all series that don't match
+                if (_.some(filterLabels, (v, k) => _.has(metric, k) && metric[k] !== v)) {
+                  return [];
+                } else {
+                  let defaultEmptyValue = null;
+                  if (isStack && _.some(values, (value) => Number.isNaN(Number(value[1])))) {
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                      'Invalid response values for stacked graph converted to 0 for query: ',
+                      queries[queryIndex],
+                    );
+                    defaultEmptyValue = 0;
+                  }
+                  return [metric, formatSeriesValues(values, samples, span, defaultEmptyValue)];
+                }
+              });
+            },
+          );
           setGraphData(newGraphData);
 
           _.each(newResults, (r, i) =>


### PR DESCRIPTION
This PR looks to address a crash for stacked charts when NaN values are returned from the Prometheus API.

There is a bug in stacked graphs for Victory charts for react. The bug occurs in their victory-stack package. An issue has been made and can be tracked [here](https://github.com/FormidableLabs/victory/issues/2844).

The root issue is a dataset which has dates in the x field and all null's in the y field. To get around this, for stacked charts we will be converting any NaN's returned to be 0 rather than null. In order to help dashboard creators and power users to debug any problematic queries, we are also adding a console.warn to let them know about this conversion, while still showing the graph otherwise.