### PR TITLE
OCPBUGS-36921: Use resource label when showing empty alert list pages

### DIFF
--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -56,7 +56,7 @@ import {
 import { SectionHeading } from './console/utils/headings';
 import { ExternalLink } from './console/utils/link';
 import { getAllQueryArguments } from './console/utils/router';
-import { LoadingInline, StatusBox } from './console/utils/status-box';
+import { EmptyBox, LoadingInline, StatusBox } from './console/utils/status-box';
 
 import MonitoringDashboardsPage from './dashboards';
 import { useBoolean } from './hooks/useBoolean';
@@ -780,6 +780,9 @@ const RulesPage_: React.FC = () => {
               loadError={loadError}
               Row={RuleTableRow}
               unfilteredData={data}
+              NoDataEmptyMsg={() => {
+                return <EmptyBox label={RuleResource.label} />;
+              }}
             />
           </div>
         </div>
@@ -1029,6 +1032,9 @@ const SilencesPage_: React.FC = () => {
                 loadError={loadError}
                 Row={SilenceTableRowWithCheckbox}
                 unfilteredData={data}
+                NoDataEmptyMsg={() => {
+                  return <EmptyBox label={SilenceResource.label} />;
+                }}
               />
             </div>
           </div>

--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -47,6 +47,7 @@ import { DropdownItem } from '@patternfly/react-core';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 import KebabDropdown from '../kebab-dropdown';
+import { EmptyBox } from '../console/utils/status-box';
 
 const tableAlertClasses = [
   'pf-u-w-50 pf-u-w-33-on-sm', // Name
@@ -212,6 +213,9 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
               Row={AlertTableRow}
               unfilteredData={data}
               csvData={csvData}
+              NoDataEmptyMsg={() => {
+                return <EmptyBox label={AlertResource.label} />;
+              }}
             />
           </div>
         </div>

--- a/web/src/components/console/utils/status-box.tsx
+++ b/web/src/components/console/utils/status-box.tsx
@@ -70,7 +70,7 @@ export const LoadingBox: React.FC<LoadingBoxProps> = ({ className, message }) =>
 );
 LoadingBox.displayName = 'LoadingBox';
 
-const EmptyBox: React.FC<EmptyBoxProps> = ({ label }) => {
+export const EmptyBox: React.FC<EmptyBoxProps> = ({ label }) => {
   const { t } = useTranslation();
   return (
     <Box>


### PR DESCRIPTION
This PR updates the empty pages of alerts listers to use the resource labels to provide more information.

<details>

<summary>Previous UIs</summary>

![image](https://github.com/user-attachments/assets/11a67f89-b006-48ee-9afc-c94f118692b5)

![image](https://github.com/user-attachments/assets/672007ba-aa9c-413b-a780-54a3cc23d7cc)

![image](https://github.com/user-attachments/assets/4f96941f-a772-4b39-befa-cfe326471d49)

![image](https://github.com/user-attachments/assets/5eb90d48-0217-4992-8d98-acb6db874ba5)

</details>


<details>

<summary>New UIs</summary>

![image](https://github.com/user-attachments/assets/f93613f5-f4f3-4d3b-b2fc-1ec4eba1ecd8)

![image](https://github.com/user-attachments/assets/780668da-7c20-47c9-ab0f-24f0a208c829)

![image](https://github.com/user-attachments/assets/e1e42513-a5b2-4da3-ba12-497e9a0f8c33)

![image](https://github.com/user-attachments/assets/6c0e6cf2-c257-4b7c-a782-b4c4cb88b401)
</details>

The developer perspective silences page hasn't been updated with this change since it is still located in the `openshift/console` codebase. Once the silence UI is brought over it will have the same changes.