### PR TITLE
OU-251: Migrate Developer Perspective Alert List to Monitoring Plugin

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -78,5 +78,16 @@
       "section": "observe",
       "insertAfter": "dashboards"
     }
+  },
+  {
+    "type": "console.tab",
+    "properties": {
+      "contextId": "dev-console-observe",
+      "name": "%public~Alerts%",
+      "href": "alerts",
+      "component": {
+        "$codeRef": "MonitoringUI"
+      }
+    }
   }
 ]

--- a/src/actions/observe.ts
+++ b/src/actions/observe.ts
@@ -31,61 +31,63 @@ export enum ActionType {
   ToggleGraphs = 'toggleGraphs',
 }
 
-export const dashboardsPatchVariable = (key: string, patch: any, perspective: string) =>
+export type Perspective = 'admin' | 'dev';
+type AlertingKey =
+  | 'alerts'
+  | 'devAlerts'
+  | 'silences'
+  | 'devSilences'
+  | 'rules'
+  | 'devRules'
+  | 'notificationAlerts';
+
+export const dashboardsPatchVariable = (key: string, patch: any, perspective: Perspective) =>
   action(ActionType.DashboardsPatchVariable, { key, patch, perspective });
 
-export const dashboardsPatchAllVariables = (variables: any, perspective: string) =>
+export const dashboardsPatchAllVariables = (variables: any, perspective: Perspective) =>
   action(ActionType.DashboardsPatchAllVariables, { variables, perspective });
 
-export const DashboardsClearVariables = (perspective: string) =>
+export const DashboardsClearVariables = (perspective: Perspective) =>
   action(ActionType.DashboardsClearVariables, { perspective });
 
-export const dashboardsSetEndTime = (endTime: number, perspective: string) =>
+export const dashboardsSetEndTime = (endTime: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetEndTime, { endTime, perspective });
 
-export const dashboardsSetPollInterval = (pollInterval: number, perspective: string) =>
+export const dashboardsSetPollInterval = (pollInterval: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetPollInterval, { pollInterval, perspective });
 
-export const dashboardsSetTimespan = (timespan: number, perspective: string) =>
+export const dashboardsSetTimespan = (timespan: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetTimespan, { timespan, perspective });
 
 export const dashboardsVariableOptionsLoaded = (
   key: string,
   newOptions: string[],
-  perspective: string,
+  perspective: Perspective,
 ) => action(ActionType.DashboardsVariableOptionsLoaded, { key, newOptions, perspective });
 
-export const alertingLoading = (
-  key: 'alerts' | 'silences' | 'notificationAlerts',
-  perspective = 'admin',
-) =>
+export const alertingLoading = (key: AlertingKey, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: false, loadError: null, data: null, perspective },
   });
 
-export const alertingLoaded = (
-  key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
-  alerts: any,
-  perspective = 'admin',
-) =>
+export const alertingLoaded = (key: AlertingKey, alerts: any, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: true, loadError: null, data: alerts, perspective },
   });
 
-export const alertingErrored = (
-  key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
-  loadError: Error,
-  perspective = 'admin',
-) =>
+export const alertingErrored = (key: AlertingKey, loadError: Error, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: true, loadError, data: null, perspective },
   });
 
-export const alertingSetRules = (key: 'rules' | 'devRules', rules: Rule[], perspective = 'admin') =>
-  action(ActionType.AlertingSetRules, { key, data: rules, perspective });
+export const alertingSetRules = (
+  key: 'rules' | 'devRules',
+  rules: Rule[],
+  perspective: Perspective,
+) => action(ActionType.AlertingSetRules, { key, data: rules, perspective });
 
 export const toggleGraphs = () => action(ActionType.ToggleGraphs);
 

