### PR TITLE
OCPBUGS-42851: Refresh interval button on "Observe -> Metrics" page failed to load for admin/developer console

### DIFF
--- a/web/src/components/SimpleSelect.tsx
+++ b/web/src/components/SimpleSelect.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import {
+  Select,
+  SelectList,
+  SelectOption,
+  SelectOptionProps,
+  SelectProps,
+} from '@patternfly/react-core/dist/esm/components/Select';
+import {
+  MenuToggle,
+  MenuToggleElement,
+  MenuToggleProps,
+} from '@patternfly/react-core/dist/esm/components/MenuToggle';
+
+export interface SimpleSelectOption extends Omit<SelectOptionProps, 'content'> {
+  /** Content of the select option. */
+  content: React.ReactNode;
+  /** Value of the select option. */
+  value: string | number;
+}
+
+export interface SimpleSelectProps extends Omit<SelectProps, 'toggle'> {
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<any>;
+  /** Initial options of the select. */
+  initialOptions?: SimpleSelectOption[];
+  /** Callback triggered on selection. */
+  onSelect?: (_event: React.MouseEvent<Element, MouseEvent>, selection: string | number) => void;
+  /** Callback triggered when the select opens or closes. */
+  onToggle?: (nextIsOpen: boolean) => void;
+  /** Flag indicating the select should be disabled. */
+  isDisabled?: boolean;
+  /** Content of the toggle. Defaults to the selected option. */
+  toggleContent?: React.ReactNode;
+  /** Placeholder text for the select input. */
+  placeholder?: string;
+  /** Width of the toggle. */
+  toggleWidth?: string;
+  /** Additional props passed to the toggle. */
+  toggleProps?: MenuToggleProps;
+}
+
+const SimpleSelectBase: React.FunctionComponent<SimpleSelectProps> = ({
+  innerRef,
+  initialOptions,
+  isDisabled,
+  onSelect,
+  onToggle,
+  toggleContent,
+  toggleWidth = '200px',
+  toggleProps,
+  placeholder = 'Select a value',
+  ...props
+}: SimpleSelectProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<SimpleSelectOption | undefined>();
+
+  React.useEffect(() => {
+    const selectedOption = initialOptions?.find((option) => option.selected);
+    setSelected(selectedOption);
+  }, [initialOptions]);
+
+  const simpleSelectOptions = initialOptions?.map((option) => {
+    const { content, value, ...props } = option;
+    const isSelected = selected?.value === value;
+    return (
+      <SelectOption value={value} key={value} isSelected={isSelected} {...props}>
+        {content}
+      </SelectOption>
+    );
+  });
+
+  const onToggleClick = () => {
+    onToggle && onToggle(!isOpen);
+    setIsOpen(!isOpen);
+  };
+
+  const _onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    onSelect && onSelect(_event, value);
+    setSelected(initialOptions.find((o) => o.value === value));
+    onToggle && onToggle(true);
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+      style={
+        {
+          width: toggleWidth,
+        } as React.CSSProperties
+      }
+      {...toggleProps}
+    >
+      {toggleContent ? toggleContent : selected?.content || placeholder}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={_onSelect}
+      onOpenChange={(isOpen) => {
+        onToggle && onToggle(isOpen);
+        setIsOpen(isOpen);
+      }}
+      toggle={toggle}
+      shouldFocusToggleOnSelect
+      ref={innerRef}
+      {...props}
+    >
+      <SelectList>{simpleSelectOptions}</SelectList>
+    </Select>
+  );
+};
+
+export const SimpleSelect = React.forwardRef((props: SimpleSelectProps, ref: React.Ref<any>) => (
+  <SimpleSelectBase {...props} innerRef={ref} />
+));
+
+SimpleSelect.displayName = 'SimpleSelect';

