### PR TITLE
OCPBUGS-41602: Reduce default logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,33 +44,33 @@ Install the chart into a new namespace or an existing namespace as specified by 
 helm upgrade -i monitoring-plugin charts/openshift-console-plugin -n my-plugin-namespace --create-namespace --set plugin.image=my-plugin-image-location
 ```
 
-## Local Development 
+## Local Development
 
-### Dependencies 
+### Dependencies
 1. [yarn](https://yarnpkg.com/en/docs/install)
-2. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/) 
-3. [podman 3.2.0+](https://podman.io) or [Docker](https://www.docker.com) 
+2. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/)
+3. [podman 3.2.0+](https://podman.io) or [Docker](https://www.docker.com)
 4. An OpenShift cluster
 
-### Running Locally 
+### Running Locally
 ```
-# Login to an OpenShift cluster 
+# Login to an OpenShift cluster
 $ oc login <clusterAddress> -u <username> -p <password>
 
-# Start podman (or Docker) 
-$ podman machine init 
-$ podman machine start 
+# Start podman (or Docker)
+$ podman machine init
+$ podman machine start
 
-# Install dependencies 
-$ make install 
+# Install dependencies
+$ make install
 
-# Run the application 
+# Run the application
 $ make start-frontend
-# In a separate terminal 
+# In a separate terminal
 $ make start-console
 ```
 The application will be running at [localhost:9000](http://localhost:9000/).
 
-### Local Development Troubleshooting 
+### Local Development Troubleshooting
 1. Disable cache. Select 'disable cache' in your browser's DevTools > Network > 'disable cache'. Or use private/incognito mode in your browser.
-
+2. Enable higher log verbosity by setting `-log-verbosity=1` when starting the plugin backend

--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -18,6 +18,7 @@ var (
 	staticPathArg   = flag.String("static-path", "", "static files path to serve frontend (default: './web/dist')")
 	configPathArg   = flag.String("config-path", "", "config files path (default: './config')")
 	pluginConfigArg = flag.String("plugin-config-path", "", "plugin yaml configuration")
+	logLevelArg     = flag.String("log-level", "error", "verbosity of logs\noptions: ['panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']\n'trace' level will log all incoming requests\n(default 'error')")
 	log             = logrus.WithField("module", "main")
 )
 
@@ -31,6 +32,7 @@ func main() {
 	staticPath := mergeEnvValue("MONITORING_PLUGIN_STATIC_PATH", *staticPathArg, "/opt/app-root/web/dist")
 	configPath := mergeEnvValue("MONITORING_PLUGIN_MANIFEST_CONFIG_PATH", *configPathArg, "/opt/app-root/web/dist")
 	pluginConfigPath := mergeEnvValue("MONITORING_PLUGIN_CONFIG_PATH", *pluginConfigArg, "/etc/plugin/config.yaml")
+	logLevel := mergeEnvValue("MONITORING_PLUGIN_LOG_LEVEL", *logLevelArg, "error")
 
 	featuresList := strings.Fields(strings.Join(strings.Split(strings.ToLower(features), ","), " "))
 
@@ -49,6 +51,7 @@ func main() {
 		StaticPath:       staticPath,
 		ConfigPath:       configPath,
 		PluginConfigPath: pluginConfigPath,
+		LogLevel:         logLevel,
 	})
 }
 


### PR DESCRIPTION
Due to the addition of a health check on the monitoring plugin deployment, the `/health` endpoint is getting hit quite often, leading to an excessive amount of logs being generated. This is also true for other endpoints as well, such as the `/plugin-manifest.json` which is polled around every 15 seconds per user logged into the console.

This PR looks to combat these excessive logs by not logging individual requests when an endpoint is hit, unless a new `log-verbosity` parameter is set to 1.