### PR TITLE
OU-258: Dev console: Use Metrics page from monitoring-plugin

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -97,5 +97,16 @@
       "path": ["/dev-monitoring/ns/:ns/alerts/:ruleID"],
       "component": { "$codeRef": "MonitoringUI" }
     }
+  },
+  {
+    "type": "console.tab",
+    "properties": {
+      "contextId": "dev-console-observe",
+      "name": "%public~Metrics%",
+      "href": "metrics",
+      "component": {
+        "$codeRef": "MonitoringUI"
+      }
+    }
   }
 ]

--- a/src/components/alerting.tsx
+++ b/src/components/alerting.tsx
@@ -1117,6 +1117,7 @@ const PollerPages = () => {
       <Switch>
         <Route path="/dev-monitoring/ns/:ns/alerts" exact component={AlertsPage} />
         <Route path="/dev-monitoring/ns/:ns/alerts/:ruleID" component={AlertsDetailsPage} />
+        <Route path="/dev-monitoring/ns/:ns/metrics" exact component={QueryBrowserPage} />
       </Switch>
     );
   }


### PR DESCRIPTION
**Description:**
This PR aims to consolidate code so that the Administrator and Developer perspectives render the same UI, which the monitoring plugin will serve.
This PR removes the files associated with the Dev Perspective > Observe > Metrics page. The monitoring plugin will now serve this page, PR for this is https://github.com/openshift/console/pull/14105 .

**Related JIRA Issues**
[CONSOLE-4187](https://issues.redhat.com/browse/CONSOLE-4187) : Dev console: Use Metrics page from monitoring-plugin
[OU-258](https://issues.redhat.com/browse/OU-258): Dev console: Use Metrics page from monitoring-plugin
These are duplicate issues because the openshift/console requires the PR title to be associated with an OCP-owned JIRA issue.

**Tandem PR: openshift/console PR#14105**
[openshift/console PR#14105](https://github.com/openshift/console/pull/14105)

**Test:** 
To see the full feature, you will need to run both this [openshift/console PR#14105](https://github.com/openshift/console/pull/14105) and this [openshift/monitoring-plugin PR#138](https://github.com/openshift/monitoring-plugin/pull/138).

This **openshift/console#PR14105** - removes the code associated with the Dev perspective > Observe > Metrics page. 
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/a2bceee7-5f8e-46a6-bedd-fe410d83ddb5">

This **openshift/monitoring-plugin#PR138** - add the Dev perspective > Observe > Metrics page (a new UI renders, similar to Admin perspective > Observe > Metrics page). 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f4c320eb-1943-4275-a984-4c890ede88d7">

**Video Demo** 
Together (openshift/console#PR14105 & openshift/monitoring-plugin#PR138) should render like this: 
https://github.com/user-attachments/assets/a80b663f-c609-4f7c-9aca-c7edbd6bf5b0


**Note**
- The 403 Error displayed in the Dashboard is unrelated to this issue and has been reported here ([OCPBUGS-37511](https://issues.redhat.com/browse/OCPBUGS-37511?filter=-2)). The issue only occurs when running the /console in localhost.