--- a/web/src/components/dropdown-poll-interval.tsx
+++ b/web/src/components/dropdown-poll-interval.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { SimpleSelect, SimpleSelectOption } from './SimpleSelect';
+import { useDispatch } from 'react-redux';
+import { queryBrowserSetPollInterval } from '../actions/observe';
+import { parsePrometheusDuration } from './console/utils/datetime';
+import { useTranslation } from 'react-i18next';
+
+export const DropDownPollInterval: React.FunctionComponent = () => {
+  const OFF_KEY = 'OFF_KEY';
+  const { t } = useTranslation('plugin__monitoring-plugin');
+  const [selected, setSelected] = React.useState<string | undefined>(OFF_KEY);
+
+  const dispatch = useDispatch();
+  const setInterval = React.useCallback(
+    (v: number) => dispatch(queryBrowserSetPollInterval(v)),
+    [dispatch],
+  );
+
+  const initialOptions = React.useMemo<SimpleSelectOption[]>(() => {
+    const intervalOptions: SimpleSelectOption[] = [
+      { content: t('Refresh off'), value: OFF_KEY },
+      { content: t('{{count}} second', { count: 15 }), value: '15s' },
+      { content: t('{{count}} second', { count: 30 }), value: '30s' },
+      { content: t('{{count}} minute', { count: 1 }), value: '1m' },
+      { content: t('{{count}} minute', { count: 15 }), value: '15m' },
+      { content: t('{{count}} hour', { count: 1 }), value: '1h' },
+      { content: t('{{count}} hour', { count: 2 }), value: '2h' },
+      { content: t('{{count}} day', { count: 1 }), value: '1d' },
+    ];
+    return intervalOptions.map((o) => ({ ...o, selected: o.value === selected }));
+  }, [selected, t]);
+
+  const onSelect = (_ev, selection) => {
+    setSelected(String(selection));
+    setInterval(parsePrometheusDuration(String(selection)));
+  };
+
+  return (
+    <SimpleSelect
+      initialOptions={initialOptions}
+      onSelect={(_ev, selection) => onSelect(_ev, selection)}
+      placeholder={t('Refresh off')}
+      className="monitoring-dashboards__variable-dropdown"
+      toggleWidth="150px"
+    />
+  );
+};

--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -57,7 +57,6 @@ import {
   queryBrowserPatchQuery,
   queryBrowserRunQueries,
   queryBrowserSetAllExpanded,
-  queryBrowserSetPollInterval,
   queryBrowserToggleAllSeries,
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
@@ -78,7 +77,6 @@ import { LoadingInline } from './console/utils/status-box';
 
 import { useBoolean } from './hooks/useBoolean';
 import KebabDropdown from './kebab-dropdown';
-import IntervalDropdown from './poll-interval-dropdown';
 import { colors, Error, QueryBrowser } from './query-browser';
 import TablePagination from './table-pagination';
 import { PrometheusAPIError, RootState } from './types';
@@ -89,6 +87,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
 import { usePerspective } from './hooks/usePerspective';
 import { useActiveNamespace } from './console/console-shared/hooks/useActiveNamespace';
+import { DropDownPollInterval } from './dropdown-poll-interval';
 
 // Stores information about the currently focused query input
 let focusedQuery;
@@ -1042,20 +1041,6 @@ const QueriesList: React.FC<{ customDatasource?: CustomDataSource }> = ({ custom
   );
 };
 
-const PollIntervalDropdown = () => {
-  const interval = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'pollInterval']),
-  );
-
-  const dispatch = useDispatch();
-  const setInterval = React.useCallback(
-    (v: number) => dispatch(queryBrowserSetPollInterval(v)),
-    [dispatch],
-  );
-
-  return <IntervalDropdown interval={interval} setInterval={setInterval} />;
-};
-
 const QueryBrowserPage_: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
 
@@ -1137,7 +1122,7 @@ const QueryBrowserPage_: React.FC = () => {
         <h1 className="co-m-pane__heading">
           <span>{t('Metrics')}</span>
           <div className="co-actions">
-            <PollIntervalDropdown />
+            <DropDownPollInterval />
             <MetricsActionsMenu />
           </div>
         </h1>


### PR DESCRIPTION
## Related Issue 
[OCPBUGS-42851](https://issues.redhat.com/browse/OCPBUGS-42851) Refresh interval button on "Observe -> Metrics" page failed to load for admin/developer console

## Screenshots 
### Before
<img width="1512" alt="OCPBUGS-42851_error" src="https://github.com/user-attachments/assets/5ea8a589-7aeb-4376-94b5-978aa11596d3">
Figure 1. Runtime Error produced by bug. 
<img width="1512" alt="OCPBUGS-42851_Admin_before" src="https://github.com/user-attachments/assets/41f7ade7-f4a6-41eb-9f47-5949da2efbcb">
Figure 2. Admin > Observe > Metrics > Interval Dropdown is not functional. 
<img width="1512" alt="OCPBUGS-42851_dev_before" src="https://github.com/user-attachments/assets/bd03cf6f-ecfc-491d-a122-a78e29428603">
Figure 3. Dev > Observe > Metrics > Interval Dropdown is not functional. 

### After
<img width="1512" alt="OCPBUGS-42851_dev_after" src="https://github.com/user-attachments/assets/ca642f34-1d2e-44e6-ad87-2da363f3c5a4">
Figure 4. Admin > Observe > Metrics > Interval Dropdown is replaced with a functional dropdown. 
<img width="1512" alt="OCPBUGS-42851_dev_after" src="https://github.com/user-attachments/assets/a682ffd7-6349-4413-b3d0-1c7cf32be3e0">
Figure 5. Admin > Observe > Metrics > Interval Dropdown is replaced with a functional dropdown. 

