### PR TITLE
NO-JIRA: Manual Cherry Pick - Use DNF and go based image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ COPY pkg/ pkg/
 
 RUN make build-backend
 
-FROM registry.redhat.io/ubi9/ubi-minimal
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17
 
-RUN microdnf -y install nginx findutils && \
+RUN dnf install -y nginx findutils && \
     mkdir /var/cache/nginx && \
     chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
     chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run


### PR DESCRIPTION
Manual Cherry Pick of #154

The download for NGINX failed in the CI of the cherry pick, and the CI is caching the failure of that download, so I'm trying a manual cherry pick of the exact same change so that the CI doesn't cache it