### PR TITLE
OU-257: Migrate Developer View > Observe > Silences Tab from openshift/console to openshift/monitoring-plugin

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -110,6 +110,33 @@
     }
   },
   {
+    "type": "console.tab",
+    "properties": {
+      "contextId": "dev-console-observe",
+      "name": "%plugin__monitoring-plugin~Silences%",
+      "href": "silences",
+      "component": {
+        "$codeRef": "MonitoringUI"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": ["/dev-monitoring/ns/:ns/silences/:id"],
+      "component": { "$codeRef": "MonitoringUI" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": ["/dev-monitoring/ns/:ns/silences/:id/:edit"],
+      "component": { "$codeRef": "MonitoringUI" }
+    }
+  },
+  {
     "type": "console.redux-reducer",
     "properties": {
       "scope": "monitoring",

--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -9,6 +9,7 @@ import {
   Rule,
   TableColumn,
   Timestamp,
+  useActiveNamespace,
   useListPageFilter,
   useResolvedExtensions,
   VirtualizedTable,
@@ -35,7 +36,6 @@ import { Link, Redirect, Route, RouteComponentProps, Switch, withRouter } from '
 
 // TODO: These will be available in future versions of the plugin SDK
 import { formatPrometheusDuration } from './console/utils/datetime';
-import { useActiveNamespace } from './console/console-shared/hooks/useActiveNamespace';
 
 import { withFallback } from './console/console-shared/error/error-boundary';
 import {
@@ -646,7 +646,7 @@ const PollerPages = () => {
   const dispatch = useDispatch();
 
   const { alertingContextId, perspective } = usePerspective();
-  const namespace = useActiveNamespace();
+  const [namespace] = useActiveNamespace();
 
   const [customExtensions] =
     useResolvedExtensions<AlertingRulesSourceExtension>(isAlertingRulesSource);
@@ -688,6 +688,9 @@ const PollerPages = () => {
         <Route path="/dev-monitoring/ns/:ns/alerts" exact component={AlertsPage} />
         <Route path="/dev-monitoring/ns/:ns/alerts/:ruleID" component={AlertsDetailsPage} />
         <Route path="/dev-monitoring/ns/:ns/metrics" exact component={QueryBrowserPage} />
+        <Route path="/dev-monitoring/ns/:ns/silences" exact component={SilencesPage} />
+        <Route path="/dev-monitoring/ns/:ns/silences/:id" exact component={SilencesDetailsPage} />
+        <Route path="/dev-monitoring/ns/:ns/silences/:id/edit" exact component={EditSilence} />
       </Switch>
     );
   }
@@ -729,6 +732,7 @@ const MonitoringUI = () => {
       <Route path="/monitoring/graph" exact component={PrometheusUIRedirect} />
       <Route path="/monitoring/query-browser" exact component={QueryBrowserPage} />
       <Route path="/monitoring/silences/~new" exact component={CreateSilence} />
+      <Route path="/dev-monitoring/ns/:ns/silences/~new" exact component={CreateSilence} />
       <Route path="/monitoring/targets" component={TargetsUI} />
       <Route component={PollerPages} />
     </Switch>

--- a/web/src/components/alerting/AlertsDetailPage.tsx
+++ b/web/src/components/alerting/AlertsDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   Silence,
   TableColumn,
   VirtualizedTable,
+  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   AlertingRuleChartExtension,
@@ -83,7 +84,8 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
 
   const { alertsKey, alertingContextId, silencesKey, perspective } = usePerspective();
 
-  const namespace = match.params?.ns;
+  const [namespace] = useActiveNamespace();
+
   const hideGraphs = useSelector(
     (state: MonitoringState) => !!getObserveState(perspective, state)?.get('hideGraphs'),
   );

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -19,6 +19,7 @@ import {
   Silence,
   SilenceStates,
   TableColumn,
+  useActiveNamespace,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -32,7 +33,6 @@ import { EmptyBox } from '../console/utils/status-box';
 import { withFallback } from '../console/console-shared/error/error-boundary';
 import { useBoolean } from '../hooks/useBoolean';
 import { Link } from 'react-router-dom';
-import { useActiveNamespace } from '../console/console-shared/hooks/useActiveNamespace';
 
 const SilencesPage_: React.FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -266,11 +266,15 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
 
   const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
 
+  const [namespace] = useActiveNamespace();
+
+  console.log('ExpireAllSilencesButton > namespace: ', { namespace });
+
   const onClick = () => {
     setInProgress();
     Promise.allSettled(
       [...selectedSilences].map((silenceID: string) =>
-        consoleFetchJSON.delete(getFetchSilenceUrl(perspective, silenceID)),
+        consoleFetchJSON.delete(getFetchSilenceUrl(perspective, silenceID, namespace)),
       ),
     ).then((values) => {
       setNotInProgress();
@@ -307,7 +311,7 @@ const SilenceTableRowWithCheckbox: React.FC<RowProps<Silence>> = ({ obj }) => (
 const CreateSilenceButton: React.FC = React.memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
-  const namespace = useActiveNamespace();
+  const [namespace] = useActiveNamespace();
 
   return (
     <Link className="co-m-primary-action" to={getNewSilenceUrl(perspective, namespace)}>

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -268,8 +268,6 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
 
   const [namespace] = useActiveNamespace();
 
-  console.log('ExpireAllSilencesButton > namespace: ', { namespace });
-
   const onClick = () => {
     setInProgress();
     Promise.allSettled(

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -149,9 +149,7 @@ const SilencesPage_: React.FC = () => {
 
   return (
     <>
-      <Helmet>
-        <title>Alerting</title>
-      </Helmet>
+      <Helmet>{perspective === 'dev' ? <title>Silences</title> : <title>Alerting</title>}</Helmet>
       <div className="co-m-pane__body">
         <SelectedSilencesContext.Provider value={{ selectedSilences, setSelectedSilences }}>
           <Flex>

--- a/web/src/components/silence-form.tsx
+++ b/web/src/components/silence-form.tsx
@@ -1,5 +1,10 @@
 import * as _ from 'lodash-es';
-import { consoleFetchJSON, Silence, SilenceStates } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  consoleFetchJSON,
+  Silence,
+  SilenceStates,
+  useActiveNamespace,
+} from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   ActionGroup,
@@ -158,8 +163,8 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
     defaults.matchers ?? [{ isRegex: false, name: '', value: '' }],
   );
   const [startsAt, setStartsAt] = React.useState(defaults.startsAt ?? formatDate(now));
-
   const user = useSelector(getUser);
+  const [namespace] = useActiveNamespace();
 
   React.useEffect(() => {
     if (!createdBy && user) {
@@ -202,7 +207,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
       return;
     }
 
-    const url = getFetchSilenceAlertUrl(perspective);
+    const url = getFetchSilenceAlertUrl(perspective, namespace);
     if (!url) {
       setError('Alertmanager URL not set');
       return;
@@ -226,11 +231,11 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
     };
 
     consoleFetchJSON
-      .post(getFetchSilenceAlertUrl(perspective), body)
+      .post(getFetchSilenceAlertUrl(perspective, namespace), body)
       .then(({ silenceID }) => {
         setError(undefined);
-        refreshSilences(dispatch, perspective, silencesKey);
-        history.push(getSilenceAlertUrl(perspective, silenceID));
+        refreshSilences(dispatch, perspective, silencesKey, namespace);
+        history.push(getSilenceAlertUrl(perspective, silenceID, namespace));
       })
       .catch((err) => {
         const errorMessage =

--- a/web/src/components/utils.ts
+++ b/web/src/components/utils.ts
@@ -119,15 +119,20 @@ export const refreshSilences = (
   dispatch: Dispatch,
   perspective: Perspective,
   silencesKey: silencesKey,
+  namespace?: string,
 ): void => {
   const { alertManagerBaseURL } = window.SERVER_FLAGS;
   if (!alertManagerBaseURL) {
     return;
   }
 
+  if (perspective === 'dev' && !namespace) {
+    return;
+  }
+
   dispatch(alertingLoading(silencesKey, perspective));
 
-  consoleFetchJSON(getFetchSilenceAlertUrl(perspective))
+  consoleFetchJSON(getFetchSilenceAlertUrl(perspective, namespace))
     .then((silences) => {
       // Set a name field on the Silence to make things easier
       _.each(silences, (s) => {


### PR DESCRIPTION
## Relates issues

### OU JIRA 
https://issues.redhat.com/browse/OU-257

### CONSOLE JIRA 
https://issues.redhat.com/browse/CONSOLE-4330
This duplicate issue was created because openshift/console github bots require a valid CONSOLE Jira to be associated with all PRs. 

### Corresponding PR to remove 'Silences' tab from `openshift/console`
https://github.com/openshift/console/pull/14480


## Description 
To consolidate the code of the` Developer View > Observe > Silences Tab` is being moved from `openshift/console` to `openshift/monitoring-plugin`.

- This PR renders the 'Silences' tab in the openshift/monitoring-plugin. 
- The corresponding [PR](https://github.com/openshift/console/pull/14480) removes the 'Silences' tab in the openshift/console. 

## Testing Notes
- This PR should be tested with https://github.com/openshift/console/pull/14480
- All functionalities should be the same as before. No new features were added. 