### PR TITLE
OCPBUGS-36970: Use the non-tenancy URL in the Admin perspective

### DIFF
--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1992,7 +1992,10 @@ const PollerPages = () => {
 
     if (prometheusBaseURL) {
       dispatch(alertingLoading(alertsKey, perspective));
-      const url = getPrometheusURL({ endpoint: PrometheusEndpoint.RULES, namespace });
+      const url = getPrometheusURL({
+        endpoint: PrometheusEndpoint.RULES,
+        namespace: isDev ? namespace : '',
+      });
       const poller = (): void => {
         fetchAlerts(url, alertsSource, namespace)
           .then(({ data }) => {


### PR DESCRIPTION
Since the namespace variable is what determines whether the tenancy URL or the admin URL is used in the `getPrometheusURL` we should ensure that it only gets passed in when being called in the dev perspective.