### PR TITLE
NO-JIRA: Use DNF and go based image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ COPY pkg/ pkg/
 
 RUN make build-backend
 
-FROM registry.redhat.io/ubi9/ubi-minimal
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17
 
-RUN microdnf -y install nginx findutils && \
+RUN dnf install -y nginx findutils && \
     mkdir /var/cache/nginx && \
     chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
     chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run


### PR DESCRIPTION
The okd-scos image in 4.17 being used doesn't have access to microdnf. This PR adds a slightly heavier image, but one that has access to dnf to install the needed dependencies.

Testing for this PR on the 4.17 branch is being done here in #153