--- a/src/components/alerting/AlertUtils.tsx
+++ b/src/components/alerting/AlertUtils.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+import {
+  Action,
+  Alert,
+  AlertSeverity,
+  AlertStates,
+  BlueInfoCircleIcon,
+  PrometheusAlert,
+  RedExclamationCircleIcon,
+  Rule,
+  Timestamp,
+  YellowExclamationTriangleIcon,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AlertSource, MonitoringResource } from '../types';
+import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+import { Alert as PFAlert } from '@patternfly/react-core';
+import { labelsToParams, RuleResource, SilenceResource } from '../utils';
+import classNames from 'classnames';
+import { BellIcon, BellSlashIcon, OutlinedBellIcon } from '@patternfly/react-icons';
+
+export const getAdditionalSources = <T extends Alert | Rule>(
+  data: Array<T>,
+  itemSource: (item: T) => string,
+) => {
+  if (data) {
+    const additionalSources = new Set<string>();
+    data.forEach((item) => {
+      const source = itemSource(item);
+      if (source !== AlertSource.Platform && source !== AlertSource.User) {
+        additionalSources.add(source);
+      }
+    });
+    return Array.from(additionalSources).map((item) => ({ id: item, title: _.startCase(item) }));
+  }
+  return [];
+};
+
+export const alertingRuleSource = (rule: Rule): AlertSource | string => {
+  if (rule.sourceId === undefined || rule.sourceId === 'prometheus') {
+    return rule.labels?.prometheus === 'openshift-monitoring/k8s'
+      ? AlertSource.Platform
+      : AlertSource.User;
+  }
+
+  return rule.sourceId;
+};
+
+export const alertSource = (alert: Alert): AlertSource | string => alertingRuleSource(alert.rule);
+
+export const SilencesNotLoadedWarning: React.FC<{ silencesLoadError: any }> = ({
+  silencesLoadError,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  return (
+    <PFAlert
+      className="co-alert"
+      isInline
+      title={t(
+        'Error loading silences from Alertmanager. Some of the alerts below may actually be silenced.',
+      )}
+      variant="warning"
+    >
+      {silencesLoadError.json?.error || silencesLoadError.message}
+    </PFAlert>
+  );
+};
+
+type ActionWithHref = Omit<Action, 'cta'> & { cta: { href: string; external?: boolean } };
+export const isActionWithHref = (action: Action): action is ActionWithHref => 'href' in action.cta;
+
+export const ruleURL = (rule: Rule) => `${RuleResource.plural}/${_.get(rule, 'id')}`;
+export const devRuleURL = (rule: Rule, namespace: string) =>
+  `/dev-monitoring/ns/${namespace}/rules/${rule?.id}`;
+
+export const silenceAlertURL = (alert: PrometheusAlert) =>
+  `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
+
+export const devSilenceAlertURL = (alert: PrometheusAlert, namespace: string) =>
+  `/dev-monitoring/ns/${namespace}/silences/~new?${labelsToParams(alert.labels)}`;
+
+type ActionWithCallBack = Omit<Action, 'cta'> & { cta: () => void };
+export const isActionWithCallback = (action: Action): action is ActionWithCallBack =>
+  typeof action.cta === 'function';
+
+export const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({
+  className,
+  resource,
+}) => (
+  <span
+    className={classNames(
+      `co-m-resource-icon co-m-resource-${resource.kind.toLowerCase()}`,
+      className,
+    )}
+    title={resource.label}
+  >
+    {resource.abbr}
+  </span>
+);
+
+type MonitoringResourceIconProps = {
+  className?: string;
+  resource: MonitoringResource;
+};
+
+export const Severity: React.FC<{ severity: string }> = React.memo(({ severity }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const getSeverityKey = (severityData: string) => {
+    switch (severityData) {
+      case AlertSeverity.Critical:
+        return t('Critical');
+      case AlertSeverity.Info:
+        return t('Info');
+      case AlertSeverity.Warning:
+        return t('Warning');
+      case AlertSeverity.None:
+        return t('None');
+      default:
+        return severityData;
+    }
+  };
+
+  return _.isNil(severity) ? (
+    <>-</>
+  ) : (
+    <>
+      <SeverityIcon severity={severity} /> {getSeverityKey(severity)}
+    </>
+  );
+});
+
+export const SeverityIcon: React.FC<{ severity: string }> = React.memo(({ severity }) => {
+  const Icon =
+    {
+      [AlertSeverity.Critical]: RedExclamationCircleIcon,
+      [AlertSeverity.Info]: BlueInfoCircleIcon,
+      [AlertSeverity.None]: BlueInfoCircleIcon,
+      [AlertSeverity.Warning]: YellowExclamationTriangleIcon,
+    }[severity] || YellowExclamationTriangleIcon;
+  return <Icon />;
+});
+
+export const AlertState: React.FC<AlertStateProps> = React.memo(({ state }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const icon = <AlertStateIcon state={state} />;
+
+  return icon ? (
+    <>
+      {icon} {getAlertStateKey(state, t)}
+    </>
+  ) : null;
+});
+
+type AlertStateProps = {
+  state: AlertStates;
+};
+
+export const AlertStateIcon: React.FC<{ state: string }> = React.memo(({ state }) => {
+  switch (state) {
+    case AlertStates.Firing:
+      return <BellIcon />;
+    case AlertStates.Pending:
+      return <OutlinedBellIcon />;
+    case AlertStates.Silenced:
+      return <BellSlashIcon className="text-muted" />;
+    default:
+      return null;
+  }
+});
+
+export const getAlertStateKey = (state, t) => {
+  switch (state) {
+    case AlertStates.Firing:
+      return t('Firing');
+    case AlertStates.Pending:
+      return t('Pending');
+    case AlertStates.Silenced:
+      return t('Silenced');
+    default:
+      return t('Not Firing');
+  }
+};
+
+export const AlertStateDescription: React.FC<{ alert: Alert }> = ({ alert }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  if (alert && !_.isEmpty(alert.silencedBy)) {
+    return <StateTimestamp text={t('Ends')} timestamp={_.max(_.map(alert.silencedBy, 'endsAt'))} />;
+  }
+  if (alert && alert.activeAt) {
+    return <StateTimestamp text={t('Since')} timestamp={alert.activeAt} />;
+  }
+  return null;
+};
+
+const StateTimestamp = ({ text, timestamp }) => (
+  <div className="text-muted monitoring-timestamp">
+    {text}&nbsp;
+    <Timestamp timestamp={timestamp} />
+  </div>
+);

--- a/src/components/alerting/AlertsPage.tsx
+++ b/src/components/alerting/AlertsPage.tsx
@@ -1,0 +1,307 @@
+import * as React from 'react';
+import { withFallback } from '../console/console-shared/error/error-boundary';
+import { useTranslation } from 'react-i18next';
+import { usePerspective } from '../hooks/usePerspective';
+import { Alerts, AlertSource, RootState } from '../types';
+import { useSelector } from 'react-redux';
+
+import * as _ from 'lodash-es';
+import {
+  alertSource,
+  AlertState,
+  AlertStateDescription,
+  devRuleURL,
+  devSilenceAlertURL,
+  getAdditionalSources,
+  isActionWithCallback,
+  isActionWithHref,
+  MonitoringResourceIcon,
+  ruleURL,
+  Severity,
+  silenceAlertURL,
+  SilencesNotLoadedWarning,
+} from './AlertUtils';
+import {
+  Action,
+  Alert,
+  AlertStates,
+  ActionServiceProvider,
+  ListPageFilter,
+  RowFilter,
+  RowProps,
+  TableColumn,
+  useListPageFilter,
+  VirtualizedTable,
+} from '@openshift-console/dynamic-plugin-sdk';
+import {
+  AlertResource,
+  alertSeverityOrder,
+  alertState,
+  alertURL,
+  devAlertURL,
+  fuzzyCaseInsensitive,
+} from '../utils';
+import { severityRowFilter } from '../alerting';
+import { sortable } from '@patternfly/react-table';
+import { Helmet } from 'react-helmet';
+import { DropdownItem } from '@patternfly/react-core';
+import { RouteComponentProps, withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
+import KebabDropdown from '../kebab-dropdown';
+
+const tableAlertClasses = [
+  'pf-u-w-50 pf-u-w-33-on-sm', // Name
+  'pf-m-hidden pf-m-visible-on-sm', // Severity
+  '', // State
+  'pf-m-hidden pf-m-visible-on-sm', // Source
+  'dropdown-kebab-pf pf-c-table__action',
+];
+
+const AlertsPage_: React.FC<AlertsPageProps> = () => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev, alertsKey, defaultAlertTenant } = usePerspective();
+
+  const {
+    data,
+    loaded = false,
+    loadError,
+  }: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey) || {});
+  const silencesLoadError = useSelector(
+    ({ observe }: RootState) => observe.get('silences')?.loadError,
+  );
+
+  const alertAdditionalSources = React.useMemo(
+    () => getAdditionalSources(data, alertSource),
+    [data],
+  );
+
+  let rowFilters: RowFilter[] = [
+    // TODO: The "name" filter doesn't really fit useListPageFilter's idea of a RowFilter, but
+    //       useListPageFilter doesn't yet provide a better way to add a filter like this
+    {
+      filter: (filter, alert: Alert) =>
+        fuzzyCaseInsensitive(filter.selected?.[0], alert.labels?.alertname),
+      filterGroupName: '',
+      items: [],
+      type: 'name',
+    } as RowFilter,
+    {
+      defaultSelected: [AlertStates.Firing],
+      filter: (filter, alert: Alert) =>
+        filter.selected?.includes(alertState(alert)) || _.isEmpty(filter.selected),
+      filterGroupName: t('Alert State'),
+      items: [
+        { id: AlertStates.Firing, title: t('Firing') },
+        { id: AlertStates.Pending, title: t('Pending') },
+        { id: AlertStates.Silenced, title: t('Silenced') },
+      ],
+      reducer: alertState,
+      type: 'alert-state',
+    },
+    severityRowFilter(t),
+    {
+      defaultSelected: [defaultAlertTenant],
+      filter: (filter, alert: Alert) =>
+        filter.selected?.includes(alertSource(alert)) || _.isEmpty(filter.selected),
+      filterGroupName: t('Source'),
+      items: [
+        { id: AlertSource.Platform, title: t('Platform') },
+        { id: AlertSource.User, title: t('User') },
+        ...alertAdditionalSources,
+      ],
+      reducer: alertSource,
+      type: 'alert-source',
+    },
+  ];
+
+  if (isDev) {
+    rowFilters = rowFilters.filter((filter) => filter.type !== 'alert-source');
+  }
+
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(data, rowFilters);
+
+  const columns = React.useMemo<TableColumn<Alert>[]>(
+    () => [
+      {
+        id: 'name',
+        props: { className: tableAlertClasses[0] },
+        sort: 'labels.alertname',
+        title: t('Name'),
+        transforms: [sortable],
+      },
+      {
+        id: 'severity',
+        props: { className: tableAlertClasses[1] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertSeverityOrder, [direction]) as Alert[],
+        title: t('Severity'),
+        transforms: [sortable],
+      },
+      {
+        id: 'state',
+        props: { className: tableAlertClasses[2] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertStateOrder, [direction]),
+        title: t('State'),
+        transforms: [sortable],
+      },
+      {
+        id: 'source',
+        props: { className: tableAlertClasses[3] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertSource, [direction]),
+        title: t('Source'),
+        transforms: [sortable],
+      },
+      {
+        id: 'actions',
+        props: { className: tableAlertClasses[4] },
+        title: '',
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>Alerting</title>
+      </Helmet>
+      <div className="co-m-pane__body">
+        <ListPageFilter
+          data={staticData}
+          labelFilter="alerts"
+          labelPath="labels"
+          loaded={loaded}
+          onFilterChange={onFilterChange}
+          rowFilters={rowFilters}
+        />
+        {silencesLoadError && <SilencesNotLoadedWarning silencesLoadError={silencesLoadError} />}
+        <div className="row">
+          <div className="col-xs-12">
+            <VirtualizedTable<Alert>
+              aria-label={t('Alerts')}
+              columns={columns}
+              data={filteredData ?? []}
+              loaded={loaded}
+              loadError={loadError}
+              Row={AlertTableRow}
+              unfilteredData={data}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+const AlertsPage = withFallback(AlertsPage_);
+
+// Sort alerts by their state (sort first by the state itself, then by the timestamp relevant to
+// the state)
+const alertStateOrder = (alert: Alert) => [
+  [AlertStates.Firing, AlertStates.Pending, AlertStates.Silenced].indexOf(alertState(alert)),
+  alertState(alert) === AlertStates.Silenced
+    ? _.max(_.map(alert.silencedBy, 'endsAt'))
+    : _.get(alert, 'activeAt'),
+];
+
+const AlertTableRow_: React.FC<AlertTableRowProps> = ({ history, obj, match }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev } = usePerspective();
+  const namespace = match.params.ns;
+
+  const { annotations = {}, labels } = obj;
+  const description = annotations.description || annotations.message;
+  const state = alertState(obj);
+
+  const title: string = obj.annotations?.description || obj.annotations?.message;
+
+  const dropdownItems = [
+    <DropdownItem
+      key="view-rule"
+      onClick={() => history.push(isDev ? devRuleURL(obj.rule, namespace) : ruleURL(obj.rule))}
+    >
+      {t('View alerting rule')}
+    </DropdownItem>,
+  ];
+  if (state !== AlertStates.Silenced) {
+    dropdownItems.unshift(
+      <DropdownItem
+        key="silence-alert"
+        onClick={() =>
+          history.push(isDev ? devSilenceAlertURL(obj, namespace) : silenceAlertURL(obj))
+        }
+      >
+        {t('Silence alert')}
+      </DropdownItem>,
+    );
+  }
+
+  const getDropdownItemsWithExtension = (actions: Action[]) => {
+    const extensionDropdownItems = [];
+    actions.forEach((action) => {
+      if (isActionWithHref(action)) {
+        extensionDropdownItems.push(
+          <DropdownItem key={action.id} href={action.cta.href}>
+            {action.label}
+          </DropdownItem>,
+        );
+      } else if (isActionWithCallback(action)) {
+        extensionDropdownItems.push(
+          <DropdownItem key={action.id} onClick={action.cta}>
+            {action.label}
+          </DropdownItem>,
+        );
+      }
+    });
+    return dropdownItems.concat(extensionDropdownItems);
+  };
+
+  return (
+    <>
+      <td className={tableAlertClasses[0]} title={title}>
+        <div className="co-resource-item">
+          <MonitoringResourceIcon resource={AlertResource} />
+          <Link
+            to={isDev ? devAlertURL(obj, obj.rule.id, namespace) : alertURL(obj, obj.rule.id)}
+            data-test-id="alert-resource-link"
+            className="co-resource-item__resource-name"
+          >
+            {labels?.alertname}
+          </Link>
+        </div>
+        <div className="monitoring-description">{description}</div>
+      </td>
+      <td className={tableAlertClasses[1]} title={title}>
+        <Severity severity={labels?.severity} />
+      </td>
+      <td className={tableAlertClasses[2]} title={title}>
+        <AlertState state={state} />
+        <AlertStateDescription alert={obj} />
+      </td>
+      <td className={tableAlertClasses[3]} title={title}>
+        {alertSource(obj) === AlertSource.User ? t('User') : t('Platform')}
+      </td>
+      <td className={tableAlertClasses[4]} title={title}>
+        <ActionServiceProvider context={{ 'monitoring-alert-list-item': { alert: obj } }}>
+          {({ actions, loaded }) => {
+            if (loaded && actions.length > 0) {
+              return <KebabDropdown dropdownItems={getDropdownItemsWithExtension(actions)} />;
+            } else {
+              return <KebabDropdown dropdownItems={dropdownItems} />;
+            }
+          }}
+        </ActionServiceProvider>
+      </td>
+    </>
+  );
+};
+const AlertTableRow = withRouter(AlertTableRow_);
+
+export default AlertsPage;
+
+type AlertTableRowProps = RouteComponentProps<AlertsPageProps> & RowProps<Alert>;
+
+type AlertsPageProps = {
+  ns: string | undefined;
+};

--- a/src/components/alerting/README.md
+++ b/src/components/alerting/README.md
@@ -1,0 +1,21 @@
+## Dev Console Migration
+The Observability UI team is in the process of migrating the developer perspective UI from the 
+openshift/console repo into this one. In the process of this, the alerting UI will be going through
+a refactor to help make the code more maintainable. At this time the current plan is as follows:
+
+```
+src/components
+│   alerting.tsx (This file will be reserved for the routing of the alerting module)
+│
+└───alerting
+│   │   AlertsUtils (Utility functions and components use across the alerting pages)
+│   │   alerts-types (Types used across the alerting pages)
+│   │   AlertsPage (Lister view of alerts for both developer and admin perspectives)
+│   │   AlertsDetailPage (Detail page of alerts)
+│   │   AlertsRulePage (Lister view of alert rules)
+│   │   AlertsRuleDetailPage (Detail page of alert rules)
+│   │   SilencesPage (Lister view of silences)
+│   │   SilencesDetailPage (Detail page of alert rules)
+```
+
+Update this doc if changes are needed and remove it once the migration is complete.

--- a/src/components/console/console-shared/hooks/useActiveNamespace.ts
+++ b/src/components/console/console-shared/hooks/useActiveNamespace.ts
@@ -1,13 +1,5 @@
-import * as React from 'react';
+import { useSelector } from 'react-redux';
 
-type NamespaceContextType = {
-  namespace?: string;
-  setNamespace?: (ns: string) => void;
-};
-
-const NamespaceContext = React.createContext<NamespaceContextType>({});
-
-export const useActiveNamespace = () => {
-  const { namespace, setNamespace } = React.useContext(NamespaceContext);
-  return [namespace, setNamespace];
+export const useActiveNamespace = (): string => {
+  return useSelector(({ UI }) => UI.get('activeNamespace'));
 };

--- a/src/components/dashboards/custom-time-range-modal.tsx
+++ b/src/components/dashboards/custom-time-range-modal.tsx
@@ -12,7 +12,7 @@ import {
   TimePicker,
 } from '@patternfly/react-core';
 
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/observe';
+import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../actions/observe';
 import { RootState } from '../types';
 
 import { setQueryArguments } from '../console/utils/router';
@@ -32,13 +32,13 @@ const toISOTimeString = (date: Date): string =>
   ).format(date);
 
 type CustomTimeRangeModalProps = {
-  activePerspective: string;
+  perspective: Perspective;
   isOpen: boolean;
   setClosed: () => void;
 };
 
 const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
-  activePerspective,
+  perspective,
   isOpen,
   setClosed,
 }) => {
@@ -46,10 +46,10 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
 
   const dispatch = useDispatch();
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
 
   // If a time is already set in Redux, default to that, otherwise default to a time range that
@@ -69,8 +69,8 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
     const from = Date.parse(`${fromDate} ${fromTime}`);
     const to = Date.parse(`${toDate} ${toTime}`);
     if (_.isInteger(from) && _.isInteger(to)) {
-      dispatch(dashboardsSetEndTime(to, activePerspective));
-      dispatch(dashboardsSetTimespan(to - from, activePerspective));
+      dispatch(dashboardsSetEndTime(to, perspective));
+      dispatch(dashboardsSetTimespan(to - from, perspective));
       setQueryArguments({
         endTime: to.toString(),
         timeRange: (to - from).toString(),

--- a/src/components/dashboards/graph.tsx
+++ b/src/components/dashboards/graph.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { CustomDataSource } from '../console/extensions/dashboard-data-source';
 
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/observe';
+import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../actions/observe';
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
 import { RootState } from '../types';
-import { DEFAULT_GRAPH_SAMPLES, getActivePerspective } from './monitoring-dashboard-utils';
+import { DEFAULT_GRAPH_SAMPLES } from './monitoring-dashboard-utils';
 
 type Props = {
   customDataSource?: CustomDataSource;
@@ -18,6 +18,7 @@ type Props = {
   units: string;
   onZoomHandle?: (timeRange: number, endTime: number) => void;
   namespace?: string;
+  perspective: Perspective;
 };
 
 const Graph: React.FC<Props> = ({
@@ -30,23 +31,23 @@ const Graph: React.FC<Props> = ({
   units,
   onZoomHandle,
   namespace,
+  perspective,
 }) => {
   const dispatch = useDispatch();
-  const activePerspective = getActivePerspective(namespace);
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
 
   const onZoom = React.useCallback(
     (from, to) => {
-      dispatch(dashboardsSetEndTime(to, activePerspective));
-      dispatch(dashboardsSetTimespan(to - from, activePerspective));
+      dispatch(dashboardsSetEndTime(to, perspective));
+      dispatch(dashboardsSetTimespan(to - from, perspective));
       onZoomHandle?.(to - from, to);
     },
-    [activePerspective, dispatch, onZoomHandle],
+    [perspective, dispatch, onZoomHandle],
   );
 
   return (

--- a/src/components/dashboards/index.tsx
+++ b/src/components/dashboards/index.tsx
@@ -51,6 +51,7 @@ import {
   dashboardsSetPollInterval,
   dashboardsSetTimespan,
   dashboardsVariableOptionsLoaded,
+  Perspective,
   queryBrowserDeleteAllQueries,
 } from '../../actions/observe';
 import IntervalDropdown from '../poll-interval-dropdown';
@@ -65,17 +66,13 @@ import {
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
   Panel,
   Row,
-  TimeDropdownsProps,
 } from './types';
 import { useBoolean } from '../hooks/useBoolean';
 import { useIsVisible } from '../hooks/useIsVisible';
 import { useFetchDashboards } from './useFetchDashboards';
-import {
-  DEFAULT_GRAPH_SAMPLES,
-  getActivePerspective,
-  getAllVariables,
-} from './monitoring-dashboard-utils';
+import { DEFAULT_GRAPH_SAMPLES, getAllVariables } from './monitoring-dashboard-utils';
 import { getTimeRanges, isTimeoutError, QUERY_CHUNK_SIZE } from '../utils';
+import { usePerspective } from '../hooks/usePerspective';
 
 const intervalVariableRegExps = ['__interval', '__rate_interval', '__auto_interval_[a-z]+'];
 
@@ -208,17 +205,20 @@ const FilterSelect: React.FC<FilterSelectProps> = ({
   );
 };
 
-const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace }) => {
+const VariableDropdown: React.FC<VariableDropdownProps> = ({
+  id,
+  name,
+  namespace,
+  perspective,
+}) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
-  const activePerspective = getActivePerspective(namespace);
-
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
 
   const variables = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'variables']),
+    observe.getIn(['dashboards', perspective, 'variables']),
   );
   const variable = variables.toJS()[name];
   const query = evaluateTemplate(variable.query, variables, timespan);
@@ -273,7 +273,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
     const timeRanges = getTimeRanges(timespan);
     const newOptions = new Set<string>();
     let abortError = false;
-    dispatch(dashboardsPatchVariable(name, { isLoading: true }, activePerspective));
+    dispatch(dashboardsPatchVariable(name, { isLoading: true }, perspective));
     Promise.allSettled(
       timeRanges.map(async (timeRange) => {
         const prometheusProps = {
@@ -314,17 +314,17 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
         setIsError(false);
         // Options were found or no options were found but that wasn't in error
         const newOptionArray = Array.from(newOptions).sort();
-        dispatch(dashboardsVariableOptionsLoaded(name, newOptionArray, activePerspective));
+        dispatch(dashboardsVariableOptionsLoaded(name, newOptionArray, perspective));
       } else {
         // No options were found, and there were errors (timeouts or other) in fetching the data
-        dispatch(dashboardsPatchVariable(name, { isLoading: false }, activePerspective));
+        dispatch(dashboardsPatchVariable(name, { isLoading: false }, perspective));
         if (!abortError) {
           setIsError(true);
         }
       }
     });
   }, [
-    activePerspective,
+    perspective,
     dispatch,
     getURL,
     name,
@@ -338,26 +338,26 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
 
   React.useEffect(() => {
     if (variable.value && variable.value !== getQueryArgument(name)) {
-      if (activePerspective === 'dev' && name !== 'namespace') {
+      if (perspective === 'dev' && name !== 'namespace') {
         setQueryArgument(name, variable.value);
-      } else if (activePerspective === 'admin') {
+      } else if (perspective === 'admin') {
         setQueryArgument(name, variable.value);
       }
     }
-  }, [activePerspective, name, variable.value]);
+  }, [perspective, name, variable.value]);
 
   const onChange = React.useCallback(
     (v: string) => {
       if (v !== variable.value) {
-        if (activePerspective === 'dev' && name !== 'namespace') {
+        if (perspective === 'dev' && name !== 'namespace') {
           setQueryArgument(name, v);
-        } else if (activePerspective === 'admin') {
+        } else if (perspective === 'admin') {
           setQueryArgument(name, v);
         }
-        dispatch(dashboardsPatchVariable(name, { value: v }, activePerspective));
+        dispatch(dashboardsPatchVariable(name, { value: v }, perspective));
       }
     },
-    [activePerspective, dispatch, name, variable.value],
+    [perspective, dispatch, name, variable.value],
   );
 
   if (variable.isHidden || (!isError && _.isEmpty(variable.options))) {
@@ -399,16 +399,22 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
   );
 };
 
-const AllVariableDropdowns = () => {
+const AllVariableDropdowns: React.FC<{ perspective: Perspective }> = ({ perspective }) => {
   const namespace = React.useContext(NamespaceContext);
   const variables = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', getActivePerspective(namespace), 'variables']),
+    observe.getIn(['dashboards', perspective, 'variables']),
   );
 
   return (
     <>
       {variables.keySeq().map((name: string) => (
-        <VariableDropdown key={name} id={name} name={name} namespace={namespace} />
+        <VariableDropdown
+          key={name}
+          id={name}
+          name={name}
+          namespace={namespace}
+          perspective={perspective}
+        />
       ))}
     </>
   );
@@ -467,13 +473,13 @@ const DashboardDropdown: React.FC<DashboardDropdownProps> = React.memo(
   },
 );
 
-export const PollIntervalDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
+export const PollIntervalDropdown: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
   const refreshIntervalFromParams = getQueryArgument('refreshInterval');
-  const activePerspective = getActivePerspective(namespace);
+  const { perspective } = usePerspective();
   const interval = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'pollInterval']),
+    observe.getIn(['dashboards', perspective, 'pollInterval']),
   );
 
   const dispatch = useDispatch();
@@ -484,9 +490,9 @@ export const PollIntervalDropdown: React.FC<TimeDropdownsProps> = ({ namespace }
       } else {
         removeQueryArgument('refreshInterval');
       }
-      dispatch(dashboardsSetPollInterval(v, activePerspective));
+      dispatch(dashboardsSetPollInterval(v, perspective));
     },
-    [dispatch, activePerspective],
+    [dispatch, perspective],
   );
 
   return (
@@ -504,11 +510,10 @@ export const PollIntervalDropdown: React.FC<TimeDropdownsProps> = ({ namespace }
 };
 
 const TimeDropdowns: React.FC = React.memo(() => {
-  const namespace = React.useContext(NamespaceContext);
   return (
     <div className="monitoring-dashboards__options">
-      <TimespanDropdown namespace={namespace} />
-      <PollIntervalDropdown namespace={namespace} />
+      <TimespanDropdown />
+      <PollIntervalDropdown />
     </div>
   );
 });
@@ -588,19 +593,18 @@ const getPanelClassModifier = (panel: Panel): string => {
   }
 };
 
-const Card: React.FC<CardProps> = React.memo(({ panel }) => {
+const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
   const namespace = React.useContext(NamespaceContext);
-  const activePerspective = getActivePerspective(namespace);
   const pollInterval = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'pollInterval']),
+    observe.getIn(['dashboards', perspective, 'pollInterval']),
   );
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
   const variables = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'variables']),
+    observe.getIn(['dashboards', perspective, 'variables']),
   );
 
   const ref = React.useRef();
@@ -674,7 +678,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
     return (
       <>
         {_.map(panel.panels, (p) => (
-          <Card key={p.id} panel={p} />
+          <Card key={p.id} panel={p} perspective={perspective} />
         ))}
       </>
     );
@@ -744,6 +748,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
                       onZoomHandle={handleZoom}
                       namespace={namespace}
                       customDataSource={customDataSource}
+                      perspective={perspective}
                     />
                   )}
                   {(panel.type === 'singlestat' || panel.type === 'gauge') && (
@@ -774,7 +779,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
   );
 });
 
-const PanelsRow: React.FC<{ row: Row }> = ({ row }) => {
+const PanelsRow: React.FC<PanelsRowProps> = ({ row, perspective }) => {
   const showButton = row.showTitle && !_.isEmpty(row.title);
 
   const [isExpanded, toggleIsExpanded] = useBoolean(showButton ? !row.collapse : true);
@@ -800,7 +805,7 @@ const PanelsRow: React.FC<{ row: Row }> = ({ row }) => {
       {isExpanded && (
         <div className="monitoring-dashboards__row">
           {_.map(row.panels, (panel) => (
-            <Card key={panel.id} panel={panel} />
+            <Card key={panel.id} panel={panel} perspective={perspective} />
           ))}
         </div>
       )}
@@ -808,10 +813,10 @@ const PanelsRow: React.FC<{ row: Row }> = ({ row }) => {
   );
 };
 
-const Board: React.FC<BoardProps> = ({ rows }) => (
+const Board: React.FC<BoardProps> = ({ rows, perspective }) => (
   <>
     {_.map(rows, (row) => (
-      <PanelsRow key={_.map(row.panels, 'id').join()} row={row} />
+      <PanelsRow key={_.map(row.panels, 'id').join()} row={row} perspective={perspective} />
     ))}
   </>
 );
@@ -823,7 +828,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
 
   const dispatch = useDispatch();
   const namespace = match.params?.ns;
-  const activePerspective = getActivePerspective(namespace);
+  const { perspective } = usePerspective();
   const [board, setBoard] = React.useState<string>();
   const [boards, isLoading, error] = useFetchDashboards(namespace);
 
@@ -833,11 +838,11 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
   // Clear variables on unmount for dev perspective
   React.useEffect(
     () => () => {
-      if (activePerspective === 'dev') {
-        dispatch(DashboardsClearVariables(activePerspective));
+      if (perspective === 'dev') {
+        dispatch(DashboardsClearVariables(perspective));
       }
     },
-    [activePerspective, dispatch],
+    [perspective, dispatch],
   );
 
   const boardItems = React.useMemo(
@@ -881,25 +886,25 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
         }
 
         const allVariables = getAllVariables(boards, newBoard, namespace);
-        dispatch(dashboardsPatchAllVariables(allVariables, activePerspective));
+        dispatch(dashboardsPatchAllVariables(allVariables, perspective));
 
         // Set time range and poll interval options to their defaults or from the query params if
         // available
         if (refreshInterval) {
-          dispatch(dashboardsSetPollInterval(_.toNumber(refreshInterval), activePerspective));
+          dispatch(dashboardsSetPollInterval(_.toNumber(refreshInterval), perspective));
         }
-        dispatch(dashboardsSetEndTime(_.toNumber(endTime) || null, activePerspective));
+        dispatch(dashboardsSetEndTime(_.toNumber(endTime) || null, perspective));
         dispatch(
           dashboardsSetTimespan(
             _.toNumber(timeSpan) || MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
-            activePerspective,
+            perspective,
           ),
         );
 
         setBoard(newBoard);
       }
     },
-    [activePerspective, board, boards, dispatch, history, namespace],
+    [perspective, board, boards, dispatch, history, namespace],
   );
 
   // Display dashboard present in the params or show the first board
@@ -912,12 +917,12 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
 
   React.useEffect(() => {
     // Dashboard query argument is only set in dev perspective, so skip for admin
-    if (activePerspective === 'admin') {
+    if (perspective === 'admin') {
       return;
     }
     const newBoard = getQueryArgument('dashboard');
     const allVariables = getAllVariables(boards, newBoard, namespace);
-    dispatch(dashboardsPatchAllVariables(allVariables, activePerspective));
+    dispatch(dashboardsPatchAllVariables(allVariables, perspective));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespace]);
 
@@ -962,12 +967,18 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
               {!_.isEmpty(boardItems) && (
                 <DashboardDropdown items={boardItems} onChange={changeBoard} selectedKey={board} />
               )}
-              <AllVariableDropdowns key={board} />
+              <AllVariableDropdowns key={board} perspective={perspective} />
             </div>
             {namespace && <TimeDropdowns />}
           </div>
         </div>
-        <Overview>{isLoading ? <LoadingInline /> : <Board key={board} rows={rows} />}</Overview>
+        <Overview>
+          {isLoading ? (
+            <LoadingInline />
+          ) : (
+            <Board key={board} rows={rows} perspective={perspective} />
+          )}
+        </Overview>
       </NamespaceContext.Provider>
     </>
   );
@@ -992,6 +1003,7 @@ type FilterSelectProps = {
 type VariableDropdownProps = {
   id: string;
   name: string;
+  perspective: Perspective;
   namespace?: string;
 };
 
@@ -1008,10 +1020,17 @@ type DashboardDropdownProps = {
 
 type BoardProps = {
   rows: Row[];
+  perspective: Perspective;
 };
 
 type CardProps = {
   panel: Panel;
+  perspective: Perspective;
+};
+
+type PanelsRowProps = {
+  row: Row;
+  perspective: Perspective;
 };
 
 export default withFallback(MonitoringDashboardsPage);

--- a/src/components/dashboards/monitoring-dashboard-utils.ts
+++ b/src/components/dashboards/monitoring-dashboard-utils.ts
@@ -6,8 +6,6 @@ import { getQueryArgument } from '../console/utils/router';
 
 export const DEFAULT_GRAPH_SAMPLES = 60;
 
-export const getActivePerspective = (namespace: string): string => (namespace ? 'dev' : 'admin');
-
 export const getAllVariables = (boards: Board[], newBoardName: string, namespace: string) => {
   const data = _.find(boards, { name: newBoardName })?.data;
 

--- a/src/components/dashboards/timespan-dropdown.tsx
+++ b/src/components/dashboards/timespan-dropdown.tsx
@@ -13,24 +13,23 @@ import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/obser
 import { useBoolean } from '../hooks/useBoolean';
 import { RootState } from '../types';
 import CustomTimeRangeModal from './custom-time-range-modal';
-import { TimeDropdownsProps } from './types';
-import { getActivePerspective } from './monitoring-dashboard-utils';
+import { usePerspective } from '../hooks/usePerspective';
 
 const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 
-const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
+const TimespanDropdown: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
-  const activePerspective = getActivePerspective(namespace);
+  const { perspective } = usePerspective();
 
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
   const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
 
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
 
   const timeSpanFromParams = getQueryArgument('timeRange');
@@ -44,11 +43,11 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
       } else {
         setQueryArgument('timeRange', parsePrometheusDuration(v).toString());
         removeQueryArgument('endTime');
-        dispatch(dashboardsSetTimespan(parsePrometheusDuration(v), activePerspective));
-        dispatch(dashboardsSetEndTime(null, activePerspective));
+        dispatch(dashboardsSetTimespan(parsePrometheusDuration(v), perspective));
+        dispatch(dashboardsSetEndTime(null, perspective));
       }
     },
-    [activePerspective, dispatch, setModalOpen],
+    [perspective, dispatch, setModalOpen],
   );
 
   const items = {
@@ -69,9 +68,9 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   return (
     <>
       <CustomTimeRangeModal
-        activePerspective={activePerspective}
         isOpen={isModalOpen}
         setClosed={setModalClosed}
+        perspective={perspective}
       />
       <div className="form-group monitoring-dashboards__dropdown-wrap">
         <label

--- a/src/components/dashboards/types.ts
+++ b/src/components/dashboards/types.ts
@@ -95,10 +95,6 @@ export type Board = {
   name: string;
 };
 
-export type TimeDropdownsProps = {
-  namespace?: string;
-};
-
 export type DataSource = {
   name: string;
   type: string;

--- a/src/components/fetch-alerts.tsx
+++ b/src/components/fetch-alerts.tsx
@@ -5,8 +5,9 @@ export const fetchAlerts = async (
   prometheusURL: string,
   externalAlertsFetch?: Array<{
     id: string;
-    getAlertingRules: () => Promise<PrometheusRulesResponse>;
+    getAlertingRules: (namespace?: string) => Promise<PrometheusRulesResponse>;
   }>,
+  namespace?: string,
 ): Promise<PrometheusRulesResponse> => {
   if (!externalAlertsFetch || externalAlertsFetch.length === 0) {
     return consoleFetchJSON(prometheusURL);
@@ -22,7 +23,7 @@ export const fetchAlerts = async (
   try {
     const groups = await Promise.allSettled([
       consoleFetchJSON(prometheusURL),
-      ...resolvedExternalAlertsSources.map((source) => source.fetch()),
+      ...resolvedExternalAlertsSources.map((source) => source.fetch(namespace)),
     ]).then((results) =>
       results
         .map((result, i) => ({ sourceId: sourceIds[i], alerts: result }))

--- a/src/components/hooks/usePerspective.tsx
+++ b/src/components/hooks/usePerspective.tsx
@@ -1,0 +1,32 @@
+import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
+import { Perspective } from 'src/actions/observe';
+import { AlertSource } from '../types';
+
+type usePerspectiveReturn = {
+  perspective: Perspective;
+  isDev: boolean;
+  rulesKey: 'devRules' | 'rules';
+  alertsKey: 'devAlerts' | 'alerts';
+  defaultAlertTenant: AlertSource;
+};
+
+export const usePerspective = (): usePerspectiveReturn => {
+  const [perspective] = useActivePerspective();
+
+  if (perspective === 'dev') {
+    return {
+      perspective: 'dev',
+      isDev: true,
+      rulesKey: 'devRules',
+      alertsKey: 'devAlerts',
+      defaultAlertTenant: AlertSource.User,
+    };
+  }
+  return {
+    perspective: 'admin',
+    isDev: false,
+    rulesKey: 'rules',
+    alertsKey: 'alerts',
+    defaultAlertTenant: AlertSource.Platform,
+  };
+};

--- a/src/components/silence-form.tsx
+++ b/src/components/silence-form.tsx
@@ -35,6 +35,7 @@ import { StatusBox } from './console/utils/status-box';
 import { useBoolean } from './hooks/useBoolean';
 import { RootState, Silences } from './types';
 import { refreshSilences, SilenceResource, silenceState } from './utils';
+import { usePerspective } from './hooks/usePerspective';
 
 const pad = (i: number): string => (i < 10 ? `0${i}` : String(i));
 
@@ -132,6 +133,8 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
 
   const dispatch = useDispatch();
 
+  const { perspective } = usePerspective();
+
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
   const [comment, setComment] = React.useState(defaults.comment ?? '');
@@ -218,7 +221,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
       .post(`${alertManagerBaseURL}/api/v2/silences`, body)
       .then(({ silenceID }) => {
         setError(undefined);
-        refreshSilences(dispatch);
+        refreshSilences(dispatch, perspective);
         history.push(`${SilenceResource.plural}/${encodeURIComponent(silenceID)}`);
       })
       .catch((err) => {


### PR DESCRIPTION
This PR is apart of a pair of PR's (along with [this](https://github.com/openshift/console/pull/14014) one in the console codebase) which look to move the alerting list page from the console codebase over to the monitoring one. This PR needs to merge before the PR in the console codebase can merge. I would further prefer if both could be merged at the same time, by receiving approval on both before either merges.

There is a good amount of code that has changed and a good amount that has been split into other files. While reviewing the code, if you get lost then feel free to take a look at the different commits for this PR, as they are grouped by what they do. Once this PR is approved I will squash them all down, and then re-request approval.

This PR changes the UI of the developer perspective to be consistent with the admin perspective. The overall functionality stays the same, but there are some changes to the workflows required. For example to silence the alert you can't do so directly from the table anymore, instead you will click the ellipsis and then select the "Silence alert" option.

<img width="1393" alt="Screenshot 2024-06-27 at 1 36 14 PM" src="https://github.com/openshift/monitoring-plugin/assets/47438010/cb9307ba-1aa4-46c4-8ab8-7e8b8f149d0a">

In addition, the tab control is done manually in the console block, with new additions being added at the end. So until the rest of the monitoring tabs are moved over the tabs will be out of their typical order as seen in the image above. 