### PR TITLE
NO-JIRA: remove incidents from default extensions

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -18,8 +18,7 @@
         "/monitoring/graph",
         "/monitoring/query-browser",
         "/monitoring/silences",
-        "/monitoring/targets",
-        "/monitoring/incidents"
+        "/monitoring/targets"
       ],
       "component": { "$codeRef": "MonitoringUI" }
     }
@@ -35,7 +34,7 @@
       "href": "/monitoring/alerts",
       "perspective": "admin",
       "section": "observe",
-      "startsWith": ["monitoring/alertrules", "monitoring/silences", "monitoring/incidents"]
+      "startsWith": ["monitoring/alertrules", "monitoring/silences"]
     }
   },
   {


### PR DESCRIPTION
This pr removes the incidents extensions from the default extensions as it should be loaded only when enabling the `incidents` feature