### PR TITLE
OU-450: Use plugin-backend as default ENTRYPOINT

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -39,22 +39,9 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 
-RUN INSTALL_PKGS="nginx" && \
-    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum -y clean all --enablerepo='*' && \
-    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
-    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
-
 USER 1001
-
-COPY --from=web-builder /usr/src/app/web/dist /usr/share/nginx/html
 
 COPY --from=web-builder /usr/src/app/web/dist /opt/app-root/web/dist
 COPY --from=go-builder $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/plugin-backend /opt/app-root
 
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
-
-# When nginx is removed from CMO, we can use the following ENTRYPOINT instead and remove the nginx install
-# After it has been removed add the CI checks to this repo. [example](https://github.com/openshift/release/pull/56011)
-# ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -46,20 +46,9 @@ RUN make build-backend
 
 FROM registry.redhat.io/ubi9/ubi-minimal
 
-RUN microdnf install nginx findutils && \
-    mkdir /var/cache/nginx && \
-    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
-    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
-
 USER 1001
 
 COPY --from=web-builder /opt/app-root/src/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root/plugin-backend
 
-COPY --from=web-builder /opt/app-root/src/web/dist /usr/share/nginx/html
-
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
-
-# When nginx is removed from CMO, we can use the following ENTRYPOINT instead
-# After it has been removed add the CI checks to this repo. [example](https://github.com/openshift/release/pull/56011)
-# ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -32,20 +32,9 @@ RUN go build -mod=mod -o plugin-backend cmd/plugin-backend.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-RUN microdnf install nginx findutils && \
-    mkdir /var/cache/nginx && \
-    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
-    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
-
 USER 1001
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 
-COPY --from=web-builder /opt/app-root/web/dist /usr/share/nginx/html
-
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
-
-# When nginx is removed from CMO, we can use the following ENTRYPOINT instead
-# After it has been removed add the CI checks to this repo. [example](https://github.com/openshift/release/pull/56011)
-# ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]


### PR DESCRIPTION
This PR looks to remove the backwards compatibility of the `monitoring-plugin` images and instead use the go backend