### PR TITLE
OCPBUGS-43243: upgrade dynamic plugin sdk to remove vulnerable dependencies 4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@lezer/common": "^1.0.0",
     "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0",
-    "@openshift-console/dynamic-plugin-sdk": "^0.0.20",
+    "@openshift-console/dynamic-plugin-sdk": "^0.0.21",
     "@openshift-console/dynamic-plugin-sdk-internal": "^0.0.11",
     "@openshift-console/dynamic-plugin-sdk-webpack": "^0.0.10",
     "@openshift-console/plugin-shared": "^0.0.3",
@@ -91,7 +91,8 @@
   },
   "resolutions": {
     "webpack": "^5.76.0",
-    "tough-cookie": "^4.1.3"
+    "tough-cookie": "^4.1.3",
+    "path-to-regexp": "^0.1.10"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,10 +455,10 @@
     semver "6.x"
     webpack "^5.73.0"
 
-"@openshift-console/dynamic-plugin-sdk@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.20.tgz#87cbcaf1d8e79dded9a982fadf6fbd2342590be1"
-  integrity sha512-QdOftHavKJErW4LUl7ntT7Hajj/kJJQOC7TjMAdiAyiCYxmHk0WydT6IYarCF+bRSGD2BxbBivMXYriNU8w3tg==
+"@openshift-console/dynamic-plugin-sdk@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.21.tgz#6e8db3dfe7cda2b8d9b3ab2cc72dbe6125fe92fc"
+  integrity sha512-6ztwhvQRP31casfTPeIf+7x4TuM27rZMHG6oMTYIlxjTpssYTzuCRTdzeSeOw3UUXzCJH25HFj2KXSh3krzAJg==
   dependencies:
     "@patternfly/quickstarts" "2.4.0"
     "@patternfly/react-core" "4.276.8"
@@ -4134,11 +4134,6 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4990,17 +4985,10 @@ path-posix@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
   integrity sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
-
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
+path-to-regexp@0.1.7, path-to-regexp@^0.1.10, path-to-regexp@^1.7.0:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.11.tgz#a527e662c89efc4646dbfa8100bf3e847e495761"
+  integrity sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR

- updates the dynamic plugin sdk to remove vulnerable dependencies
- updates other vulnerable dependencies directly

This PR is done directly to release-4.14 as the sdk dependency support varies for 4.14

