### PR TITLE
OKD-210: Use rhel9 base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,14 @@ COPY ./locales ./locales
 COPY ./src ./src
 RUN yarn build
 
-FROM registry.redhat.io/ubi8/nginx-120:1-84.1675799502
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+
+RUN INSTALL_PKGS="nginx" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
 
 USER 1001
 


### PR DESCRIPTION
Recently, we added OKD configs for openshift components - [this](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main__okd-scos.yaml) is the OKD config for the monitoring plugin component. The config overrides the base image with a centos image, which doesn't work because the base image for the `Dockerfile` is an nginx image. To be consistent with other repos and the ART dockerfile, change the nginx base image to a rhel base image, so that prow can do the substitution. This also prevents any CVE vulnerabilities we would have when using the nginx image.