### PR TITLE
OU-248: Split code from Alert Details Page out into other files

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -78,5 +78,16 @@
       "section": "observe",
       "insertAfter": "dashboards"
     }
+  },
+  {
+    "type": "console.tab",
+    "properties": {
+      "contextId": "dev-console-observe",
+      "name": "%public~Alerts%",
+      "href": "alerts",
+      "component": {
+        "$codeRef": "MonitoringUI"
+      }
+    }
   }
 ]

--- a/src/actions/observe.ts
+++ b/src/actions/observe.ts
@@ -31,61 +31,63 @@ export enum ActionType {
   ToggleGraphs = 'toggleGraphs',
 }
 
-export const dashboardsPatchVariable = (key: string, patch: any, perspective: string) =>
+export type Perspective = 'admin' | 'dev';
+type AlertingKey =
+  | 'alerts'
+  | 'devAlerts'
+  | 'silences'
+  | 'devSilences'
+  | 'rules'
+  | 'devRules'
+  | 'notificationAlerts';
+
+export const dashboardsPatchVariable = (key: string, patch: any, perspective: Perspective) =>
   action(ActionType.DashboardsPatchVariable, { key, patch, perspective });
 
-export const dashboardsPatchAllVariables = (variables: any, perspective: string) =>
+export const dashboardsPatchAllVariables = (variables: any, perspective: Perspective) =>
   action(ActionType.DashboardsPatchAllVariables, { variables, perspective });
 
-export const DashboardsClearVariables = (perspective: string) =>
+export const DashboardsClearVariables = (perspective: Perspective) =>
   action(ActionType.DashboardsClearVariables, { perspective });
 
-export const dashboardsSetEndTime = (endTime: number, perspective: string) =>
+export const dashboardsSetEndTime = (endTime: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetEndTime, { endTime, perspective });
 
-export const dashboardsSetPollInterval = (pollInterval: number, perspective: string) =>
+export const dashboardsSetPollInterval = (pollInterval: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetPollInterval, { pollInterval, perspective });
 
-export const dashboardsSetTimespan = (timespan: number, perspective: string) =>
+export const dashboardsSetTimespan = (timespan: number, perspective: Perspective) =>
   action(ActionType.DashboardsSetTimespan, { timespan, perspective });
 
 export const dashboardsVariableOptionsLoaded = (
   key: string,
   newOptions: string[],
-  perspective: string,
+  perspective: Perspective,
 ) => action(ActionType.DashboardsVariableOptionsLoaded, { key, newOptions, perspective });
 
-export const alertingLoading = (
-  key: 'alerts' | 'silences' | 'notificationAlerts',
-  perspective = 'admin',
-) =>
+export const alertingLoading = (key: AlertingKey, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: false, loadError: null, data: null, perspective },
   });
 
-export const alertingLoaded = (
-  key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
-  alerts: any,
-  perspective = 'admin',
-) =>
+export const alertingLoaded = (key: AlertingKey, alerts: any, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: true, loadError: null, data: alerts, perspective },
   });
 
-export const alertingErrored = (
-  key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
-  loadError: Error,
-  perspective = 'admin',
-) =>
+export const alertingErrored = (key: AlertingKey, loadError: Error, perspective: Perspective) =>
   action(ActionType.AlertingSetData, {
     key,
     data: { loaded: true, loadError, data: null, perspective },
   });
 
