### PR TITLE
OU-395: Alert detail page renders buttons and links from the plugin extension

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -830,11 +830,29 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
                 <ActionServiceProvider context={{ 'alert-detail-toolbar-actions': { alert } }}>
                   {({ actions, loaded }) =>
                     loaded
-                      ? actions.filter(isActionWithHref).map((action) => (
-                          <ToolbarItem key={action.id}>
-                            <Link to={action.cta.href}>{action.label}</Link>
-                          </ToolbarItem>
-                        ))
+                      ? actions.map((action) => {
+                          if (isActionWithHref(action)) {
+                            return (
+                              <ToolbarItem
+                                key={action.id}
+                                spacer={{ default: 'spacerNone' }}
+                                className="pf-u-px-md"
+                              >
+                                <Link to={action.cta.href}>{action.label}</Link>
+                              </ToolbarItem>
+                            );
+                          } else if (isActionWithCallback(action)) {
+                            return (
+                              <ToolbarItem key={action.id} spacer={{ default: 'spacerNone' }}>
+                                <Button variant="link" onClick={action.cta}>
+                                  {action.label}
+                                </Button>
+                              </ToolbarItem>
+                            );
+                          }
+
+                          return null;
+                        })
                       : null
                   }
                 </ActionServiceProvider>


### PR DESCRIPTION
In the screenshot below the see related logs is a link and the troubleshoot is a button, both with same styling for consistency.

![Screenshot 2024-04-10 at 13 28 47](https://github.com/openshift/monitoring-plugin/assets/5461414/d3289001-6bf3-4f16-b105-4e529e786d3f)
