### PR TITLE
incidents-filter-matcher

### DIFF
--- a/src/components/Incidents/IncidentsPage.jsx
+++ b/src/components/Incidents/IncidentsPage.jsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { Helmet } from 'react-helmet';
 import { useBoolean } from '../hooks/useBoolean';
-import * as _ from 'lodash-es';
+import some from 'lodash-es/some';
 
 const IncidentsPage = ({ customDataSource, namespace }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -37,16 +37,16 @@ const IncidentsPage = ({ customDataSource, namespace }) => {
   const [incidentsData, setIncidentsData] = React.useState([]);
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
-  const incidentsMatcher = (incident) => _.some(incident, 'informative');
   const now = Date.now();
   const timeRanges = getIncidentsTimeRanges(span, now);
   const safeFetch = useSafeFetch();
   const title = t('Incidents');
+  const matcher = (incident, prop) => some([incident], prop);
 
   const incidentTypeFilter = (t) => ({
     filter: filterIncident,
     filterGroupName: t('Incident type'),
-    isMatch: incidentsMatcher,
+    isMatch: (incident, prop) => matcher(incident, prop),
     items: [
       { id: 'long-standing', title: t('Long standing') },
       { id: 'informative', title: t('Informative') },

--- a/src/components/Incidents/IncidentsPage.jsx
+++ b/src/components/Incidents/IncidentsPage.jsx
@@ -26,6 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { Helmet } from 'react-helmet';
 import { useBoolean } from '../hooks/useBoolean';
+import * as _ from 'lodash-es';
 
 const IncidentsPage = ({ customDataSource, namespace }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -35,15 +36,17 @@ const IncidentsPage = ({ customDataSource, namespace }) => {
   const [alertsData, setAlertsData] = React.useState([]);
   const [incidentsData, setIncidentsData] = React.useState([]);
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
+
+  const incidentsMatcher = (incident) => _.some(incident, 'informative');
   const now = Date.now();
   const timeRanges = getIncidentsTimeRanges(span, now);
   const safeFetch = useSafeFetch();
   const title = t('Incidents');
 
   const incidentTypeFilter = (t) => ({
-    filter: (filter, incident) => filterIncident(incident, filter),
+    filter: filterIncident,
     filterGroupName: t('Incident type'),
-    isMatch: () => console.log('here should be filter state'),
+    isMatch: incidentsMatcher,
     items: [
       { id: 'long-standing', title: t('Long standing') },
       { id: 'informative', title: t('Informative') },

--- a/src/components/Incidents/utils.js
+++ b/src/components/Incidents/utils.js
@@ -197,6 +197,7 @@ export function processIncidentTimestamps(data) {
       type: incident.metric.type,
       values: processedValues,
       x: incidents.length - index,
+      state: 'informative',
     };
   });
 }
@@ -249,7 +250,7 @@ export const getIncidentsTimeRanges = (timespan, maxEndTime = Date.now()) => {
  * };
  *
  */
-export function filterIncident(incident, filters) {
+export function filterIncident(filters, incident) {
   const { selected } = filters;
   const currentDate = new Date(); // Get the current date and time in UTC
   const currentDay = currentDate.getUTCDate();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/42de826d-288f-4515-b14c-b6d919894890)

1. Set up matcher function so it could provide label numbers for filter dropdown
2. I refactored the processIncidentTimestamps a bit so it could assign boolean values correctly

In the next PR I will look into refactoring filterIncident function so I could utilize these boolean values for filtering and avoid doing double filtering