-export const alertingSetRules = (key: 'rules' | 'devRules', rules: Rule[], perspective = 'admin') =>
-  action(ActionType.AlertingSetRules, { key, data: rules, perspective });
+export const alertingSetRules = (
+  key: 'rules' | 'devRules',
+  rules: Rule[],
+  perspective: Perspective,
+) => action(ActionType.AlertingSetRules, { key, data: rules, perspective });
 
 export const toggleGraphs = () => action(ActionType.ToggleGraphs);
 

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -125,6 +125,7 @@ import {
   AlertState,
   AlertStateDescription,
   AlertStateIcon,
+  devRuleURL,
   getAdditionalSources,
   getAlertStateKey,
   isActionWithCallback,
@@ -847,11 +848,7 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
                     <div className="co-resource-item">
                       <MonitoringResourceIcon resource={RuleResource} />
                       <Link
-                        to={
-                          namespace
-                            ? `/dev-monitoring/ns/${namespace}/rules/${rule?.id}`
-                            : ruleURL(rule)
-                        }
+                        to={namespace ? devRuleURL(rule, namespace) : ruleURL(rule)}
                         data-test="alert-rules-detail-resource-link"
                         className="co-resource-item__resource-name"
                       >

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -152,7 +152,7 @@ const alertSource = (alert: Alert): AlertSource | string => alertingRuleSource(a
 const pollers = {};
 const pollerTimeouts = {};
 
-const silenceAlertURL = (alert: Alert) =>
+const silenceAlertURL = (alert: PrometheusAlert) =>
   `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
 
 const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({ className, resource }) => (
@@ -1018,7 +1018,7 @@ const PrometheusTemplate = ({ text }) => (
 );
 
 type ActiveAlertsProps = RouteComponentProps & {
-  alerts: Alert[];
+  alerts: PrometheusAlert[];
   namespace: string;
   ruleID: string;
 };
@@ -1035,7 +1035,7 @@ const ActiveAlerts_: React.FC<ActiveAlertsProps> = ({ alerts, history, namespace
         <div className="col-sm-2 col-xs-3">{t('Value')}</div>
       </div>
       <div className="co-m-table-grid__body">
-        {_.sortBy(alerts, alertDescription).map((a, i) => (
+        {_.sortBy<PrometheusAlert>(alerts, alertDescription).map((a, i) => (
           <div className="row co-resource-list__item" key={i}>
             <div className="col-xs-6">
               <Link
@@ -1431,7 +1431,7 @@ const SilenceDropdownActions: React.FC<{ silence: Silence }> = ({ silence }) => 
   <SilenceDropdown className="co-actions-menu" silence={silence} Toggle={ActionsToggle} />
 );
 
-type SilencedAlertsListProps = RouteComponentProps & { alerts: Alerts[] };
+type SilencedAlertsListProps = RouteComponentProps & { alerts: Alert[] };
 
 const SilencedAlertsList_: React.FC<SilencedAlertsListProps> = ({ alerts, history }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -1445,7 +1445,7 @@ const SilencedAlertsList_: React.FC<SilencedAlertsListProps> = ({ alerts, histor
         <div className="col-xs-3">{t('Severity')}</div>
       </div>
       <div className="co-m-table-grid__body">
-        {_.sortBy(alerts, alertDescription).map((a, i) => (
+        {_.sortBy<Alert>(alerts, alertDescription).map((a, i) => (
           <div className="row co-resource-list__item" key={i}>
             <div className="col-xs-9">
               <Link
@@ -2410,7 +2410,9 @@ const PollerPages = () => {
     } else {
       dispatch(alertingErrored('alerts', new Error('prometheusBaseURL not set')));
     }
-    return () => _.each(pollerTimeouts, clearTimeout);
+    return () => {
+      _.each(pollerTimeouts, clearTimeout);
+    };
   }, [alertsSource, dispatch]);
 
   return (

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1298,7 +1298,7 @@ const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
   silenceID,
 }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
 
   const dispatch = useDispatch();
 
@@ -2089,7 +2089,7 @@ type ExpireAllSilencesButtonProps = {
 const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setErrorMessage }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
 
   const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
 
@@ -2373,7 +2373,7 @@ const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match })
 const PollerPages = () => {
   const dispatch = useDispatch();
 
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
 
   const [customExtensions] =
     useResolvedExtensions<AlertingRulesSourceExtension>(isAlertingRulesSource);

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1,16 +1,11 @@
 import {
-  ActionServiceProvider,
   Alert,
   AlertSeverity,
   AlertStates,
   consoleFetchJSON,
-  GreenCheckCircleIcon,
   ListPageFilter,
   PrometheusAlert,
   PrometheusEndpoint,
-  PrometheusLabels,
-  ResourceLink,
-  ResourceStatus,
   RowFilter,
   RowProps,
   Rule,
@@ -30,26 +25,17 @@ import {
   Checkbox,
   CodeBlock,
   CodeBlockCode,
-  Dropdown,
   DropdownItem,
-  DropdownPosition,
   DropdownToggle,
   Flex,
   FlexItem,
-  KebabToggle,
-  Label,
-  Modal,
-  ModalVariant,
-  Popover,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { BanIcon, HourglassHalfIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
 import classNames from 'classnames';
-import { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -69,18 +55,8 @@ import {
   isAlertingRulesSource,
 } from './console/extensions/alerts';
 import { getPrometheusURL } from './console/graphs/helpers';
-import {
-  ContainerModel,
-  DaemonSetModel,
-  DeploymentModel,
-  JobModel,
-  NamespaceModel,
-  NodeModel,
-  PodModel,
-  StatefulSetModel,
-} from './console/models';
 import { SectionHeading } from './console/utils/headings';
-import { ExternalLink, LinkifyExternal } from './console/utils/link';
+import { ExternalLink } from './console/utils/link';
 import { getAllQueryArguments } from './console/utils/router';
 import { LoadingInline, StatusBox } from './console/utils/status-box';
 
@@ -96,23 +72,19 @@ import { useBoolean } from './hooks/useBoolean';
 import KebabDropdown from './kebab-dropdown';
 import { Labels } from './labels';
 import { QueryBrowserPage, ToggleGraph } from './metrics';
-import { FormatSeriesTitle, QueryBrowser } from './query-browser';
 import { CreateSilence, EditSilence } from './silence-form';
 import { TargetsUI } from './targets';
 import { Alerts, AlertSource, RootState, Silences } from './types';
 import {
   alertDescription,
   alertingRuleStateOrder,
-  AlertResource,
   alertSeverityOrder,
-  alertState,
   alertURL,
   fuzzyCaseInsensitive,
   getAlertsAndRules,
   labelsToParams,
   refreshSilences,
   RuleResource,
-  silenceMatcherEqualitySymbol,
   SilenceResource,
   silenceState,
 } from './utils';
@@ -121,101 +93,36 @@ import './_monitoring.scss';
 import { usePerspective } from './hooks/usePerspective';
 import {
   alertingRuleSource,
-  alertSource,
   AlertState,
-  AlertStateDescription,
   AlertStateIcon,
-  devRuleURL,
   getAdditionalSources,
   getAlertStateKey,
-  isActionWithCallback,
-  isActionWithHref,
+  getSourceKey,
+  Graph,
   MonitoringResourceIcon,
+  OnToggle,
+  PopoverField,
+  queryBrowserURL,
   ruleURL,
+  SelectedSilencesContext,
   Severity,
-  SeverityIcon,
+  SeverityBadge,
+  SeverityCounts,
+  SeverityHelp,
   silenceAlertURL,
+  SilenceDropdown,
+  SilenceMatchersList,
   SilencesNotLoadedWarning,
+  SilenceState,
+  SilenceTableRow,
+  SourceHelp,
+  tableSilenceClasses,
 } from './alerting/AlertUtils';
 import AlertsPage from './alerting/AlertsPage';
-
-const SelectedSilencesContext = React.createContext({
-  selectedSilences: new Set(),
-  setSelectedSilences: undefined,
-});
+import AlertsDetailsPage from './alerting/AlertsDetailPage';
 
 const pollers = {};
 const pollerTimeouts = {};
-
-const SilenceState = ({ silence }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const state = silenceState(silence);
-  const icon = {
-    [SilenceStates.Active]: <GreenCheckCircleIcon />,
-    [SilenceStates.Pending]: <HourglassHalfIcon className="monitoring-state-icon--pending" />,
-    [SilenceStates.Expired]: <BanIcon className="text-muted" data-test-id="ban-icon" />,
-  }[state];
-
-  const getStateKey = (stateData) => {
-    switch (stateData) {
-      case SilenceStates.Active:
-        return t('Active');
-      case SilenceStates.Pending:
-        return t('Pending');
-      default:
-        return t('Expired');
-    }
-  };
-
-  return icon ? (
-    <>
-      {icon} {getStateKey(state)}
-    </>
-  ) : null;
-};
-
-const StateTimestamp = ({ text, timestamp }) => (
-  <div className="text-muted monitoring-timestamp">
-    {text}&nbsp;
-    <Timestamp timestamp={timestamp} />
-  </div>
-);
-
-const SeverityBadge: React.FC<{ severity: string }> = React.memo(({ severity }) =>
-  _.isNil(severity) || severity === 'none' ? null : (
-    <ResourceStatus>
-      <Severity severity={severity} />
-    </ResourceStatus>
-  ),
-);
-
-const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
-  if (_.isEmpty(alerts)) {
-    return <>-</>;
-  }
-
-  const counts = _.countBy(alerts, (a) => {
-    const { severity } = a.labels;
-    return severity === AlertSeverity.Critical || severity === AlertSeverity.Warning
-      ? severity
-      : AlertSeverity.Info;
-  });
-
-  const severities = [AlertSeverity.Critical, AlertSeverity.Warning, AlertSeverity.Info].filter(
-    (s) => counts[s] > 0,
-  );
-
-  return (
-    <>
-      {severities.map((s) => (
-        <span className="monitoring-icon-wrap" key={s}>
-          <SeverityIcon severity={s} /> {counts[s]}
-        </span>
-      ))}
-    </>
-  );
-};
 
 const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -236,648 +143,9 @@ const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
   );
 };
 
-const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: string }> = ({
-  bodyContent,
-  label,
-}) => (
-  <Popover headerContent={label} bodyContent={bodyContent}>
-    <Button variant="plain" className="details-item__popover-button">
-      {label}
-    </Button>
-  </Popover>
-);
-
-const AlertStateHelp: React.FC = () => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  return (
-    <dl className="co-inline">
-      <dt>
-        <AlertStateIcon state={AlertStates.Pending} /> <strong>{t('Pending: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'The alert is active but is waiting for the duration that is specified in the alerting rule before it fires.',
-        )}
-      </dd>
-      <dt>
-        <AlertStateIcon state={AlertStates.Firing} /> <strong>{t('Firing: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert will continue to fire as long as the condition remains true.',
-        )}
-      </dd>
-      <dt>
-        <AlertStateIcon state={AlertStates.Silenced} /> <strong>{t('Silenced: ')}</strong>
-      </dt>
-      <dt></dt>
-      <dd>
-        {t(
-          'The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications will not be sent for alerts that match all the listed values or regular expressions.',
-        )}
-      </dd>
-    </dl>
-  );
-};
-
-const SeverityHelp: React.FC = () => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  return (
-    <dl className="co-inline">
-      <dt>
-        <SeverityIcon severity={AlertSeverity.Critical} /> <strong>{t('Critical: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'The condition that triggered the alert could have a critical impact. The alert requires immediate attention when fired and is typically paged to an individual or to a critical response team.',
-        )}
-      </dd>
-      <dt>
-        <SeverityIcon severity={AlertSeverity.Warning} /> <strong>{t('Warning: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'The alert provides a warning notification about something that might require attention in order to prevent a problem from occurring. Warnings are typically routed to a ticketing system for non-immediate review.',
-        )}
-      </dd>
-      <dt>
-        <SeverityIcon severity={AlertSeverity.Info} /> <strong>{t('Info: ')}</strong>
-      </dt>
-      <dd>{t('The alert is provided for informational purposes only.')}</dd>
-      <dt>
-        <SeverityIcon severity={AlertSeverity.None} /> <strong>{t('None: ')}</strong>
-      </dt>
-      <dd>{t('The alert has no defined severity.')}</dd>
-      <dd>{t('You can also create custom severity definitions for user workload alerts.')}</dd>
-    </dl>
-  );
-};
-
-const SourceHelp: React.FC = () => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  return (
-    <dl className="co-inline">
-      <dt>
-        <strong>{t('Platform: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'Platform-level alerts relate only to OpenShift namespaces. OpenShift namespaces provide core OpenShift functionality.',
-        )}
-      </dd>
-      <dt>
-        <strong>{t('User: ')}</strong>
-      </dt>
-      <dd>
-        {t(
-          'User workload alerts relate to user-defined namespaces. These alerts are user-created and are customizable. User workload monitoring can be enabled post-installation to provide observability into your own services.',
-        )}
-      </dd>
-    </dl>
-  );
-};
-
-const queryBrowserURL = (query: string, namespace: string) =>
-  namespace
-    ? `/dev-monitoring/ns/${namespace}/metrics?query0=${encodeURIComponent(query)}`
-    : `/monitoring/query-browser?query0=${encodeURIComponent(query)}`;
-
-const Graph: React.FC<GraphProps> = ({
-  filterLabels = undefined,
-  formatSeriesTitle,
-  namespace,
-  query,
-  ruleDuration,
-}) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  // 3 times the rule's duration, but not less than 30 minutes
-  const timespan = Math.max(3 * ruleDuration, 30 * 60) * 1000;
-
-  const GraphLink = () =>
-    query ? (
-      <Link aria-label={t('View in Metrics')} to={queryBrowserURL(query, namespace)}>
-        {t('View in Metrics')}
-      </Link>
-    ) : null;
-
-  return (
-    <QueryBrowser
-      namespace={namespace}
-      defaultTimespan={timespan}
-      filterLabels={filterLabels}
-      formatSeriesTitle={formatSeriesTitle}
-      GraphLink={GraphLink}
-      pollInterval={Math.round(timespan / 120)}
-      queries={[query]}
-    />
-  );
-};
-
-const tableSilenceClasses = [
-  'pf-c-table__action', // Checkbox
-  'pf-u-w-50 pf-u-w-33-on-sm', // Name
-  'pf-m-hidden pf-m-visible-on-sm', // Firing alerts
-  '', // State
-  'pf-m-hidden pf-m-visible-on-sm', // Creator
-  'dropdown-kebab-pf pf-c-table__action',
-];
-
-const SilenceMatchersList = ({ silence }) => (
-  <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
-    {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
-      <Label className="co-label" key={i}>
-        <span className="co-label__key">{name}</span>
-        <span className="co-label__eq">{silenceMatcherEqualitySymbol(isEqual, isRegex)}</span>
-        <span className="co-label__value">{value}</span>
-      </Label>
-    ))}
-  </div>
-);
-
-type SilenceTableRowProps = {
-  obj: Silence;
-  showCheckbox?: boolean;
-};
-
-const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const { createdBy, endsAt, firingAlerts, id, name, startsAt } = obj;
-  const state = silenceState(obj);
-
-  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
-
-  const onCheckboxChange = React.useCallback(
-    (isChecked: boolean) => {
-      setSelectedSilences((oldSet) => {
-        const newSet = new Set(oldSet);
-        if (isChecked) {
-          newSet.add(id);
-        } else {
-          newSet.delete(id);
-        }
-        return newSet;
-      });
-    },
-    [id, setSelectedSilences],
-  );
-
-  return (
-    <>
-      {showCheckbox && (
-        <td className={tableSilenceClasses[0]}>
-          <Checkbox
-            id={id}
-            isChecked={selectedSilences.has(id)}
-            isDisabled={state === SilenceStates.Expired}
-            onChange={onCheckboxChange}
-          />
-        </td>
-      )}
-      <td className={tableSilenceClasses[1]}>
-        <div className="co-resource-item">
-          <MonitoringResourceIcon resource={SilenceResource} />
-          <Link
-            className="co-resource-item__resource-name"
-            data-test-id="silence-resource-link"
-            title={id}
-            to={`${SilenceResource.plural}/${id}`}
-          >
-            {name}
-          </Link>
-        </div>
-        <div className="monitoring-label-list">
-          <SilenceMatchersList silence={obj} />
-        </div>
-      </td>
-      <td className={tableSilenceClasses[2]}>
-        <SeverityCounts alerts={firingAlerts} />
-      </td>
-      <td className={classNames(tableSilenceClasses[3], 'co-break-word')}>
-        <SilenceState silence={obj} />
-        {state === SilenceStates.Pending && (
-          <StateTimestamp text={t('Starts')} timestamp={startsAt} />
-        )}
-        {state === SilenceStates.Active && <StateTimestamp text={t('Ends')} timestamp={endsAt} />}
-        {state === SilenceStates.Expired && (
-          <StateTimestamp text={t('Expired')} timestamp={endsAt} />
-        )}
-      </td>
-      <td className={tableSilenceClasses[4]}>{createdBy || '-'}</td>
-      <td className={tableSilenceClasses[5]}>
-        <SilenceDropdownKebab silence={obj} />
-      </td>
-    </>
-  );
-};
-
 const SilenceTableRowWithCheckbox: React.FC<RowProps<Silence>> = ({ obj }) => (
   <SilenceTableRow showCheckbox={true} obj={obj} />
 );
-
-const alertMessageResources: {
-  [labelName: string]: { kind: string; namespaced?: boolean };
-} = {
-  container: ContainerModel,
-  daemonset: DaemonSetModel,
-  deployment: DeploymentModel,
-  job: JobModel,
-  namespace: NamespaceModel,
-  node: NodeModel,
-  pod: PodModel,
-  statefulset: StatefulSetModel,
-};
-
-const matchCount = (haystack: string, regExpString: string) =>
-  _.size(haystack.match(new RegExp(regExpString, 'g')));
-
-const AlertMessage: React.FC<AlertMessageProps> = ({ alertText, labels, template }) => {
-  if (_.isEmpty(alertText)) {
-    return null;
-  }
-
-  let messageParts: React.ReactNode[] = [alertText];
-
-  // Go through each recognized resource type and replace any resource names that exist in alertText
-  // with a link to the resource's details page
-  _.each(alertMessageResources, (model, label) => {
-    const labelValue = labels[label];
-
-    if (labelValue && !(model.namespaced && _.isEmpty(labels.namespace))) {
-      const tagCount = matchCount(template, `\\{\\{ *\\$labels\\.${label} *\\}\\}`);
-      const resourceNameCount = matchCount(alertText, _.escapeRegExp(labelValue));
-
-      // Don't do the replacement unless the counts match. This avoids overwriting the wrong string
-      // if labelValue happens to appear elsewhere in alertText
-      if (tagCount > 0 && tagCount === resourceNameCount) {
-        const link = (
-          <ResourceLink
-            className="co-resource-item--monitoring-alert"
-            inline
-            key={model.kind}
-            kind={model.kind}
-            name={labelValue}
-            namespace={model.namespaced ? labels.namespace : undefined}
-          />
-        );
-        messageParts = _.flatMap(messageParts, (part) => {
-          if (_.isString(part) && part.indexOf(labelValue) !== -1) {
-            // `part` contains at least one instance of the resource name, so replace each instance
-            // with the link to the resource. Since the link is a component, we can't simply do a
-            // string substitution. Instead, create an array that contains each of the string parts
-            // and the resource links in the correct order.
-            const splitParts = part.split(labelValue);
-            return _.flatMap(splitParts, (p) => [p, link]).slice(0, -1);
-          }
-          return [part];
-        });
-      }
-    }
-  });
-
-  return (
-    <div className="co-alert-manager">
-      <p>
-        <LinkifyExternal>{messageParts}</LinkifyExternal>
-      </p>
-    </div>
-  );
-};
-
-const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rule }) => {
-  const annotation = alert.annotations.description ? 'description' : 'message';
-  return (
-    <AlertMessage
-      alertText={alert.annotations[annotation]}
-      labels={alert.labels}
-      template={rule.annotations[annotation]}
-    />
-  );
-};
-
-const getSourceKey = (source, t: TFunction) => {
-  switch (source) {
-    case 'Platform':
-      return t('Platform');
-    case 'User':
-      return t('User');
-    default:
-      return source;
-  }
-};
-
-const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const columns = React.useMemo<TableColumn<Silence>[]>(
-    () => [
-      {
-        id: 'name',
-        props: { className: tableSilenceClasses[1] },
-        title: t('Name'),
-      },
-      {
-        id: 'firingAlerts',
-        props: { className: tableSilenceClasses[2] },
-        title: t('Firing alerts'),
-      },
-      {
-        id: 'state',
-        props: { className: tableSilenceClasses[3] },
-        title: t('State'),
-      },
-      {
-        id: 'createdBy',
-        props: { className: tableSilenceClasses[4] },
-        title: t('Creator'),
-      },
-      {
-        id: 'actions',
-        props: { className: tableSilenceClasses[5] },
-        title: '',
-      },
-    ],
-    [t],
-  );
-
-  return (
-    <VirtualizedTable<Silence>
-      aria-label={t('Silenced by')}
-      columns={columns}
-      data={silences}
-      loaded={true}
-      loadError={undefined}
-      Row={SilenceTableRow}
-      unfilteredData={silences}
-    />
-  );
-};
-
-type AlertsDetailsPageProps = RouteComponentProps<{ ns?: string; ruleID: string }>;
-
-const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const { alertsKey } = usePerspective();
-  const namespace = match.params?.ns;
-  const hideGraphs = useSelector(({ observe }: RootState) => !!observe.get('hideGraphs'));
-
-  const alerts: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey));
-
-  const silencesLoaded = ({ observe }) => observe.get('silences')?.loaded;
-
-  const ruleAlerts = _.filter(alerts?.data, (a) => a.rule.id === match?.params?.ruleID);
-  const rule = ruleAlerts?.[0]?.rule;
-
-  // Search for an alert that matches all of the labels in the URL parameters. We expect there to be
-  // only one such alert that matches, so don't display any alert if multiple matches were found.
-  const queryParams = getAllQueryArguments();
-  const foundAlerts = _.filter(ruleAlerts, (a) => _.isMatch(a.labels, queryParams));
-  const alert = foundAlerts.length === 1 ? foundAlerts[0] : undefined;
-
-  const state = alertState(alert);
-
-  const labelsMemoKey = JSON.stringify(alert?.labels);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
-
-  // eslint-disable-next-line camelcase
-  const runbookURL = alert?.annotations?.runbook_url;
-
-  const sourceId = rule?.sourceId;
-
-  // Load alert metrics chart from plugin
-  const [alertsChartExtensions] =
-    useResolvedExtensions<AlertingRuleChartExtension>(isAlertingRuleChart);
-  const alertsChart = alertsChartExtensions
-    .filter((extension) => extension.properties.sourceId === sourceId)
-    .map((extension) => extension.properties.chart);
-
-  const AlertsChart = alertsChart?.[0];
-
-  return (
-    <>
-      <StatusBox
-        data={alert}
-        label={AlertResource.label}
-        loaded={alerts?.loaded}
-        loadError={alerts?.loadError}
-      >
-        <div className="pf-c-page__main-breadcrumb">
-          <Breadcrumb className="monitoring-breadcrumbs">
-            <BreadcrumbItem>
-              <Link
-                className="pf-c-breadcrumb__link"
-                to={namespace ? `/dev-monitoring/ns/${namespace}/alerts` : '/monitoring/alerts'}
-              >
-                {t('Alerts')}
-              </Link>
-            </BreadcrumbItem>
-            <BreadcrumbItem isActive>{t('Alert details')}</BreadcrumbItem>
-          </Breadcrumb>
-        </div>
-        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
-          <h1 className="co-m-pane__heading">
-            <div data-test="resource-title" className="co-resource-item">
-              <MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />
-              {labels?.alertname}
-              <SeverityBadge severity={labels?.severity} />
-            </div>
-            {state !== AlertStates.Silenced && (
-              <div data-test-id="details-actions">
-                <Button
-                  className="co-action-buttons__btn"
-                  onClick={() => history.push(silenceAlertURL(alert))}
-                  variant="primary"
-                >
-                  {t('Silence alert')}
-                </Button>
-              </div>
-            )}
-          </h1>
-          <HeaderAlertMessage alert={alert} rule={rule} />
-        </div>
-        <div className="co-m-pane__body">
-          <Toolbar className="monitoring-alert-detail-toolbar">
-            <ToolbarContent>
-              <ToolbarItem variant="label">
-                <SectionHeading text={t('Alert details')} />
-              </ToolbarItem>
-              <ToolbarGroup alignment={{ default: 'alignRight' }}>
-                <ActionServiceProvider context={{ 'alert-detail-toolbar-actions': { alert } }}>
-                  {({ actions, loaded }) =>
-                    loaded
-                      ? actions.map((action) => {
-                          if (isActionWithHref(action)) {
-                            return (
-                              <ToolbarItem
-                                key={action.id}
-                                spacer={{ default: 'spacerNone' }}
-                                className="pf-u-px-md"
-                              >
-                                <Link to={action.cta.href}>{action.label}</Link>
-                              </ToolbarItem>
-                            );
-                          } else if (isActionWithCallback(action)) {
-                            return (
-                              <ToolbarItem key={action.id} spacer={{ default: 'spacerNone' }}>
-                                <Button variant="link" onClick={action.cta}>
-                                  {action.label}
-                                </Button>
-                              </ToolbarItem>
-                            );
-                          }
-
-                          return null;
-                        })
-                      : null
-                  }
-                </ActionServiceProvider>
-                <ToolbarItem>
-                  <ToggleGraph />
-                </ToolbarItem>
-              </ToolbarGroup>
-            </ToolbarContent>
-          </Toolbar>
-
-          <div className="co-m-pane__body-group">
-            <div className="row">
-              <div className="col-sm-12">
-                {!sourceId || sourceId === 'prometheus' ? (
-                  <Graph
-                    filterLabels={labels}
-                    namespace={namespace}
-                    query={rule?.query}
-                    ruleDuration={rule?.duration}
-                  />
-                ) : AlertsChart && !hideGraphs ? (
-                  <AlertsChart rule={rule} />
-                ) : null}
-              </div>
-            </div>
-            <div className="row">
-              <div className="col-sm-6">
-                <dl className="co-m-pane__details">
-                  <dt>{t('Name')}</dt>
-                  <dd>{labels?.alertname}</dd>
-                  <dt>
-                    <PopoverField bodyContent={<SeverityHelp />} label={t('Severity')} />
-                  </dt>
-                  <dd>
-                    <Severity severity={labels?.severity} />
-                  </dd>
-                  {alert?.annotations?.description && (
-                    <>
-                      <dt>{t('Description')}</dt>
-                      <dd>
-                        <AlertMessage
-                          alertText={alert.annotations.description}
-                          labels={labels}
-                          template={rule?.annotations?.description}
-                        />
-                      </dd>
-                    </>
-                  )}
-                  {alert?.annotations?.summary && (
-                    <>
-                      <dt>{t('Summary')}</dt>
-                      <dd>{alert.annotations.summary}</dd>
-                    </>
-                  )}
-                  {alert?.annotations?.message && (
-                    <>
-                      <dt>{t('Message')}</dt>
-                      <dd>
-                        <AlertMessage
-                          alertText={alert.annotations.message}
-                          labels={labels}
-                          template={rule?.annotations?.message}
-                        />
-                      </dd>
-                    </>
-                  )}
-                  {runbookURL && (
-                    <>
-                      <dt>{t('Runbook')}</dt>
-                      <dd>
-                        <ExternalLink href={runbookURL} text={runbookURL} />
-                      </dd>
-                    </>
-                  )}
-                </dl>
-              </div>
-              <div className="col-sm-6">
-                <dl className="co-m-pane__details">
-                  <dt>
-                    <PopoverField bodyContent={<SourceHelp />} label={t('Source')} />
-                  </dt>
-                  <dd>{alert && getSourceKey(_.startCase(alertSource(alert)), t)}</dd>
-                  <dt>
-                    <PopoverField bodyContent={<AlertStateHelp />} label={t('State')} />
-                  </dt>
-                  <dd>
-                    <AlertState state={state} />
-                    <AlertStateDescription alert={alert} />
-                  </dd>
-                </dl>
-              </div>
-            </div>
-          </div>
-          <div className="co-m-pane__body-group">
-            <div className="row">
-              <div className="col-xs-12">
-                <dl className="co-m-pane__details" data-test="label-list">
-                  <dt>{t('Labels')}</dt>
-                  <dd>
-                    <Labels kind="alert" labels={labels} />
-                  </dd>
-                </dl>
-              </div>
-            </div>
-          </div>
-          <div className="co-m-pane__body-group">
-            <div className="row">
-              <div className="col-xs-12">
-                <dl className="co-m-pane__details">
-                  <dt>{t('Alerting rule')}</dt>
-                  <dd>
-                    <div className="co-resource-item">
-                      <MonitoringResourceIcon resource={RuleResource} />
-                      <Link
-                        to={namespace ? devRuleURL(rule, namespace) : ruleURL(rule)}
-                        data-test="alert-rules-detail-resource-link"
-                        className="co-resource-item__resource-name"
-                      >
-                        {_.get(rule, 'name')}
-                      </Link>
-                    </div>
-                  </dd>
-                </dl>
-              </div>
-            </div>
-          </div>
-        </div>
-        {silencesLoaded && !_.isEmpty(alert?.silencedBy) && (
-          <div className="co-m-pane__body">
-            <div className="co-m-pane__body-group">
-              <SectionHeading text={t('Silenced by')} />
-              <div className="row">
-                <div className="col-xs-12">
-                  <SilencedByList silences={alert?.silencedBy} />
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </StatusBox>
-    </>
-  );
-};
-const AlertsDetailsPage = withFallback(withRouter(AlertsDetailsPage_));
 
 // Renders Prometheus template text and highlights any {{ ... }} tags that it contains
 const PrometheusTemplate = ({ text }) => (
@@ -1159,143 +427,6 @@ const AlertRulesDetailsPage_: React.FC<AlertRulesDetailsPageProps> = ({ match })
   );
 };
 export const AlertRulesDetailsPage = withFallback(AlertRulesDetailsPage_);
-
-type ExpireSilenceModalProps = {
-  isOpen: boolean;
-  setClosed: () => void;
-  silenceID: string;
-};
-
-const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
-  isOpen,
-  setClosed,
-  silenceID,
-}) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-  const { perspective } = usePerspective();
-
-  const dispatch = useDispatch();
-
-  const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
-  const [errorMessage, setErrorMessage] = React.useState();
-
-  const expireSilence = () => {
-    setInProgress();
-    consoleFetchJSON
-      .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v2/silence/${silenceID}`)
-      .then(() => {
-        refreshSilences(dispatch, perspective);
-        setClosed();
-      })
-      .catch((err) => {
-        setErrorMessage(_.get(err, 'json.error') || err.message || 'Error expiring silence');
-        setNotInProgress();
-      })
-      .then(setNotInProgress);
-  };
-
-  return (
-    <Modal
-      isOpen={isOpen}
-      position="top"
-      showClose={false}
-      title={t('Expire silence')}
-      variant={ModalVariant.small}
-    >
-      <Flex direction={{ default: 'column' }}>
-        <FlexItem>{t('Are you sure you want to expire this silence?')}</FlexItem>
-        <Flex direction={{ default: 'column' }}>
-          <FlexItem>
-            {errorMessage && (
-              <PFAlert
-                className="co-alert co-alert--scrollable"
-                isInline
-                title={t('An error occurred')}
-                variant="danger"
-              >
-                <div className="co-pre-line">{errorMessage}</div>
-              </PFAlert>
-            )}
-          </FlexItem>
-          <Flex>
-            <FlexItem>{isInProgress && <LoadingInline />}</FlexItem>
-            <FlexItem align={{ default: 'alignRight' }}>
-              <Button variant="secondary" onClick={setClosed}>
-                {t('Cancel')}
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button variant="primary" onClick={expireSilence}>
-                {t('Expire silence')}
-              </Button>
-            </FlexItem>
-          </Flex>
-        </Flex>
-      </Flex>
-    </Modal>
-  );
-};
-
-type SilenceDropdownProps = RouteComponentProps & {
-  className?: string;
-  isPlain?: boolean;
-  silence: Silence;
-  Toggle: React.FC<{ onToggle: OnToggle }>;
-};
-
-const SilenceDropdown_: React.FC<SilenceDropdownProps> = ({
-  className,
-  history,
-  isPlain,
-  silence,
-  Toggle,
-}) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
-  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
-
-  const editSilence = () => {
-    history.push(`${SilenceResource.plural}/${silence.id}/edit`);
-  };
-
-  const dropdownItems =
-    silenceState(silence) === SilenceStates.Expired
-      ? [
-          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
-            {t('Recreate silence')}
-          </DropdownItem>,
-        ]
-      : [
-          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
-            {t('Edit silence')}
-          </DropdownItem>,
-          <DropdownItem key="cancel-silence" component="button" onClick={setModalOpen}>
-            {t('Expire silence')}
-          </DropdownItem>,
-        ];
-
-  return (
-    <>
-      <Dropdown
-        className={className}
-        data-test="silence-actions"
-        dropdownItems={dropdownItems}
-        isOpen={isOpen}
-        isPlain={isPlain}
-        onSelect={setClosed}
-        position={DropdownPosition.right}
-        toggle={<Toggle onToggle={setIsOpen} />}
-      />
-      <ExpireSilenceModal isOpen={isModalOpen} setClosed={setModalClosed} silenceID={silence.id} />
-    </>
-  );
-};
-const SilenceDropdown = withRouter(SilenceDropdown_);
-
-const SilenceDropdownKebab: React.FC<{ silence: Silence }> = ({ silence }) => (
-  <SilenceDropdown isPlain silence={silence} Toggle={KebabToggle} />
-);
 
 const ActionsToggle: React.FC<{ onToggle: OnToggle }> = ({ onToggle, ...props }) => (
   <DropdownToggle data-test="silence-actions-toggle" onToggle={onToggle} {...props}>
@@ -2060,22 +1191,5 @@ const MonitoringUI = () => (
     <Route component={PollerPages} />
   </Switch>
 );
-
-type AlertMessageProps = {
-  alertText: string;
-  labels: PrometheusLabels;
-  template: string;
-};
-
-type GraphProps = {
-  filterLabels?: PrometheusLabels;
-  formatSeriesTitle?: FormatSeriesTitle;
-  namespace?: string;
-  query: string;
-  ruleDuration: number;
-  showLegend?: boolean;
-};
-
-type OnToggle = (value: boolean, e: MouseEvent) => void;
 
 export default MonitoringUI;

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -100,26 +100,28 @@ import {
   getSourceKey,
   Graph,
   MonitoringResourceIcon,
-  OnToggle,
   PopoverField,
   queryBrowserURL,
   ruleURL,
-  SelectedSilencesContext,
   Severity,
   SeverityBadge,
   SeverityCounts,
   SeverityHelp,
   silenceAlertURL,
-  SilenceDropdown,
-  SilenceMatchersList,
   SilencesNotLoadedWarning,
-  SilenceState,
-  SilenceTableRow,
   SourceHelp,
-  tableSilenceClasses,
 } from './alerting/AlertUtils';
 import AlertsPage from './alerting/AlertsPage';
 import AlertsDetailsPage from './alerting/AlertsDetailPage';
+import {
+  SelectedSilencesContext,
+  SilenceDropdown,
+  SilenceMatchersList,
+  SilenceState,
+  SilenceTableRow,
+  tableSilenceClasses,
+} from './alerting/SilencesUtils';
+import { OnToggle } from './alerting/AlertUtils';
 
 const pollers = {};
 const pollerTimeouts = {};

--- a/src/components/alerting/AlertUtils.tsx
+++ b/src/components/alerting/AlertUtils.tsx
@@ -5,19 +5,59 @@ import {
   AlertSeverity,
   AlertStates,
   BlueInfoCircleIcon,
+  consoleFetchJSON,
+  GreenCheckCircleIcon,
   PrometheusAlert,
+  PrometheusLabels,
   RedExclamationCircleIcon,
+  ResourceStatus,
   Rule,
+  Silence,
+  SilenceStates,
   Timestamp,
   YellowExclamationTriangleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { AlertSource, MonitoringResource } from '../types';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import { Alert as PFAlert } from '@patternfly/react-core';
-import { labelsToParams, RuleResource, SilenceResource } from '../utils';
+import {
+  Alert as PFAlert,
+  Popover,
+  Button,
+  Checkbox,
+  Label,
+  DropdownItem,
+  Dropdown,
+  DropdownPosition,
+  KebabToggle,
+  ModalVariant,
+  Modal,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import {
+  labelsToParams,
+  refreshSilences,
+  RuleResource,
+  silenceMatcherEqualitySymbol,
+  SilenceResource,
+  silenceState,
+} from '../utils';
 import classNames from 'classnames';
-import { BellIcon, BellSlashIcon, OutlinedBellIcon } from '@patternfly/react-icons';
+import {
+  BellIcon,
+  BellSlashIcon,
+  OutlinedBellIcon,
+  BanIcon,
+  HourglassHalfIcon,
+} from '@patternfly/react-icons';
+import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { TFunction } from 'i18next';
+import { useBoolean } from '../hooks/useBoolean';
+import { usePerspective } from '../hooks/usePerspective';
+import { useDispatch } from 'react-redux';
+import { LoadingInline } from '../console/utils/status-box';
 
 export const getAdditionalSources = <T extends Alert | Rule>(
   data: Array<T>,
@@ -202,3 +242,435 @@ const StateTimestamp = ({ text, timestamp }) => (
     <Timestamp timestamp={timestamp} />
   </div>
 );
+
+export const SeverityBadge: React.FC<{ severity: string }> = React.memo(({ severity }) =>
+  _.isNil(severity) || severity === 'none' ? null : (
+    <ResourceStatus>
+      <Severity severity={severity} />
+    </ResourceStatus>
+  ),
+);
+
+export const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: string }> = ({
+  bodyContent,
+  label,
+}) => (
+  <Popover headerContent={label} bodyContent={bodyContent}>
+    <Button variant="plain" className="details-item__popover-button">
+      {label}
+    </Button>
+  </Popover>
+);
+
+export const Graph: React.FC<GraphProps> = ({
+  filterLabels = undefined,
+  formatSeriesTitle,
+  namespace,
+  query,
+  ruleDuration,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  // 3 times the rule's duration, but not less than 30 minutes
+  const timespan = Math.max(3 * ruleDuration, 30 * 60) * 1000;
+
+  const GraphLink = () =>
+    query ? (
+      <Link aria-label={t('View in Metrics')} to={queryBrowserURL(query, namespace)}>
+        {t('View in Metrics')}
+      </Link>
+    ) : null;
+
+  return (
+    <QueryBrowser
+      namespace={namespace}
+      defaultTimespan={timespan}
+      filterLabels={filterLabels}
+      formatSeriesTitle={formatSeriesTitle}
+      GraphLink={GraphLink}
+      pollInterval={Math.round(timespan / 120)}
+      queries={[query]}
+    />
+  );
+};
+
+type GraphProps = {
+  filterLabels?: PrometheusLabels;
+  formatSeriesTitle?: FormatSeriesTitle;
+  namespace?: string;
+  query: string;
+  ruleDuration: number;
+  showLegend?: boolean;
+};
+
+export const queryBrowserURL = (query: string, namespace: string) =>
+  namespace
+    ? `/dev-monitoring/ns/${namespace}/metrics?query0=${encodeURIComponent(query)}`
+    : `/monitoring/query-browser?query0=${encodeURIComponent(query)}`;
+
+export const SeverityHelp: React.FC = () => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  return (
+    <dl className="co-inline">
+      <dt>
+        <SeverityIcon severity={AlertSeverity.Critical} /> <strong>{t('Critical: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'The condition that triggered the alert could have a critical impact. The alert requires immediate attention when fired and is typically paged to an individual or to a critical response team.',
+        )}
+      </dd>
+      <dt>
+        <SeverityIcon severity={AlertSeverity.Warning} /> <strong>{t('Warning: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'The alert provides a warning notification about something that might require attention in order to prevent a problem from occurring. Warnings are typically routed to a ticketing system for non-immediate review.',
+        )}
+      </dd>
+      <dt>
+        <SeverityIcon severity={AlertSeverity.Info} /> <strong>{t('Info: ')}</strong>
+      </dt>
+      <dd>{t('The alert is provided for informational purposes only.')}</dd>
+      <dt>
+        <SeverityIcon severity={AlertSeverity.None} /> <strong>{t('None: ')}</strong>
+      </dt>
+      <dd>{t('The alert has no defined severity.')}</dd>
+      <dd>{t('You can also create custom severity definitions for user workload alerts.')}</dd>
+    </dl>
+  );
+};
+
+export const SourceHelp: React.FC = () => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  return (
+    <dl className="co-inline">
+      <dt>
+        <strong>{t('Platform: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'Platform-level alerts relate only to OpenShift namespaces. OpenShift namespaces provide core OpenShift functionality.',
+        )}
+      </dd>
+      <dt>
+        <strong>{t('User: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'User workload alerts relate to user-defined namespaces. These alerts are user-created and are customizable. User workload monitoring can be enabled post-installation to provide observability into your own services.',
+        )}
+      </dd>
+    </dl>
+  );
+};
+
+export const getSourceKey = (source, t: TFunction) => {
+  switch (source) {
+    case 'Platform':
+      return t('Platform');
+    case 'User':
+      return t('User');
+    default:
+      return source;
+  }
+};
+
+export const tableSilenceClasses = [
+  'pf-c-table__action', // Checkbox
+  'pf-u-w-50 pf-u-w-33-on-sm', // Name
+  'pf-m-hidden pf-m-visible-on-sm', // Firing alerts
+  '', // State
+  'pf-m-hidden pf-m-visible-on-sm', // Creator
+  'dropdown-kebab-pf pf-c-table__action',
+];
+
+export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const { createdBy, endsAt, firingAlerts, id, name, startsAt } = obj;
+  const state = silenceState(obj);
+
+  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
+
+  const onCheckboxChange = React.useCallback(
+    (isChecked: boolean) => {
+      setSelectedSilences((oldSet) => {
+        const newSet = new Set(oldSet);
+        if (isChecked) {
+          newSet.add(id);
+        } else {
+          newSet.delete(id);
+        }
+        return newSet;
+      });
+    },
+    [id, setSelectedSilences],
+  );
+
+  return (
+    <>
+      {showCheckbox && (
+        <td className={tableSilenceClasses[0]}>
+          <Checkbox
+            id={id}
+            isChecked={selectedSilences.has(id)}
+            isDisabled={state === SilenceStates.Expired}
+            onChange={onCheckboxChange}
+          />
+        </td>
+      )}
+      <td className={tableSilenceClasses[1]}>
+        <div className="co-resource-item">
+          <MonitoringResourceIcon resource={SilenceResource} />
+          <Link
+            className="co-resource-item__resource-name"
+            data-test-id="silence-resource-link"
+            title={id}
+            to={`${SilenceResource.plural}/${id}`}
+          >
+            {name}
+          </Link>
+        </div>
+        <div className="monitoring-label-list">
+          <SilenceMatchersList silence={obj} />
+        </div>
+      </td>
+      <td className={tableSilenceClasses[2]}>
+        <SeverityCounts alerts={firingAlerts} />
+      </td>
+      <td className={classNames(tableSilenceClasses[3], 'co-break-word')}>
+        <SilenceState silence={obj} />
+        {state === SilenceStates.Pending && (
+          <StateTimestamp text={t('Starts')} timestamp={startsAt} />
+        )}
+        {state === SilenceStates.Active && <StateTimestamp text={t('Ends')} timestamp={endsAt} />}
+        {state === SilenceStates.Expired && (
+          <StateTimestamp text={t('Expired')} timestamp={endsAt} />
+        )}
+      </td>
+      <td className={tableSilenceClasses[4]}>{createdBy || '-'}</td>
+      <td className={tableSilenceClasses[5]}>
+        <SilenceDropdownKebab silence={obj} />
+      </td>
+    </>
+  );
+};
+
+type SilenceTableRowProps = {
+  obj: Silence;
+  showCheckbox?: boolean;
+};
+
+export const SelectedSilencesContext = React.createContext({
+  selectedSilences: new Set(),
+  setSelectedSilences: undefined,
+});
+
+export const SilenceMatchersList = ({ silence }) => (
+  <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
+    {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
+      <Label className="co-label" key={i}>
+        <span className="co-label__key">{name}</span>
+        <span className="co-label__eq">{silenceMatcherEqualitySymbol(isEqual, isRegex)}</span>
+        <span className="co-label__value">{value}</span>
+      </Label>
+    ))}
+  </div>
+);
+
+export const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
+  if (_.isEmpty(alerts)) {
+    return <>-</>;
+  }
+
+  const counts = _.countBy(alerts, (a) => {
+    const { severity } = a.labels;
+    return severity === AlertSeverity.Critical || severity === AlertSeverity.Warning
+      ? severity
+      : AlertSeverity.Info;
+  });
+
+  const severities = [AlertSeverity.Critical, AlertSeverity.Warning, AlertSeverity.Info].filter(
+    (s) => counts[s] > 0,
+  );
+
+  return (
+    <>
+      {severities.map((s) => (
+        <span className="monitoring-icon-wrap" key={s}>
+          <SeverityIcon severity={s} /> {counts[s]}
+        </span>
+      ))}
+    </>
+  );
+};
+
+export const SilenceState = ({ silence }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const state = silenceState(silence);
+  const icon = {
+    [SilenceStates.Active]: <GreenCheckCircleIcon />,
+    [SilenceStates.Pending]: <HourglassHalfIcon className="monitoring-state-icon--pending" />,
+    [SilenceStates.Expired]: <BanIcon className="text-muted" data-test-id="ban-icon" />,
+  }[state];
+
+  const getStateKey = (stateData) => {
+    switch (stateData) {
+      case SilenceStates.Active:
+        return t('Active');
+      case SilenceStates.Pending:
+        return t('Pending');
+      default:
+        return t('Expired');
+    }
+  };
+
+  return icon ? (
+    <>
+      {icon} {getStateKey(state)}
+    </>
+  ) : null;
+};
+
+const SilenceDropdownKebab: React.FC<{ silence: Silence }> = ({ silence }) => (
+  <SilenceDropdown isPlain silence={silence} Toggle={KebabToggle} />
+);
+
+const SilenceDropdown_: React.FC<SilenceDropdownProps> = ({
+  className,
+  history,
+  isPlain,
+  silence,
+  Toggle,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
+  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
+
+  const editSilence = () => {
+    history.push(`${SilenceResource.plural}/${silence.id}/edit`);
+  };
+
+  const dropdownItems =
+    silenceState(silence) === SilenceStates.Expired
+      ? [
+          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
+            {t('Recreate silence')}
+          </DropdownItem>,
+        ]
+      : [
+          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
+            {t('Edit silence')}
+          </DropdownItem>,
+          <DropdownItem key="cancel-silence" component="button" onClick={setModalOpen}>
+            {t('Expire silence')}
+          </DropdownItem>,
+        ];
+
+  return (
+    <>
+      <Dropdown
+        className={className}
+        data-test="silence-actions"
+        dropdownItems={dropdownItems}
+        isOpen={isOpen}
+        isPlain={isPlain}
+        onSelect={setClosed}
+        position={DropdownPosition.right}
+        toggle={<Toggle onToggle={setIsOpen} />}
+      />
+      <ExpireSilenceModal isOpen={isModalOpen} setClosed={setModalClosed} silenceID={silence.id} />
+    </>
+  );
+};
+export const SilenceDropdown = withRouter(SilenceDropdown_);
+
+const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
+  isOpen,
+  setClosed,
+  silenceID,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { perspective } = usePerspective();
+
+  const dispatch = useDispatch();
+
+  const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
+  const [errorMessage, setErrorMessage] = React.useState();
+
+  const expireSilence = () => {
+    setInProgress();
+    consoleFetchJSON
+      .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v2/silence/${silenceID}`)
+      .then(() => {
+        refreshSilences(dispatch, perspective);
+        setClosed();
+      })
+      .catch((err) => {
+        setErrorMessage(_.get(err, 'json.error') || err.message || 'Error expiring silence');
+        setNotInProgress();
+      })
+      .then(setNotInProgress);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      position="top"
+      showClose={false}
+      title={t('Expire silence')}
+      variant={ModalVariant.small}
+    >
+      <Flex direction={{ default: 'column' }}>
+        <FlexItem>{t('Are you sure you want to expire this silence?')}</FlexItem>
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem>
+            {errorMessage && (
+              <PFAlert
+                className="co-alert co-alert--scrollable"
+                isInline
+                title={t('An error occurred')}
+                variant="danger"
+              >
+                <div className="co-pre-line">{errorMessage}</div>
+              </PFAlert>
+            )}
+          </FlexItem>
+          <Flex>
+            <FlexItem>{isInProgress && <LoadingInline />}</FlexItem>
+            <FlexItem align={{ default: 'alignRight' }}>
+              <Button variant="secondary" onClick={setClosed}>
+                {t('Cancel')}
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="primary" onClick={expireSilence}>
+                {t('Expire silence')}
+              </Button>
+            </FlexItem>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Modal>
+  );
+};
+
+type SilenceDropdownProps = RouteComponentProps & {
+  className?: string;
+  isPlain?: boolean;
+  silence: Silence;
+  Toggle: React.FC<{ onToggle: OnToggle }>;
+};
+
+export type OnToggle = (value: boolean, e: MouseEvent) => void;
+
+type ExpireSilenceModalProps = {
+  isOpen: boolean;
+  setClosed: () => void;
+  silenceID: string;
+};

--- a/src/components/alerting/AlertUtils.tsx
+++ b/src/components/alerting/AlertUtils.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import {
+  Action,
+  Alert,
+  AlertSeverity,
+  AlertStates,
+  BlueInfoCircleIcon,
+  PrometheusAlert,
+  RedExclamationCircleIcon,
+  Rule,
+  Timestamp,
+  YellowExclamationTriangleIcon,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AlertSource, MonitoringResource } from '../types';
+import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+import { Alert as PFAlert } from '@patternfly/react-core';
+import { labelsToParams, RuleResource, SilenceResource } from '../utils';
+import classNames from 'classnames';
+import { BellIcon, BellSlashIcon, OutlinedBellIcon } from '@patternfly/react-icons';
+
+export const getAdditionalSources = <T extends Alert | Rule>(
+  data: Array<T>,
+  itemSource: (item: T) => string,
+) => {
+  if (data) {
+    const additionalSources = new Set<string>();
+    data.forEach((item) => {
+      const source = itemSource(item);
+      if (source !== AlertSource.Platform && source !== AlertSource.User) {
+        additionalSources.add(source);
+      }
+    });
+    return Array.from(additionalSources).map((item) => ({ id: item, title: _.startCase(item) }));
+  }
+  return [];
+};
+
+export const alertingRuleSource = (rule: Rule): AlertSource | string => {
+  if (rule.sourceId === undefined || rule.sourceId === 'prometheus') {
+    return rule.labels?.prometheus === 'openshift-monitoring/k8s'
+      ? AlertSource.Platform
+      : AlertSource.User;
+  }
+
+  return rule.sourceId;
+};
+
+export const alertSource = (alert: Alert): AlertSource | string => alertingRuleSource(alert.rule);
+
+export const SilencesNotLoadedWarning: React.FC<{ silencesLoadError: any }> = ({
+  silencesLoadError,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  return (
+    <PFAlert
+      className="co-alert"
+      isInline
+      title={t(
+        'Error loading silences from Alertmanager. Some of the alerts below may actually be silenced.',
+      )}
+      variant="warning"
+    >
+      {silencesLoadError.json?.error || silencesLoadError.message}
+    </PFAlert>
+  );
+};
+
+type ActionWithHref = Omit<Action, 'cta'> & { cta: { href: string; external?: boolean } };
+export const isActionWithHref = (action: Action): action is ActionWithHref => 'href' in action.cta;
+
+export const ruleURL = (rule: Rule) => `${RuleResource.plural}/${_.get(rule, 'id')}`;
+
+export const silenceAlertURL = (alert: PrometheusAlert) =>
+  `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
+
+type ActionWithCallBack = Omit<Action, 'cta'> & { cta: () => void };
+export const isActionWithCallback = (action: Action): action is ActionWithCallBack =>
+  typeof action.cta === 'function';
+
+export const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({
+  className,
+  resource,
+}) => (
+  <span
+    className={classNames(
+      `co-m-resource-icon co-m-resource-${resource.kind.toLowerCase()}`,
+      className,
+    )}
+    title={resource.label}
+  >
+    {resource.abbr}
+  </span>
+);
+
+type MonitoringResourceIconProps = {
+  className?: string;
+  resource: MonitoringResource;
+};
+
+export const Severity: React.FC<{ severity: string }> = React.memo(({ severity }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const getSeverityKey = (severityData: string) => {
+    switch (severityData) {
+      case AlertSeverity.Critical:
+        return t('Critical');
+      case AlertSeverity.Info:
+        return t('Info');
+      case AlertSeverity.Warning:
+        return t('Warning');
+      case AlertSeverity.None:
+        return t('None');
+      default:
+        return severityData;
+    }
+  };
+
+  return _.isNil(severity) ? (
+    <>-</>
+  ) : (
+    <>
+      <SeverityIcon severity={severity} /> {getSeverityKey(severity)}
+    </>
+  );
+});
+
+export const SeverityIcon: React.FC<{ severity: string }> = React.memo(({ severity }) => {
+  const Icon =
+    {
+      [AlertSeverity.Critical]: RedExclamationCircleIcon,
+      [AlertSeverity.Info]: BlueInfoCircleIcon,
+      [AlertSeverity.None]: BlueInfoCircleIcon,
+      [AlertSeverity.Warning]: YellowExclamationTriangleIcon,
+    }[severity] || YellowExclamationTriangleIcon;
+  return <Icon />;
+});
+
+export const AlertState: React.FC<AlertStateProps> = React.memo(({ state }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const icon = <AlertStateIcon state={state} />;
+
+  return icon ? (
+    <>
+      {icon} {getAlertStateKey(state, t)}
+    </>
+  ) : null;
+});
+
+type AlertStateProps = {
+  state: AlertStates;
+};
+
+export const AlertStateIcon: React.FC<{ state: string }> = React.memo(({ state }) => {
+  switch (state) {
+    case AlertStates.Firing:
+      return <BellIcon />;
+    case AlertStates.Pending:
+      return <OutlinedBellIcon />;
+    case AlertStates.Silenced:
+      return <BellSlashIcon className="text-muted" />;
+    default:
+      return null;
+  }
+});
+
+export const getAlertStateKey = (state, t) => {
+  switch (state) {
+    case AlertStates.Firing:
+      return t('Firing');
+    case AlertStates.Pending:
+      return t('Pending');
+    case AlertStates.Silenced:
+      return t('Silenced');
+    default:
+      return t('Not Firing');
+  }
+};
+
+export const AlertStateDescription: React.FC<{ alert: Alert }> = ({ alert }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  if (alert && !_.isEmpty(alert.silencedBy)) {
+    return <StateTimestamp text={t('Ends')} timestamp={_.max(_.map(alert.silencedBy, 'endsAt'))} />;
+  }
+  if (alert && alert.activeAt) {
+    return <StateTimestamp text={t('Since')} timestamp={alert.activeAt} />;
+  }
+  return null;
+};
+
+const StateTimestamp = ({ text, timestamp }) => (
+  <div className="text-muted monitoring-timestamp">
+    {text}&nbsp;
+    <Timestamp timestamp={timestamp} />
+  </div>
+);

--- a/src/components/alerting/AlertUtils.tsx
+++ b/src/components/alerting/AlertUtils.tsx
@@ -71,9 +71,14 @@ type ActionWithHref = Omit<Action, 'cta'> & { cta: { href: string; external?: bo
 export const isActionWithHref = (action: Action): action is ActionWithHref => 'href' in action.cta;
 
 export const ruleURL = (rule: Rule) => `${RuleResource.plural}/${_.get(rule, 'id')}`;
+export const devRuleURL = (rule: Rule, namespace: string) =>
+  `/dev-monitoring/ns/${namespace}/rules/${rule?.id}`;
 
 export const silenceAlertURL = (alert: PrometheusAlert) =>
   `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
+
+export const devSilenceAlertURL = (alert: PrometheusAlert, namespace: string) =>
+  `/dev-monitoring/ns/${namespace}/silences/~new?${labelsToParams(alert.labels)}`;
 
 type ActionWithCallBack = Omit<Action, 'cta'> & { cta: () => void };
 export const isActionWithCallback = (action: Action): action is ActionWithCallBack =>

--- a/src/components/alerting/AlertUtils.tsx
+++ b/src/components/alerting/AlertUtils.tsx
@@ -5,59 +5,24 @@ import {
   AlertSeverity,
   AlertStates,
   BlueInfoCircleIcon,
-  consoleFetchJSON,
-  GreenCheckCircleIcon,
   PrometheusAlert,
   PrometheusLabels,
   RedExclamationCircleIcon,
   ResourceStatus,
   Rule,
-  Silence,
-  SilenceStates,
   Timestamp,
   YellowExclamationTriangleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { AlertSource, MonitoringResource } from '../types';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import {
-  Alert as PFAlert,
-  Popover,
-  Button,
-  Checkbox,
-  Label,
-  DropdownItem,
-  Dropdown,
-  DropdownPosition,
-  KebabToggle,
-  ModalVariant,
-  Modal,
-  Flex,
-  FlexItem,
-} from '@patternfly/react-core';
-import {
-  labelsToParams,
-  refreshSilences,
-  RuleResource,
-  silenceMatcherEqualitySymbol,
-  SilenceResource,
-  silenceState,
-} from '../utils';
+import { Alert as PFAlert, Popover, Button } from '@patternfly/react-core';
+import { labelsToParams, RuleResource, SilenceResource } from '../utils';
 import classNames from 'classnames';
-import {
-  BellIcon,
-  BellSlashIcon,
-  OutlinedBellIcon,
-  BanIcon,
-  HourglassHalfIcon,
-} from '@patternfly/react-icons';
+import { BellIcon, BellSlashIcon, OutlinedBellIcon } from '@patternfly/react-icons';
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { TFunction } from 'i18next';
-import { useBoolean } from '../hooks/useBoolean';
-import { usePerspective } from '../hooks/usePerspective';
-import { useDispatch } from 'react-redux';
-import { LoadingInline } from '../console/utils/status-box';
 
 export const getAdditionalSources = <T extends Alert | Rule>(
   data: Array<T>,
@@ -236,7 +201,7 @@ export const AlertStateDescription: React.FC<{ alert: Alert }> = ({ alert }) => 
   return null;
 };
 
-const StateTimestamp = ({ text, timestamp }) => (
+export const StateTimestamp = ({ text, timestamp }) => (
   <div className="text-muted monitoring-timestamp">
     {text}&nbsp;
     <Timestamp timestamp={timestamp} />
@@ -378,109 +343,6 @@ export const getSourceKey = (source, t: TFunction) => {
   }
 };
 
-export const tableSilenceClasses = [
-  'pf-c-table__action', // Checkbox
-  'pf-u-w-50 pf-u-w-33-on-sm', // Name
-  'pf-m-hidden pf-m-visible-on-sm', // Firing alerts
-  '', // State
-  'pf-m-hidden pf-m-visible-on-sm', // Creator
-  'dropdown-kebab-pf pf-c-table__action',
-];
-
-export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const { createdBy, endsAt, firingAlerts, id, name, startsAt } = obj;
-  const state = silenceState(obj);
-
-  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
-
-  const onCheckboxChange = React.useCallback(
-    (isChecked: boolean) => {
-      setSelectedSilences((oldSet) => {
-        const newSet = new Set(oldSet);
-        if (isChecked) {
-          newSet.add(id);
-        } else {
-          newSet.delete(id);
-        }
-        return newSet;
-      });
-    },
-    [id, setSelectedSilences],
-  );
-
-  return (
-    <>
-      {showCheckbox && (
-        <td className={tableSilenceClasses[0]}>
-          <Checkbox
-            id={id}
-            isChecked={selectedSilences.has(id)}
-            isDisabled={state === SilenceStates.Expired}
-            onChange={onCheckboxChange}
-          />
-        </td>
-      )}
-      <td className={tableSilenceClasses[1]}>
-        <div className="co-resource-item">
-          <MonitoringResourceIcon resource={SilenceResource} />
-          <Link
-            className="co-resource-item__resource-name"
-            data-test-id="silence-resource-link"
-            title={id}
-            to={`${SilenceResource.plural}/${id}`}
-          >
-            {name}
-          </Link>
-        </div>
-        <div className="monitoring-label-list">
-          <SilenceMatchersList silence={obj} />
-        </div>
-      </td>
-      <td className={tableSilenceClasses[2]}>
-        <SeverityCounts alerts={firingAlerts} />
-      </td>
-      <td className={classNames(tableSilenceClasses[3], 'co-break-word')}>
-        <SilenceState silence={obj} />
-        {state === SilenceStates.Pending && (
-          <StateTimestamp text={t('Starts')} timestamp={startsAt} />
-        )}
-        {state === SilenceStates.Active && <StateTimestamp text={t('Ends')} timestamp={endsAt} />}
-        {state === SilenceStates.Expired && (
-          <StateTimestamp text={t('Expired')} timestamp={endsAt} />
-        )}
-      </td>
-      <td className={tableSilenceClasses[4]}>{createdBy || '-'}</td>
-      <td className={tableSilenceClasses[5]}>
-        <SilenceDropdownKebab silence={obj} />
-      </td>
-    </>
-  );
-};
-
-type SilenceTableRowProps = {
-  obj: Silence;
-  showCheckbox?: boolean;
-};
-
-export const SelectedSilencesContext = React.createContext({
-  selectedSilences: new Set(),
-  setSelectedSilences: undefined,
-});
-
-export const SilenceMatchersList = ({ silence }) => (
-  <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
-    {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
-      <Label className="co-label" key={i}>
-        <span className="co-label__key">{name}</span>
-        <span className="co-label__eq">{silenceMatcherEqualitySymbol(isEqual, isRegex)}</span>
-        <span className="co-label__value">{value}</span>
-      </Label>
-    ))}
-  </div>
-);
-
 export const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
   if (_.isEmpty(alerts)) {
     return <>-</>;
@@ -507,170 +369,4 @@ export const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
     </>
   );
 };
-
-export const SilenceState = ({ silence }) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const state = silenceState(silence);
-  const icon = {
-    [SilenceStates.Active]: <GreenCheckCircleIcon />,
-    [SilenceStates.Pending]: <HourglassHalfIcon className="monitoring-state-icon--pending" />,
-    [SilenceStates.Expired]: <BanIcon className="text-muted" data-test-id="ban-icon" />,
-  }[state];
-
-  const getStateKey = (stateData) => {
-    switch (stateData) {
-      case SilenceStates.Active:
-        return t('Active');
-      case SilenceStates.Pending:
-        return t('Pending');
-      default:
-        return t('Expired');
-    }
-  };
-
-  return icon ? (
-    <>
-      {icon} {getStateKey(state)}
-    </>
-  ) : null;
-};
-
-const SilenceDropdownKebab: React.FC<{ silence: Silence }> = ({ silence }) => (
-  <SilenceDropdown isPlain silence={silence} Toggle={KebabToggle} />
-);
-
-const SilenceDropdown_: React.FC<SilenceDropdownProps> = ({
-  className,
-  history,
-  isPlain,
-  silence,
-  Toggle,
-}) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-
-  const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
-  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
-
-  const editSilence = () => {
-    history.push(`${SilenceResource.plural}/${silence.id}/edit`);
-  };
-
-  const dropdownItems =
-    silenceState(silence) === SilenceStates.Expired
-      ? [
-          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
-            {t('Recreate silence')}
-          </DropdownItem>,
-        ]
-      : [
-          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
-            {t('Edit silence')}
-          </DropdownItem>,
-          <DropdownItem key="cancel-silence" component="button" onClick={setModalOpen}>
-            {t('Expire silence')}
-          </DropdownItem>,
-        ];
-
-  return (
-    <>
-      <Dropdown
-        className={className}
-        data-test="silence-actions"
-        dropdownItems={dropdownItems}
-        isOpen={isOpen}
-        isPlain={isPlain}
-        onSelect={setClosed}
-        position={DropdownPosition.right}
-        toggle={<Toggle onToggle={setIsOpen} />}
-      />
-      <ExpireSilenceModal isOpen={isModalOpen} setClosed={setModalClosed} silenceID={silence.id} />
-    </>
-  );
-};
-export const SilenceDropdown = withRouter(SilenceDropdown_);
-
-const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
-  isOpen,
-  setClosed,
-  silenceID,
-}) => {
-  const { t } = useTranslation('plugin__monitoring-plugin');
-  const { perspective } = usePerspective();
-
-  const dispatch = useDispatch();
-
-  const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
-  const [errorMessage, setErrorMessage] = React.useState();
-
-  const expireSilence = () => {
-    setInProgress();
-    consoleFetchJSON
-      .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v2/silence/${silenceID}`)
-      .then(() => {
-        refreshSilences(dispatch, perspective);
-        setClosed();
-      })
-      .catch((err) => {
-        setErrorMessage(_.get(err, 'json.error') || err.message || 'Error expiring silence');
-        setNotInProgress();
-      })
-      .then(setNotInProgress);
-  };
-
-  return (
-    <Modal
-      isOpen={isOpen}
-      position="top"
-      showClose={false}
-      title={t('Expire silence')}
-      variant={ModalVariant.small}
-    >
-      <Flex direction={{ default: 'column' }}>
-        <FlexItem>{t('Are you sure you want to expire this silence?')}</FlexItem>
-        <Flex direction={{ default: 'column' }}>
-          <FlexItem>
-            {errorMessage && (
-              <PFAlert
-                className="co-alert co-alert--scrollable"
-                isInline
-                title={t('An error occurred')}
-                variant="danger"
-              >
-                <div className="co-pre-line">{errorMessage}</div>
-              </PFAlert>
-            )}
-          </FlexItem>
-          <Flex>
-            <FlexItem>{isInProgress && <LoadingInline />}</FlexItem>
-            <FlexItem align={{ default: 'alignRight' }}>
-              <Button variant="secondary" onClick={setClosed}>
-                {t('Cancel')}
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button variant="primary" onClick={expireSilence}>
-                {t('Expire silence')}
-              </Button>
-            </FlexItem>
-          </Flex>
-        </Flex>
-      </Flex>
-    </Modal>
-  );
-};
-
-type SilenceDropdownProps = RouteComponentProps & {
-  className?: string;
-  isPlain?: boolean;
-  silence: Silence;
-  Toggle: React.FC<{ onToggle: OnToggle }>;
-};
-
 export type OnToggle = (value: boolean, e: MouseEvent) => void;
-
-type ExpireSilenceModalProps = {
-  isOpen: boolean;
-  setClosed: () => void;
-  silenceID: string;
-};

--- a/src/components/alerting/AlertsDetailPage.tsx
+++ b/src/components/alerting/AlertsDetailPage.tsx
@@ -1,0 +1,500 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePerspective } from '../hooks/usePerspective';
+import { Alerts, RootState } from '../types';
+import { useSelector } from 'react-redux';
+import * as _ from 'lodash-es';
+import { getAllQueryArguments } from '../console/utils/router';
+import { AlertResource, alertState, RuleResource } from '../utils';
+import {
+  Alert,
+  AlertStates,
+  ActionServiceProvider,
+  PrometheusLabels,
+  Rule,
+  useResolvedExtensions,
+  ResourceLink,
+  Silence,
+  TableColumn,
+  VirtualizedTable,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AlertingRuleChartExtension, isAlertingRuleChart } from '../console/extensions/alerts';
+import { StatusBox } from '../console/utils/status-box';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { ExternalLink, LinkifyExternal } from '../console/utils/link';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {
+  alertSource,
+  AlertState,
+  AlertStateDescription,
+  AlertStateIcon,
+  devRuleURL,
+  getSourceKey,
+  Graph,
+  isActionWithCallback,
+  isActionWithHref,
+  MonitoringResourceIcon,
+  PopoverField,
+  ruleURL,
+  Severity,
+  SeverityBadge,
+  SeverityHelp,
+  silenceAlertURL,
+  SilenceTableRow,
+  SourceHelp,
+  tableSilenceClasses,
+} from './AlertUtils';
+import { withFallback } from '../console/console-shared/error/error-boundary';
+import { SectionHeading } from '../console/utils/headings';
+import { ToggleGraph } from '../metrics';
+import {
+  ContainerModel,
+  DaemonSetModel,
+  DeploymentModel,
+  JobModel,
+  NamespaceModel,
+  NodeModel,
+  PodModel,
+  StatefulSetModel,
+} from '../console/models';
+import { Labels } from '../labels';
+
+const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const { alertsKey } = usePerspective();
+  const namespace = match.params?.ns;
+  const hideGraphs = useSelector(({ observe }: RootState) => !!observe.get('hideGraphs'));
+
+  const alerts: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey));
+
+  const silencesLoaded = ({ observe }) => observe.get('silences')?.loaded;
+
+  const ruleAlerts = _.filter(alerts?.data, (a) => a.rule.id === match?.params?.ruleID);
+  const rule = ruleAlerts?.[0]?.rule;
+
+  // Search for an alert that matches all of the labels in the URL parameters. We expect there to be
+  // only one such alert that matches, so don't display any alert if multiple matches were found.
+  const queryParams = getAllQueryArguments();
+  const foundAlerts = _.filter(ruleAlerts, (a) => _.isMatch(a.labels, queryParams));
+  const alert = foundAlerts.length === 1 ? foundAlerts[0] : undefined;
+
+  const state = alertState(alert);
+
+  const labelsMemoKey = JSON.stringify(alert?.labels);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
+
+  // eslint-disable-next-line camelcase
+  const runbookURL = alert?.annotations?.runbook_url;
+
+  const sourceId = rule?.sourceId;
+
+  // Load alert metrics chart from plugin
+  const [alertsChartExtensions] =
+    useResolvedExtensions<AlertingRuleChartExtension>(isAlertingRuleChart);
+  const alertsChart = alertsChartExtensions
+    .filter((extension) => extension.properties.sourceId === sourceId)
+    .map((extension) => extension.properties.chart);
+
+  const AlertsChart = alertsChart?.[0];
+
+  return (
+    <>
+      <StatusBox
+        data={alert}
+        label={AlertResource.label}
+        loaded={alerts?.loaded}
+        loadError={alerts?.loadError}
+      >
+        <div className="pf-c-page__main-breadcrumb">
+          <Breadcrumb className="monitoring-breadcrumbs">
+            <BreadcrumbItem>
+              <Link
+                className="pf-c-breadcrumb__link"
+                to={namespace ? `/dev-monitoring/ns/${namespace}/alerts` : '/monitoring/alerts'}
+              >
+                {t('Alerts')}
+              </Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem isActive>{t('Alert details')}</BreadcrumbItem>
+          </Breadcrumb>
+        </div>
+        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+          <h1 className="co-m-pane__heading">
+            <div data-test="resource-title" className="co-resource-item">
+              <MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />
+              {labels?.alertname}
+              <SeverityBadge severity={labels?.severity} />
+            </div>
+            {state !== AlertStates.Silenced && (
+              <div data-test-id="details-actions">
+                <Button
+                  className="co-action-buttons__btn"
+                  onClick={() => history.push(silenceAlertURL(alert))}
+                  variant="primary"
+                >
+                  {t('Silence alert')}
+                </Button>
+              </div>
+            )}
+          </h1>
+          <HeaderAlertMessage alert={alert} rule={rule} />
+        </div>
+        <div className="co-m-pane__body">
+          <Toolbar className="monitoring-alert-detail-toolbar">
+            <ToolbarContent>
+              <ToolbarItem variant="label">
+                <SectionHeading text={t('Alert details')} />
+              </ToolbarItem>
+              <ToolbarGroup alignment={{ default: 'alignRight' }}>
+                <ActionServiceProvider context={{ 'alert-detail-toolbar-actions': { alert } }}>
+                  {({ actions, loaded }) =>
+                    loaded
+                      ? actions.map((action) => {
+                          if (isActionWithHref(action)) {
+                            return (
+                              <ToolbarItem
+                                key={action.id}
+                                spacer={{ default: 'spacerNone' }}
+                                className="pf-u-px-md"
+                              >
+                                <Link to={action.cta.href}>{action.label}</Link>
+                              </ToolbarItem>
+                            );
+                          } else if (isActionWithCallback(action)) {
+                            return (
+                              <ToolbarItem key={action.id} spacer={{ default: 'spacerNone' }}>
+                                <Button variant="link" onClick={action.cta}>
+                                  {action.label}
+                                </Button>
+                              </ToolbarItem>
+                            );
+                          }
+
+                          return null;
+                        })
+                      : null
+                  }
+                </ActionServiceProvider>
+                <ToolbarItem>
+                  <ToggleGraph />
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarContent>
+          </Toolbar>
+
+          <div className="co-m-pane__body-group">
+            <div className="row">
+              <div className="col-sm-12">
+                {!sourceId || sourceId === 'prometheus' ? (
+                  <Graph
+                    filterLabels={labels}
+                    namespace={namespace}
+                    query={rule?.query}
+                    ruleDuration={rule?.duration}
+                  />
+                ) : AlertsChart && !hideGraphs ? (
+                  <AlertsChart rule={rule} />
+                ) : null}
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-sm-6">
+                <dl className="co-m-pane__details">
+                  <dt>{t('Name')}</dt>
+                  <dd>{labels?.alertname}</dd>
+                  <dt>
+                    <PopoverField bodyContent={<SeverityHelp />} label={t('Severity')} />
+                  </dt>
+                  <dd>
+                    <Severity severity={labels?.severity} />
+                  </dd>
+                  {alert?.annotations?.description && (
+                    <>
+                      <dt>{t('Description')}</dt>
+                      <dd>
+                        <AlertMessage
+                          alertText={alert.annotations.description}
+                          labels={labels}
+                          template={rule?.annotations?.description}
+                        />
+                      </dd>
+                    </>
+                  )}
+                  {alert?.annotations?.summary && (
+                    <>
+                      <dt>{t('Summary')}</dt>
+                      <dd>{alert.annotations.summary}</dd>
+                    </>
+                  )}
+                  {alert?.annotations?.message && (
+                    <>
+                      <dt>{t('Message')}</dt>
+                      <dd>
+                        <AlertMessage
+                          alertText={alert.annotations.message}
+                          labels={labels}
+                          template={rule?.annotations?.message}
+                        />
+                      </dd>
+                    </>
+                  )}
+                  {runbookURL && (
+                    <>
+                      <dt>{t('Runbook')}</dt>
+                      <dd>
+                        <ExternalLink href={runbookURL} text={runbookURL} />
+                      </dd>
+                    </>
+                  )}
+                </dl>
+              </div>
+              <div className="col-sm-6">
+                <dl className="co-m-pane__details">
+                  <dt>
+                    <PopoverField bodyContent={<SourceHelp />} label={t('Source')} />
+                  </dt>
+                  <dd>{alert && getSourceKey(_.startCase(alertSource(alert)), t)}</dd>
+                  <dt>
+                    <PopoverField bodyContent={<AlertStateHelp />} label={t('State')} />
+                  </dt>
+                  <dd>
+                    <AlertState state={state} />
+                    <AlertStateDescription alert={alert} />
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+          <div className="co-m-pane__body-group">
+            <div className="row">
+              <div className="col-xs-12">
+                <dl className="co-m-pane__details" data-test="label-list">
+                  <dt>{t('Labels')}</dt>
+                  <dd>
+                    <Labels kind="alert" labels={labels} />
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+          <div className="co-m-pane__body-group">
+            <div className="row">
+              <div className="col-xs-12">
+                <dl className="co-m-pane__details">
+                  <dt>{t('Alerting rule')}</dt>
+                  <dd>
+                    <div className="co-resource-item">
+                      <MonitoringResourceIcon resource={RuleResource} />
+                      <Link
+                        to={namespace ? devRuleURL(rule, namespace) : ruleURL(rule)}
+                        data-test="alert-rules-detail-resource-link"
+                        className="co-resource-item__resource-name"
+                      >
+                        {_.get(rule, 'name')}
+                      </Link>
+                    </div>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+        {silencesLoaded && !_.isEmpty(alert?.silencedBy) && (
+          <div className="co-m-pane__body">
+            <div className="co-m-pane__body-group">
+              <SectionHeading text={t('Silenced by')} />
+              <div className="row">
+                <div className="col-xs-12">
+                  <SilencedByList silences={alert?.silencedBy} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </StatusBox>
+    </>
+  );
+};
+const AlertsDetailsPage = withFallback(withRouter(AlertsDetailsPage_));
+
+const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rule }) => {
+  const annotation = alert.annotations.description ? 'description' : 'message';
+  return (
+    <AlertMessage
+      alertText={alert.annotations[annotation]}
+      labels={alert.labels}
+      template={rule.annotations[annotation]}
+    />
+  );
+};
+
+const AlertMessage: React.FC<AlertMessageProps> = ({ alertText, labels, template }) => {
+  if (_.isEmpty(alertText)) {
+    return null;
+  }
+
+  let messageParts: React.ReactNode[] = [alertText];
+
+  // Go through each recognized resource type and replace any resource names that exist in alertText
+  // with a link to the resource's details page
+  _.each(alertMessageResources, (model, label) => {
+    const labelValue = labels[label];
+
+    if (labelValue && !(model.namespaced && _.isEmpty(labels.namespace))) {
+      const tagCount = matchCount(template, `\\{\\{ *\\$labels\\.${label} *\\}\\}`);
+      const resourceNameCount = matchCount(alertText, _.escapeRegExp(labelValue));
+
+      // Don't do the replacement unless the counts match. This avoids overwriting the wrong string
+      // if labelValue happens to appear elsewhere in alertText
+      if (tagCount > 0 && tagCount === resourceNameCount) {
+        const link = (
+          <ResourceLink
+            className="co-resource-item--monitoring-alert"
+            inline
+            key={model.kind}
+            kind={model.kind}
+            name={labelValue}
+            namespace={model.namespaced ? labels.namespace : undefined}
+          />
+        );
+        messageParts = _.flatMap(messageParts, (part) => {
+          if (_.isString(part) && part.indexOf(labelValue) !== -1) {
+            // `part` contains at least one instance of the resource name, so replace each instance
+            // with the link to the resource. Since the link is a component, we can't simply do a
+            // string substitution. Instead, create an array that contains each of the string parts
+            // and the resource links in the correct order.
+            const splitParts = part.split(labelValue);
+            return _.flatMap(splitParts, (p) => [p, link]).slice(0, -1);
+          }
+          return [part];
+        });
+      }
+    }
+  });
+
+  return (
+    <div className="co-alert-manager">
+      <p>
+        <LinkifyExternal>{messageParts}</LinkifyExternal>
+      </p>
+    </div>
+  );
+};
+
+const alertMessageResources: {
+  [labelName: string]: { kind: string; namespaced?: boolean };
+} = {
+  container: ContainerModel,
+  daemonset: DaemonSetModel,
+  deployment: DeploymentModel,
+  job: JobModel,
+  namespace: NamespaceModel,
+  node: NodeModel,
+  pod: PodModel,
+  statefulset: StatefulSetModel,
+};
+
+const matchCount = (haystack: string, regExpString: string) =>
+  _.size(haystack.match(new RegExp(regExpString, 'g')));
+
+const AlertStateHelp: React.FC = () => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  return (
+    <dl className="co-inline">
+      <dt>
+        <AlertStateIcon state={AlertStates.Pending} /> <strong>{t('Pending: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'The alert is active but is waiting for the duration that is specified in the alerting rule before it fires.',
+        )}
+      </dd>
+      <dt>
+        <AlertStateIcon state={AlertStates.Firing} /> <strong>{t('Firing: ')}</strong>
+      </dt>
+      <dd>
+        {t(
+          'The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert will continue to fire as long as the condition remains true.',
+        )}
+      </dd>
+      <dt>
+        <AlertStateIcon state={AlertStates.Silenced} /> <strong>{t('Silenced: ')}</strong>
+      </dt>
+      <dt></dt>
+      <dd>
+        {t(
+          'The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications will not be sent for alerts that match all the listed values or regular expressions.',
+        )}
+      </dd>
+    </dl>
+  );
+};
+
+const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const columns = React.useMemo<TableColumn<Silence>[]>(
+    () => [
+      {
+        id: 'name',
+        props: { className: tableSilenceClasses[1] },
+        title: t('Name'),
+      },
+      {
+        id: 'firingAlerts',
+        props: { className: tableSilenceClasses[2] },
+        title: t('Firing alerts'),
+      },
+      {
+        id: 'state',
+        props: { className: tableSilenceClasses[3] },
+        title: t('State'),
+      },
+      {
+        id: 'createdBy',
+        props: { className: tableSilenceClasses[4] },
+        title: t('Creator'),
+      },
+      {
+        id: 'actions',
+        props: { className: tableSilenceClasses[5] },
+        title: '',
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <VirtualizedTable<Silence>
+      aria-label={t('Silenced by')}
+      columns={columns}
+      data={silences}
+      loaded={true}
+      loadError={undefined}
+      Row={SilenceTableRow}
+      unfilteredData={silences}
+    />
+  );
+};
+
+export default AlertsDetailsPage;
+
+type AlertsDetailsPageProps = RouteComponentProps<{ ns?: string; ruleID: string }>;
+
+type AlertMessageProps = {
+  alertText: string;
+  labels: PrometheusLabels;
+  template: string;
+};

--- a/src/components/alerting/AlertsDetailPage.tsx
+++ b/src/components/alerting/AlertsDetailPage.tsx
@@ -49,9 +49,7 @@ import {
   SeverityBadge,
   SeverityHelp,
   silenceAlertURL,
-  SilenceTableRow,
   SourceHelp,
-  tableSilenceClasses,
 } from './AlertUtils';
 import { withFallback } from '../console/console-shared/error/error-boundary';
 import { SectionHeading } from '../console/utils/headings';
@@ -67,6 +65,7 @@ import {
   StatefulSetModel,
 } from '../console/models';
 import { Labels } from '../labels';
+import { SilenceTableRow, tableSilenceClasses } from './SilencesUtils';
 
 const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');

--- a/src/components/alerting/AlertsPage.tsx
+++ b/src/components/alerting/AlertsPage.tsx
@@ -10,6 +10,8 @@ import {
   alertSource,
   AlertState,
   AlertStateDescription,
+  devRuleURL,
+  devSilenceAlertURL,
   getAdditionalSources,
   isActionWithCallback,
   isActionWithHref,
@@ -168,8 +170,6 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
       <div className="co-m-pane__body">
         <ListPageFilter
           data={staticData}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore TODO
           labelFilter="alerts"
           labelPath="labels"
           loaded={loaded}
@@ -217,13 +217,21 @@ const AlertTableRow_: React.FC<AlertTableRowProps> = ({ history, obj, match }) =
   const title: string = obj.annotations?.description || obj.annotations?.message;
 
   const dropdownItems = [
-    <DropdownItem key="view-rule" onClick={() => history.push(ruleURL(obj.rule))}>
+    <DropdownItem
+      key="view-rule"
+      onClick={() => history.push(isDev ? devRuleURL(obj.rule, namespace) : ruleURL(obj.rule))}
+    >
       {t('View alerting rule')}
     </DropdownItem>,
   ];
   if (state !== AlertStates.Silenced) {
     dropdownItems.unshift(
-      <DropdownItem key="silence-alert" onClick={() => history.push(silenceAlertURL(obj))}>
+      <DropdownItem
+        key="silence-alert"
+        onClick={() =>
+          history.push(isDev ? devSilenceAlertURL(obj, namespace) : silenceAlertURL(obj))
+        }
+      >
         {t('Silence alert')}
       </DropdownItem>,
     );

--- a/src/components/alerting/AlertsPage.tsx
+++ b/src/components/alerting/AlertsPage.tsx
@@ -1,0 +1,299 @@
+import * as React from 'react';
+import { withFallback } from '../console/console-shared/error/error-boundary';
+import { useTranslation } from 'react-i18next';
+import { usePerspective } from '../hooks/usePerspective';
+import { Alerts, AlertSource, RootState } from '../types';
+import { useSelector } from 'react-redux';
+
+import * as _ from 'lodash-es';
+import {
+  alertSource,
+  AlertState,
+  AlertStateDescription,
+  getAdditionalSources,
+  isActionWithCallback,
+  isActionWithHref,
+  MonitoringResourceIcon,
+  ruleURL,
+  Severity,
+  silenceAlertURL,
+  SilencesNotLoadedWarning,
+} from './AlertUtils';
+import {
+  Action,
+  Alert,
+  AlertStates,
+  ActionServiceProvider,
+  ListPageFilter,
+  RowFilter,
+  RowProps,
+  TableColumn,
+  useListPageFilter,
+  VirtualizedTable,
+} from '@openshift-console/dynamic-plugin-sdk';
+import {
+  AlertResource,
+  alertSeverityOrder,
+  alertState,
+  alertURL,
+  devAlertURL,
+  fuzzyCaseInsensitive,
+} from '../utils';
+import { severityRowFilter } from '../alerting';
+import { sortable } from '@patternfly/react-table';
+import { Helmet } from 'react-helmet';
+import { DropdownItem } from '@patternfly/react-core';
+import { RouteComponentProps, withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
+import KebabDropdown from '../kebab-dropdown';
+
+const tableAlertClasses = [
+  'pf-u-w-50 pf-u-w-33-on-sm', // Name
+  'pf-m-hidden pf-m-visible-on-sm', // Severity
+  '', // State
+  'pf-m-hidden pf-m-visible-on-sm', // Source
+  'dropdown-kebab-pf pf-c-table__action',
+];
+
+const AlertsPage_: React.FC<AlertsPageProps> = () => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev, alertsKey, defaultAlertTenant } = usePerspective();
+
+  const {
+    data,
+    loaded = false,
+    loadError,
+  }: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey) || {});
+  const silencesLoadError = useSelector(
+    ({ observe }: RootState) => observe.get('silences')?.loadError,
+  );
+
+  const alertAdditionalSources = React.useMemo(
+    () => getAdditionalSources(data, alertSource),
+    [data],
+  );
+
+  const rowFilters: RowFilter[] = [
+    // TODO: The "name" filter doesn't really fit useListPageFilter's idea of a RowFilter, but
+    //       useListPageFilter doesn't yet provide a better way to add a filter like this
+    {
+      filter: (filter, alert: Alert) =>
+        fuzzyCaseInsensitive(filter.selected?.[0], alert.labels?.alertname),
+      filterGroupName: '',
+      items: [],
+      type: 'name',
+    } as RowFilter,
+    {
+      defaultSelected: [AlertStates.Firing],
+      filter: (filter, alert: Alert) =>
+        filter.selected?.includes(alertState(alert)) || _.isEmpty(filter.selected),
+      filterGroupName: t('Alert State'),
+      items: [
+        { id: AlertStates.Firing, title: t('Firing') },
+        { id: AlertStates.Pending, title: t('Pending') },
+        { id: AlertStates.Silenced, title: t('Silenced') },
+      ],
+      reducer: alertState,
+      type: 'alert-state',
+    },
+    severityRowFilter(t),
+    {
+      defaultSelected: [defaultAlertTenant],
+      filter: (filter, alert: Alert) =>
+        filter.selected?.includes(alertSource(alert)) || _.isEmpty(filter.selected),
+      filterGroupName: t('Source'),
+      items: [
+        { id: AlertSource.Platform, title: t('Platform') },
+        { id: AlertSource.User, title: t('User') },
+        ...alertAdditionalSources,
+      ],
+      reducer: alertSource,
+      type: 'alert-source',
+    },
+  ];
+
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(data, rowFilters);
+
+  if (isDev) {
+    rowFilters.filter((filter) => filter.filterGroupName !== t('Source'));
+  }
+
+  const columns = React.useMemo<TableColumn<Alert>[]>(
+    () => [
+      {
+        id: 'name',
+        props: { className: tableAlertClasses[0] },
+        sort: 'labels.alertname',
+        title: t('Name'),
+        transforms: [sortable],
+      },
+      {
+        id: 'severity',
+        props: { className: tableAlertClasses[1] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertSeverityOrder, [direction]) as Alert[],
+        title: t('Severity'),
+        transforms: [sortable],
+      },
+      {
+        id: 'state',
+        props: { className: tableAlertClasses[2] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertStateOrder, [direction]),
+        title: t('State'),
+        transforms: [sortable],
+      },
+      {
+        id: 'source',
+        props: { className: tableAlertClasses[3] },
+        sort: (alerts: Alert[], direction: 'asc' | 'desc') =>
+          _.orderBy(alerts, alertSource, [direction]),
+        title: t('Source'),
+        transforms: [sortable],
+      },
+      {
+        id: 'actions',
+        props: { className: tableAlertClasses[4] },
+        title: '',
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>Alerting</title>
+      </Helmet>
+      <div className="co-m-pane__body">
+        <ListPageFilter
+          data={staticData}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore TODO
+          labelFilter="alerts"
+          labelPath="labels"
+          loaded={loaded}
+          onFilterChange={onFilterChange}
+          rowFilters={rowFilters}
+        />
+        {silencesLoadError && <SilencesNotLoadedWarning silencesLoadError={silencesLoadError} />}
+        <div className="row">
+          <div className="col-xs-12">
+            <VirtualizedTable<Alert>
+              aria-label={t('Alerts')}
+              columns={columns}
+              data={filteredData ?? []}
+              loaded={loaded}
+              loadError={loadError}
+              Row={AlertTableRow}
+              unfilteredData={data}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+const AlertsPage = withFallback(AlertsPage_);
+
+// Sort alerts by their state (sort first by the state itself, then by the timestamp relevant to
+// the state)
+const alertStateOrder = (alert: Alert) => [
+  [AlertStates.Firing, AlertStates.Pending, AlertStates.Silenced].indexOf(alertState(alert)),
+  alertState(alert) === AlertStates.Silenced
+    ? _.max(_.map(alert.silencedBy, 'endsAt'))
+    : _.get(alert, 'activeAt'),
+];
+
+const AlertTableRow_: React.FC<AlertTableRowProps> = ({ history, obj, match }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev } = usePerspective();
+  const namespace = match.params.ns;
+
+  const { annotations = {}, labels } = obj;
+  const description = annotations.description || annotations.message;
+  const state = alertState(obj);
+
+  const title: string = obj.annotations?.description || obj.annotations?.message;
+
+  const dropdownItems = [
+    <DropdownItem key="view-rule" onClick={() => history.push(ruleURL(obj.rule))}>
+      {t('View alerting rule')}
+    </DropdownItem>,
+  ];
+  if (state !== AlertStates.Silenced) {
+    dropdownItems.unshift(
+      <DropdownItem key="silence-alert" onClick={() => history.push(silenceAlertURL(obj))}>
+        {t('Silence alert')}
+      </DropdownItem>,
+    );
+  }
+
+  const getDropdownItemsWithExtension = (actions: Action[]) => {
+    const extensionDropdownItems = [];
+    actions.forEach((action) => {
+      if (isActionWithHref(action)) {
+        extensionDropdownItems.push(
+          <DropdownItem key={action.id} href={action.cta.href}>
+            {action.label}
+          </DropdownItem>,
+        );
+      } else if (isActionWithCallback(action)) {
+        extensionDropdownItems.push(
+          <DropdownItem key={action.id} onClick={action.cta}>
+            {action.label}
+          </DropdownItem>,
+        );
+      }
+    });
+    return dropdownItems.concat(extensionDropdownItems);
+  };
+
+  return (
+    <>
+      <td className={tableAlertClasses[0]} title={title}>
+        <div className="co-resource-item">
+          <MonitoringResourceIcon resource={AlertResource} />
+          <Link
+            to={isDev ? devAlertURL(obj, obj.rule.id, namespace) : alertURL(obj, obj.rule.id)}
+            data-test-id="alert-resource-link"
+            className="co-resource-item__resource-name"
+          >
+            {labels?.alertname}
+          </Link>
+        </div>
+        <div className="monitoring-description">{description}</div>
+      </td>
+      <td className={tableAlertClasses[1]} title={title}>
+        <Severity severity={labels?.severity} />
+      </td>
+      <td className={tableAlertClasses[2]} title={title}>
+        <AlertState state={state} />
+        <AlertStateDescription alert={obj} />
+      </td>
+      <td className={tableAlertClasses[3]} title={title}>
+        {alertSource(obj) === AlertSource.User ? t('User') : t('Platform')}
+      </td>
+      <td className={tableAlertClasses[4]} title={title}>
+        <ActionServiceProvider context={{ 'monitoring-alert-list-item': { alert: obj } }}>
+          {({ actions, loaded }) => {
+            if (loaded && actions.length > 0) {
+              return <KebabDropdown dropdownItems={getDropdownItemsWithExtension(actions)} />;
+            } else {
+              return <KebabDropdown dropdownItems={dropdownItems} />;
+            }
+          }}
+        </ActionServiceProvider>
+      </td>
+    </>
+  );
+};
+const AlertTableRow = withRouter(AlertTableRow_);
+
+export default AlertsPage;
+
+type AlertTableRowProps = RouteComponentProps<AlertsPageProps> & RowProps<Alert>;
+
+type AlertsPageProps = {
+  ns: string | undefined;
+};

--- a/src/components/alerting/AlertsPage.tsx
+++ b/src/components/alerting/AlertsPage.tsx
@@ -75,7 +75,7 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
     [data],
   );
 
-  const rowFilters: RowFilter[] = [
+  let rowFilters: RowFilter[] = [
     // TODO: The "name" filter doesn't really fit useListPageFilter's idea of a RowFilter, but
     //       useListPageFilter doesn't yet provide a better way to add a filter like this
     {
@@ -114,11 +114,14 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
     },
   ];
 
-  const [staticData, filteredData, onFilterChange] = useListPageFilter(data, rowFilters);
-
   if (isDev) {
-    rowFilters.filter((filter) => filter.filterGroupName !== t('Source'));
+    rowFilters = rowFilters.filter((filter) => filter.type !== 'alert-source');
   }
+
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(
+    data?.filter((alert: Alert) => (isDev ? alertSource(alert) === AlertSource.User : true)),
+    rowFilters,
+  );
 
   const columns = React.useMemo<TableColumn<Alert>[]>(
     () => [

--- a/src/components/alerting/README.md
+++ b/src/components/alerting/README.md
@@ -16,6 +16,7 @@ src/components
 │   │   AlertsRuleDetailPage (Detail page of alert rules)
 │   │   SilencesPage (Lister view of silences)
 │   │   SilencesDetailPage (Detail page of alert rules)
+│   │   SilencesUtils (Utility functions specific to silence functionality)
 ```
 
 Update this doc if changes are needed and remove it once the migration is complete.

--- a/src/components/alerting/README.md
+++ b/src/components/alerting/README.md
@@ -1,0 +1,21 @@
+## Dev Console Migration
+The Observability UI team is in the process of migrating the developer perspective UI from the 
+openshift/console repo into this one. In the process of this, the alerting UI will be going through
+a refactor to help make the code more maintainable. At this time the current plan is as follows:
+
+```
+src/components
+│   alerting.tsx (This file will be reserved for the routing of the alerting module)
+│
+└───alerting
+│   │   AlertsUtils (Utility functions and components use across the alerting pages)
+│   │   alerts-types (Types used across the alerting pages)
+│   │   AlertsPage (Lister view of alerts for both developer and admin perspectives)
+│   │   AlertsDetailPage (Detail page of alerts)
+│   │   AlertsRulePage (Lister view of alert rules)
+│   │   AlertsRuleDetailPage (Detail page of alert rules)
+│   │   SilencesPage (Lister view of silences)
+│   │   SilencesDetailPage (Detail page of alert rules)
+```
+
+Update this doc if changes are needed and remove it once the migration is complete.

--- a/src/components/alerting/SilencesUtils.tsx
+++ b/src/components/alerting/SilencesUtils.tsx
@@ -1,0 +1,305 @@
+import * as React from 'react';
+import {
+  consoleFetchJSON,
+  GreenCheckCircleIcon,
+  Silence,
+  SilenceStates,
+} from '@openshift-console/dynamic-plugin-sdk';
+import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+import {
+  Alert as PFAlert,
+  Button,
+  Checkbox,
+  Label,
+  DropdownItem,
+  Dropdown,
+  DropdownPosition,
+  KebabToggle,
+  ModalVariant,
+  Modal,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import {
+  refreshSilences,
+  silenceMatcherEqualitySymbol,
+  SilenceResource,
+  silenceState,
+} from '../utils';
+import classNames from 'classnames';
+import { BanIcon, HourglassHalfIcon } from '@patternfly/react-icons';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { useBoolean } from '../hooks/useBoolean';
+import { usePerspective } from '../hooks/usePerspective';
+import { useDispatch } from 'react-redux';
+import { LoadingInline } from '../console/utils/status-box';
+import { MonitoringResourceIcon, OnToggle, SeverityCounts, StateTimestamp } from './AlertUtils';
+
+export const tableSilenceClasses = [
+  'pf-c-table__action', // Checkbox
+  'pf-u-w-50 pf-u-w-33-on-sm', // Name
+  'pf-m-hidden pf-m-visible-on-sm', // Firing alerts
+  '', // State
+  'pf-m-hidden pf-m-visible-on-sm', // Creator
+  'dropdown-kebab-pf pf-c-table__action',
+];
+
+export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const { createdBy, endsAt, firingAlerts, id, name, startsAt } = obj;
+  const state = silenceState(obj);
+
+  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
+
+  const onCheckboxChange = React.useCallback(
+    (isChecked: boolean) => {
+      setSelectedSilences((oldSet) => {
+        const newSet = new Set(oldSet);
+        if (isChecked) {
+          newSet.add(id);
+        } else {
+          newSet.delete(id);
+        }
+        return newSet;
+      });
+    },
+    [id, setSelectedSilences],
+  );
+
+  return (
+    <>
+      {showCheckbox && (
+        <td className={tableSilenceClasses[0]}>
+          <Checkbox
+            id={id}
+            isChecked={selectedSilences.has(id)}
+            isDisabled={state === SilenceStates.Expired}
+            onChange={onCheckboxChange}
+          />
+        </td>
+      )}
+      <td className={tableSilenceClasses[1]}>
+        <div className="co-resource-item">
+          <MonitoringResourceIcon resource={SilenceResource} />
+          <Link
+            className="co-resource-item__resource-name"
+            data-test-id="silence-resource-link"
+            title={id}
+            to={`${SilenceResource.plural}/${id}`}
+          >
+            {name}
+          </Link>
+        </div>
+        <div className="monitoring-label-list">
+          <SilenceMatchersList silence={obj} />
+        </div>
+      </td>
+      <td className={tableSilenceClasses[2]}>
+        <SeverityCounts alerts={firingAlerts} />
+      </td>
+      <td className={classNames(tableSilenceClasses[3], 'co-break-word')}>
+        <SilenceState silence={obj} />
+        {state === SilenceStates.Pending && (
+          <StateTimestamp text={t('Starts')} timestamp={startsAt} />
+        )}
+        {state === SilenceStates.Active && <StateTimestamp text={t('Ends')} timestamp={endsAt} />}
+        {state === SilenceStates.Expired && (
+          <StateTimestamp text={t('Expired')} timestamp={endsAt} />
+        )}
+      </td>
+      <td className={tableSilenceClasses[4]}>{createdBy || '-'}</td>
+      <td className={tableSilenceClasses[5]}>
+        <SilenceDropdownKebab silence={obj} />
+      </td>
+    </>
+  );
+};
+
+type SilenceTableRowProps = {
+  obj: Silence;
+  showCheckbox?: boolean;
+};
+
+export const SelectedSilencesContext = React.createContext({
+  selectedSilences: new Set(),
+  setSelectedSilences: undefined,
+});
+
+export const SilenceMatchersList = ({ silence }) => (
+  <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
+    {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
+      <Label className="co-label" key={i}>
+        <span className="co-label__key">{name}</span>
+        <span className="co-label__eq">{silenceMatcherEqualitySymbol(isEqual, isRegex)}</span>
+        <span className="co-label__value">{value}</span>
+      </Label>
+    ))}
+  </div>
+);
+
+export type ExpireSilenceModalProps = {
+  isOpen: boolean;
+  setClosed: () => void;
+  silenceID: string;
+};
+
+export const SilenceState = ({ silence }) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const state = silenceState(silence);
+  const icon = {
+    [SilenceStates.Active]: <GreenCheckCircleIcon />,
+    [SilenceStates.Pending]: <HourglassHalfIcon className="monitoring-state-icon--pending" />,
+    [SilenceStates.Expired]: <BanIcon className="text-muted" data-test-id="ban-icon" />,
+  }[state];
+
+  const getStateKey = (stateData) => {
+    switch (stateData) {
+      case SilenceStates.Active:
+        return t('Active');
+      case SilenceStates.Pending:
+        return t('Pending');
+      default:
+        return t('Expired');
+    }
+  };
+
+  return icon ? (
+    <>
+      {icon} {getStateKey(state)}
+    </>
+  ) : null;
+};
+
+const SilenceDropdownKebab: React.FC<{ silence: Silence }> = ({ silence }) => (
+  <SilenceDropdown isPlain silence={silence} Toggle={KebabToggle} />
+);
+
+const SilenceDropdown_: React.FC<SilenceDropdownProps> = ({
+  className,
+  history,
+  isPlain,
+  silence,
+  Toggle,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+
+  const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
+  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
+
+  const editSilence = () => {
+    history.push(`${SilenceResource.plural}/${silence.id}/edit`);
+  };
+
+  const dropdownItems =
+    silenceState(silence) === SilenceStates.Expired
+      ? [
+          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
+            {t('Recreate silence')}
+          </DropdownItem>,
+        ]
+      : [
+          <DropdownItem key="edit-silence" component="button" onClick={editSilence}>
+            {t('Edit silence')}
+          </DropdownItem>,
+          <DropdownItem key="cancel-silence" component="button" onClick={setModalOpen}>
+            {t('Expire silence')}
+          </DropdownItem>,
+        ];
+
+  return (
+    <>
+      <Dropdown
+        className={className}
+        data-test="silence-actions"
+        dropdownItems={dropdownItems}
+        isOpen={isOpen}
+        isPlain={isPlain}
+        onSelect={setClosed}
+        position={DropdownPosition.right}
+        toggle={<Toggle onToggle={setIsOpen} />}
+      />
+      <ExpireSilenceModal isOpen={isModalOpen} setClosed={setModalClosed} silenceID={silence.id} />
+    </>
+  );
+};
+export const SilenceDropdown = withRouter(SilenceDropdown_);
+
+const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
+  isOpen,
+  setClosed,
+  silenceID,
+}) => {
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const { perspective } = usePerspective();
+
+  const dispatch = useDispatch();
+
+  const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
+  const [errorMessage, setErrorMessage] = React.useState();
+
+  const expireSilence = () => {
+    setInProgress();
+    consoleFetchJSON
+      .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v2/silence/${silenceID}`)
+      .then(() => {
+        refreshSilences(dispatch, perspective);
+        setClosed();
+      })
+      .catch((err) => {
+        setErrorMessage(_.get(err, 'json.error') || err.message || 'Error expiring silence');
+        setNotInProgress();
+      })
+      .then(setNotInProgress);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      position="top"
+      showClose={false}
+      title={t('Expire silence')}
+      variant={ModalVariant.small}
+    >
+      <Flex direction={{ default: 'column' }}>
+        <FlexItem>{t('Are you sure you want to expire this silence?')}</FlexItem>
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem>
+            {errorMessage && (
+              <PFAlert
+                className="co-alert co-alert--scrollable"
+                isInline
+                title={t('An error occurred')}
+                variant="danger"
+              >
+                <div className="co-pre-line">{errorMessage}</div>
+              </PFAlert>
+            )}
+          </FlexItem>
+          <Flex>
+            <FlexItem>{isInProgress && <LoadingInline />}</FlexItem>
+            <FlexItem align={{ default: 'alignRight' }}>
+              <Button variant="secondary" onClick={setClosed}>
+                {t('Cancel')}
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="primary" onClick={expireSilence}>
+                {t('Expire silence')}
+              </Button>
+            </FlexItem>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Modal>
+  );
+};
+
+type SilenceDropdownProps = RouteComponentProps & {
+  className?: string;
+  isPlain?: boolean;
+  silence: Silence;
+  Toggle: React.FC<{ onToggle: OnToggle }>;
+};

--- a/src/components/console/console-shared/hooks/useActiveNamespace.ts
+++ b/src/components/console/console-shared/hooks/useActiveNamespace.ts
@@ -1,13 +1,5 @@
-import * as React from 'react';
+import { useSelector } from 'react-redux';
 
-type NamespaceContextType = {
-  namespace?: string;
-  setNamespace?: (ns: string) => void;
-};
-
-const NamespaceContext = React.createContext<NamespaceContextType>({});
-
-export const useActiveNamespace = () => {
-  const { namespace, setNamespace } = React.useContext(NamespaceContext);
-  return [namespace, setNamespace];
+export const useActiveNamespace = (): string => {
+  return useSelector(({ UI }) => UI.get('activeNamespace'));
 };

--- a/src/components/dashboards/custom-time-range-modal.tsx
+++ b/src/components/dashboards/custom-time-range-modal.tsx
@@ -12,7 +12,7 @@ import {
   TimePicker,
 } from '@patternfly/react-core';
 
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/observe';
+import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../actions/observe';
 import { RootState } from '../types';
 
 import { setQueryArguments } from '../console/utils/router';
@@ -32,13 +32,13 @@ const toISOTimeString = (date: Date): string =>
   ).format(date);
 
 type CustomTimeRangeModalProps = {
-  activePerspective: string;
+  perspective: Perspective;
   isOpen: boolean;
   setClosed: () => void;
 };
 
 const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
-  activePerspective,
+  perspective,
   isOpen,
   setClosed,
 }) => {
@@ -46,10 +46,10 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
 
   const dispatch = useDispatch();
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
 
   // If a time is already set in Redux, default to that, otherwise default to a time range that
@@ -69,8 +69,8 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
     const from = Date.parse(`${fromDate} ${fromTime}`);
     const to = Date.parse(`${toDate} ${toTime}`);
     if (_.isInteger(from) && _.isInteger(to)) {
-      dispatch(dashboardsSetEndTime(to, activePerspective));
-      dispatch(dashboardsSetTimespan(to - from, activePerspective));
+      dispatch(dashboardsSetEndTime(to, perspective));
+      dispatch(dashboardsSetTimespan(to - from, perspective));
       setQueryArguments({
         endTime: to.toString(),
         timeRange: (to - from).toString(),

--- a/src/components/dashboards/graph.tsx
+++ b/src/components/dashboards/graph.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { CustomDataSource } from '../console/extensions/dashboard-data-source';
 
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/observe';
+import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../actions/observe';
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
 import { RootState } from '../types';
-import { DEFAULT_GRAPH_SAMPLES, getActivePerspective } from './monitoring-dashboard-utils';
+import { DEFAULT_GRAPH_SAMPLES } from './monitoring-dashboard-utils';
 
 type Props = {
   customDataSource?: CustomDataSource;
@@ -18,6 +18,7 @@ type Props = {
   units: string;
   onZoomHandle?: (timeRange: number, endTime: number) => void;
   namespace?: string;
+  perspective: Perspective;
 };
 
 const Graph: React.FC<Props> = ({
@@ -30,23 +31,23 @@ const Graph: React.FC<Props> = ({
   units,
   onZoomHandle,
   namespace,
+  perspective,
 }) => {
   const dispatch = useDispatch();
-  const activePerspective = getActivePerspective(namespace);
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
 
   const onZoom = React.useCallback(
     (from, to) => {
-      dispatch(dashboardsSetEndTime(to, activePerspective));
-      dispatch(dashboardsSetTimespan(to - from, activePerspective));
+      dispatch(dashboardsSetEndTime(to, perspective));
+      dispatch(dashboardsSetTimespan(to - from, perspective));
       onZoomHandle?.(to - from, to);
     },
-    [activePerspective, dispatch, onZoomHandle],
+    [perspective, dispatch, onZoomHandle],
   );
 
   return (

--- a/src/components/dashboards/index.tsx
+++ b/src/components/dashboards/index.tsx
@@ -477,7 +477,7 @@ export const PollIntervalDropdown: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
   const refreshIntervalFromParams = getQueryArgument('refreshInterval');
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
   const interval = useSelector(({ observe }: RootState) =>
     observe.getIn(['dashboards', perspective, 'pollInterval']),
   );
@@ -828,7 +828,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({ hi
 
   const dispatch = useDispatch();
   const namespace = match.params?.ns;
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
   const [board, setBoard] = React.useState<string>();
   const [boards, isLoading, error] = useFetchDashboards(namespace);
 

--- a/src/components/dashboards/monitoring-dashboard-utils.ts
+++ b/src/components/dashboards/monitoring-dashboard-utils.ts
@@ -6,8 +6,6 @@ import { getQueryArgument } from '../console/utils/router';
 
 export const DEFAULT_GRAPH_SAMPLES = 60;
 
-export const getActivePerspective = (namespace: string): string => (namespace ? 'dev' : 'admin');
-
 export const getAllVariables = (boards: Board[], newBoardName: string, namespace: string) => {
   const data = _.find(boards, { name: newBoardName })?.data;
 

--- a/src/components/dashboards/timespan-dropdown.tsx
+++ b/src/components/dashboards/timespan-dropdown.tsx
@@ -20,7 +20,7 @@ const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 const TimespanDropdown: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
 
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
   const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);

--- a/src/components/dashboards/timespan-dropdown.tsx
+++ b/src/components/dashboards/timespan-dropdown.tsx
@@ -13,24 +13,23 @@ import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/obser
 import { useBoolean } from '../hooks/useBoolean';
 import { RootState } from '../types';
 import CustomTimeRangeModal from './custom-time-range-modal';
-import { TimeDropdownsProps } from './types';
-import { getActivePerspective } from './monitoring-dashboard-utils';
+import { usePerspective } from '../hooks/usePerspective';
 
 const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 
-const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
+const TimespanDropdown: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
-  const activePerspective = getActivePerspective(namespace);
+  const [perspective] = usePerspective();
 
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
   const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
 
   const timespan = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'timespan']),
+    observe.getIn(['dashboards', perspective, 'timespan']),
   );
   const endTime = useSelector(({ observe }: RootState) =>
-    observe.getIn(['dashboards', activePerspective, 'endTime']),
+    observe.getIn(['dashboards', perspective, 'endTime']),
   );
 
   const timeSpanFromParams = getQueryArgument('timeRange');
@@ -44,11 +43,11 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
       } else {
         setQueryArgument('timeRange', parsePrometheusDuration(v).toString());
         removeQueryArgument('endTime');
-        dispatch(dashboardsSetTimespan(parsePrometheusDuration(v), activePerspective));
-        dispatch(dashboardsSetEndTime(null, activePerspective));
+        dispatch(dashboardsSetTimespan(parsePrometheusDuration(v), perspective));
+        dispatch(dashboardsSetEndTime(null, perspective));
       }
     },
-    [activePerspective, dispatch, setModalOpen],
+    [perspective, dispatch, setModalOpen],
   );
 
   const items = {
@@ -69,9 +68,9 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   return (
     <>
       <CustomTimeRangeModal
-        activePerspective={activePerspective}
         isOpen={isModalOpen}
         setClosed={setModalClosed}
+        perspective={perspective}
       />
       <div className="form-group monitoring-dashboards__dropdown-wrap">
         <label

--- a/src/components/dashboards/types.ts
+++ b/src/components/dashboards/types.ts
@@ -95,10 +95,6 @@ export type Board = {
   name: string;
 };
 
-export type TimeDropdownsProps = {
-  namespace?: string;
-};
-
 export type DataSource = {
   name: string;
   type: string;

--- a/src/components/fetch-alerts.tsx
+++ b/src/components/fetch-alerts.tsx
@@ -5,8 +5,9 @@ export const fetchAlerts = async (
   prometheusURL: string,
   externalAlertsFetch?: Array<{
     id: string;
-    getAlertingRules: () => Promise<PrometheusRulesResponse>;
+    getAlertingRules: (namespace?: string) => Promise<PrometheusRulesResponse>;
   }>,
+  namespace?: string,
 ): Promise<PrometheusRulesResponse> => {
   if (!externalAlertsFetch || externalAlertsFetch.length === 0) {
     return consoleFetchJSON(prometheusURL);
@@ -22,7 +23,7 @@ export const fetchAlerts = async (
   try {
     const groups = await Promise.allSettled([
       consoleFetchJSON(prometheusURL),
-      ...resolvedExternalAlertsSources.map((source) => source.fetch()),
+      ...resolvedExternalAlertsSources.map((source) => source.fetch(namespace)),
     ]).then((results) =>
       results
         .map((result, i) => ({ sourceId: sourceIds[i], alerts: result }))

--- a/src/components/hooks/usePerspective.tsx
+++ b/src/components/hooks/usePerspective.tsx
@@ -1,11 +1,17 @@
 import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import { Perspective } from 'src/actions/observe';
 
-export const usePerspective = (): [Perspective, 'rules' | 'devRules', 'alerts' | 'devAlerts'] => {
+type usePerspectiveReturn = {
+  perspective: Perspective;
+  rulesKey: 'devRules' | 'rules';
+  alertsKey: 'devAlerts' | 'alerts';
+};
+
+export const usePerspective = (): usePerspectiveReturn => {
   const [perspective] = useActivePerspective();
 
   if (perspective === 'dev') {
-    return ['dev', 'devRules', 'devAlerts'];
+    return { perspective: 'dev', rulesKey: 'devRules', alertsKey: 'devAlerts' };
   }
-  return ['admin', 'rules', 'alerts'];
+  return { perspective: 'admin', rulesKey: 'rules', alertsKey: 'alerts' };
 };

--- a/src/components/hooks/usePerspective.tsx
+++ b/src/components/hooks/usePerspective.tsx
@@ -1,0 +1,11 @@
+import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
+import { Perspective } from 'src/actions/observe';
+
+export const usePerspective = (): [Perspective, 'rules' | 'devRules', 'alerts' | 'devAlerts'] => {
+  const [perspective] = useActivePerspective();
+
+  if (perspective === 'dev') {
+    return ['dev', 'devRules', 'devAlerts'];
+  }
+  return ['admin', 'rules', 'alerts'];
+};

--- a/src/components/hooks/usePerspective.tsx
+++ b/src/components/hooks/usePerspective.tsx
@@ -1,17 +1,32 @@
 import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import { Perspective } from 'src/actions/observe';
+import { AlertSource } from '../types';
 
 type usePerspectiveReturn = {
   perspective: Perspective;
+  isDev: boolean;
   rulesKey: 'devRules' | 'rules';
   alertsKey: 'devAlerts' | 'alerts';
+  defaultAlertTenant: AlertSource;
 };
 
 export const usePerspective = (): usePerspectiveReturn => {
   const [perspective] = useActivePerspective();
 
   if (perspective === 'dev') {
-    return { perspective: 'dev', rulesKey: 'devRules', alertsKey: 'devAlerts' };
+    return {
+      perspective: 'dev',
+      isDev: true,
+      rulesKey: 'devRules',
+      alertsKey: 'devAlerts',
+      defaultAlertTenant: AlertSource.User,
+    };
   }
-  return { perspective: 'admin', rulesKey: 'rules', alertsKey: 'alerts' };
+  return {
+    perspective: 'admin',
+    isDev: false,
+    rulesKey: 'rules',
+    alertsKey: 'alerts',
+    defaultAlertTenant: AlertSource.Platform,
+  };
 };

--- a/src/components/silence-form.tsx
+++ b/src/components/silence-form.tsx
@@ -133,7 +133,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
 
   const dispatch = useDispatch();
 
-  const [perspective] = usePerspective();
+  const { perspective } = usePerspective();
 
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 

--- a/src/components/silence-form.tsx
+++ b/src/components/silence-form.tsx
@@ -35,6 +35,7 @@ import { StatusBox } from './console/utils/status-box';
 import { useBoolean } from './hooks/useBoolean';
 import { RootState, Silences } from './types';
 import { refreshSilences, SilenceResource, silenceState } from './utils';
+import { usePerspective } from './hooks/usePerspective';
 
 const pad = (i: number): string => (i < 10 ? `0${i}` : String(i));
 
@@ -132,6 +133,8 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
 
   const dispatch = useDispatch();
 
+  const [perspective] = usePerspective();
+
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
   const [comment, setComment] = React.useState(defaults.comment ?? '');
@@ -218,7 +221,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
       .post(`${alertManagerBaseURL}/api/v2/silences`, body)
       .then(({ silenceID }) => {
         setError(undefined);
-        refreshSilences(dispatch);
+        refreshSilences(dispatch, perspective);
         history.push(`${SilenceResource.plural}/${encodeURIComponent(silenceID)}`);
       })
       .catch((err) => {

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -7,6 +7,7 @@ import {
   AlertSeverity,
   AlertStates,
   consoleFetchJSON,
+  PrometheusAlert,
   PrometheusLabels,
   PrometheusRule,
   PrometheusRulesResponse,
@@ -48,7 +49,7 @@ export const fuzzyCaseInsensitive = (a: string, b: string): boolean =>
 export const labelsToParams = (labels: PrometheusLabels) =>
   _.map(labels, (v, k) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
 
-export const alertURL = (alert: Alert, ruleID: string) =>
+export const alertURL = (alert: PrometheusAlert, ruleID: string) =>
   `${AlertResource.plural}/${ruleID}?${labelsToParams(alert.labels)}`;
 
 export const getAlertsAndRules = (
@@ -125,7 +126,7 @@ export const refreshSilences = (dispatch: Dispatch): void => {
     });
 };
 
-export const alertDescription = (alert: Alert | Rule): string =>
+export const alertDescription = (alert: PrometheusAlert | Rule): string =>
   alert.annotations?.description || alert.annotations?.message || alert.labels?.alertname;
 
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -16,7 +16,7 @@ import {
   SilenceStates,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import { alertingErrored, alertingLoaded, alertingLoading } from '../actions/observe';
+import { alertingErrored, alertingLoaded, alertingLoading, Perspective } from '../actions/observe';
 import { AlertSource, MonitoringResource, Target, TimeRange } from './types';
 
 export const PROMETHEUS_BASE_PATH = window.SERVER_FLAGS.prometheusBaseURL;
@@ -105,13 +105,13 @@ const getSilenceName = (silence: Silence) => {
         .join(', ');
 };
 
-export const refreshSilences = (dispatch: Dispatch): void => {
+export const refreshSilences = (dispatch: Dispatch, perspective: Perspective): void => {
   const { alertManagerBaseURL } = window.SERVER_FLAGS;
   if (!alertManagerBaseURL) {
     return;
   }
 
-  dispatch(alertingLoading('silences'));
+  dispatch(alertingLoading('silences', perspective));
 
   consoleFetchJSON(`${alertManagerBaseURL}/api/v2/silences`)
     .then((silences) => {
@@ -119,10 +119,10 @@ export const refreshSilences = (dispatch: Dispatch): void => {
       _.each(silences, (s) => {
         s.name = getSilenceName(s);
       });
-      dispatch(alertingLoaded('silences', silences));
+      dispatch(alertingLoaded('silences', silences, perspective));
     })
     .catch((e) => {
-      dispatch(alertingErrored('silences', e));
+      dispatch(alertingErrored('silences', e, perspective));
     });
 };
 

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -52,6 +52,9 @@ export const labelsToParams = (labels: PrometheusLabels) =>
 export const alertURL = (alert: PrometheusAlert, ruleID: string) =>
   `${AlertResource.plural}/${ruleID}?${labelsToParams(alert.labels)}`;
 
+export const devAlertURL = (alert: Alert, ruleID: string, namespace: string) =>
+  `/dev-monitoring/ns/${namespace}/alerts/${ruleID}?${labelsToParams(alert.labels)}`;
+
 export const getAlertsAndRules = (
   data: PrometheusRulesResponse['data'],
 ): { alerts: Alert[]; rules: Rule[] } => {


### PR DESCRIPTION
The original story for this was to move the Alerts Details page to the monitoring-plugin, however that is already the case. In keeping with the rest of this set of stories, this PR instead looks to split the code from the `alerting.tsx` file out into the individual pages as well as util files which contain shared code across the different pages.

This PR is currently branched off of #125 and cannot be merged until that is merged. Once merged, this will need to be rebased onto main. For review, only the last 2 commits are exclusive to this branch.