### PR TITLE
OU-259: Update console-extension to use translations in plugin__monitoring-plugin

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -30,7 +30,7 @@
     },
     "properties": {
       "id": "alerting",
-      "name": "%public~Alerting%",
+      "name": "%plugin__monitoring-plugin~Alerting%",
       "href": "/monitoring/alerts",
       "perspective": "admin",
       "section": "observe",
@@ -44,7 +44,7 @@
     },
     "properties": {
       "id": "metrics",
-      "name": "%public~Metrics%",
+      "name": "%plugin__monitoring-plugin~Metrics%",
       "href": "/monitoring/query-browser",
       "perspective": "admin",
       "section": "observe",
@@ -58,7 +58,7 @@
     },
     "properties": {
       "id": "dashboards",
-      "name": "%public~Dashboards%",
+      "name": "%plugin__monitoring-plugin~Dashboards%",
       "href": "/monitoring/dashboards",
       "perspective": "admin",
       "section": "observe",
@@ -72,7 +72,7 @@
     },
     "properties": {
       "id": "targets",
-      "name": "%public~Targets%",
+      "name": "%plugin__monitoring-plugin~Targets%",
       "href": "/monitoring/targets",
       "perspective": "admin",
       "section": "observe",
@@ -83,7 +83,7 @@
     "type": "console.tab",
     "properties": {
       "contextId": "dev-console-observe",
-      "name": "%public~Alerts%",
+      "name": "%plugin__monitoring-plugin~Alerts%",
       "href": "alerts",
       "component": {
         "$codeRef": "MonitoringUI"
@@ -102,7 +102,7 @@
     "type": "console.tab",
     "properties": {
       "contextId": "dev-console-observe",
-      "name": "%public~Metrics%",
+      "name": "%plugin__monitoring-plugin~Metrics%",
       "href": "metrics",
       "component": {
         "$codeRef": "MonitoringUI"


### PR DESCRIPTION
Update `console-extension.json` to use translations from `openshift/monitoring-plugin/.../plugin__monitoring-plugin.json` instead of `openshift/console/.../public.json`