### PR TITLE
OU-379: Add datasource parameter to handle metrics from custom datasources

### DIFF
--- a/locales/en/plugin__monitoring-plugin.json
+++ b/locales/en/plugin__monitoring-plugin.json
@@ -134,6 +134,8 @@
   "No datapoints found.": "No datapoints found.",
   "Unselect all": "Unselect all",
   "Select all": "Select all",
+  "Error loading custom data source": "Error loading custom data source",
+  "An error occurred while loading the custom data source.": "An error occurred while loading the custom data source.",
   "No query entered": "No query entered",
   "Enter a query in the box below to explore metrics for this cluster.": "Enter a query in the box below to explore metrics for this cluster.",
   "Insert example query": "Insert example query",

--- a/src/components/dashboards/index.tsx
+++ b/src/components/dashboards/index.tsx
@@ -480,12 +480,22 @@ const HeaderTop: React.FC = React.memo(() => {
   );
 });
 
-const QueryBrowserLink = ({ queries }) => {
+const QueryBrowserLink = ({
+  queries,
+  customDataSourceName,
+}: {
+  queries: Array<string>;
+  customDataSourceName: string;
+}) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
   const params = new URLSearchParams();
   queries.forEach((q, i) => params.set(`query${i}`, q));
   const namespace = React.useContext(NamespaceContext);
+
+  if (customDataSourceName) {
+    params.set('datasource', customDataSourceName);
+  }
 
   return (
     <Link
@@ -646,7 +656,9 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
         <CardHeader className="monitoring-dashboards__card-header">
           <CardTitle>{panel.title}</CardTitle>
           <CardActions className="co-overview-card__actions">
-            {!isLoading && <QueryBrowserLink queries={queries} />}
+            {!isLoading && (
+              <QueryBrowserLink queries={queries} customDataSourceName={customDataSourceName} />
+            )}
           </CardActions>
         </CardHeader>
         <CardBody className="co-dashboard-card__body--dashboard">


### PR DESCRIPTION
This PR:

- Adds support for metrics to fetch data from a custom datasource registered using the console-dashboards-plugin
- Adds a `datasource` URL param with the name of the custom datasource, so when clicking on a dashboards that contains a custom datasource the metrics are loaded form the correct backend