### PR TITLE
OU-251: Prevent rule labels from being added to alert labels for dev console

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1996,7 +1996,7 @@ const PollerPages = () => {
       const poller = (): void => {
         fetchAlerts(url, alertsSource, namespace)
           .then(({ data }) => {
-            const { alerts, rules } = getAlertsAndRules(data);
+            const { alerts, rules } = getAlertsAndRules(data, !isDev);
             dispatch(alertingLoaded(alertsKey, alerts, perspective));
             dispatch(alertingSetRules(rulesKey, rules, perspective));
           })
@@ -2018,7 +2018,7 @@ const PollerPages = () => {
     return (): void => {
       _.each(pollerTimeouts, clearTimeout);
     };
-  }, [alertsSource, dispatch, perspective, rulesKey, alertsKey, namespace]);
+  }, [alertsSource, dispatch, perspective, rulesKey, alertsKey, namespace, isDev]);
 
   if (isDev) {
     return (

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -57,6 +57,7 @@ export const devAlertURL = (alert: Alert, ruleID: string, namespace: string) =>
 
 export const getAlertsAndRules = (
   data: PrometheusRulesResponse['data'],
+  isAdminPerspective: boolean,
 ): { alerts: Alert[]; rules: Rule[] } => {
   // Flatten the rules data to make it easier to work with, discard non-alerting rules since those
   // are the only ones we will be using and add a unique ID to each rule.
@@ -77,10 +78,14 @@ export const getAlertsAndRules = (
     return _.filter(g.rules, { type: 'alerting' }).map(addID);
   });
 
-  // Add external labels to all `rules[].alerts[].labels`
-  rules.forEach((rule) => {
-    rule.alerts.forEach((alert) => (alert.labels = { ...rule.labels, ...alert.labels }));
-  });
+  // The console codebase and developer perspective actions don't expect the external labels to be
+  // included on the alerts
+  if (isAdminPerspective) {
+    // Add external labels to all `rules[].alerts[].labels`
+    rules.forEach((rule) => {
+      rule.alerts.forEach((alert) => (alert.labels = { ...rule.labels, ...alert.labels }));
+    });
+  }
 
   // Add `rule` object to each alert
   const alerts = _.flatMap(rules, (rule) => rule.alerts.map((a) => ({ rule, ...a })));


### PR DESCRIPTION
The monitoring-plugin adds the labels from the rules onto the individual alerts, which causes the dev details page to fail to match the labels from the alert (which are encoded into the url) and then says alert not found.

This PR prevents the rule labels from being added to the alert labels in the developer persepctive.