### PR TITLE
NO-JIRA: Update readme and deployment scripts

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,3 +1,5 @@
+# mcp (monitoring-console-plugin)
+
 FROM registry.redhat.io/ubi9/nodejs-18:latest AS web-builder
 
 USER 0

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ start-backend:
 build-image:
 	./scripts/build-image.sh
 
+
 .PHONY: install
 install:
 	make install-frontend && make install-backend
@@ -75,3 +76,7 @@ deploy:
 .PHONY: deploy-acm
 deploy-acm:
 	./scripts/deploy-acm.sh
+
+.PHONY: build-mcp-image
+build-mcp-image:
+	DOCKER_FILE_NAME="Dockerfile.mcp" scripts/build-image.sh

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -43,6 +43,7 @@ type Feature string
 
 const (
 	AcmAlerting Feature = "acm-alerting"
+	Incidents   Feature = "incidents"
 )
 
 func (pluginConfig *PluginConfig) MarshalJSON() ([]byte, error) {

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -8,6 +8,22 @@ TAG="${TAG:-v1.0.0}"
 REGISTRY_ORG="${REGISTRY_ORG:-openshift-observability-ui}"
 DOCKER_FILE_NAME="${DOCKER_FILE_NAME:-Dockerfile.dev}"
 
+# Terminal output colors
+YELLOW='\033[0;33m'
+ENDCOLOR='\033[0m' # No Color
+RED='\033[0;31m'
+
+
+# due to apple silicon limitation with installing npm packages inside amd64 images, builds of the frontend must be done outside the dockerfile.
+if [[ "$OSTYPE" == "darwin"* ]] && [[ "$DOCKER_FILE_NAME" == "Dockerfile.mcp" ]]; then
+    printf "${YELLOW}Updateing plugin-name ${ENDCOLOR}\n"
+    make update-plugin-name
+    export I18N_NAMESPACE='plugin__monitoring-console-plugin'
+
+    printf "${YELLOW}Building Frontend${ENDCOLOR}\n"
+    make build-frontend
+fi
+
 if [[ -x "$(command -v podman)" && $PREFER_PODMAN == 1 ]]; then
     OCI_BIN="podman"
 else
@@ -17,9 +33,20 @@ fi
 BASE_IMAGE="quay.io/${REGISTRY_ORG}/monitoring-plugin"
 IMAGE=${BASE_IMAGE}:${TAG}
 
+make lint-backend
+
 echo "Building image '${IMAGE}' with ${OCI_BIN}"
 $OCI_BIN build -t $IMAGE --platform=linux/amd64 -f $DOCKER_FILE_NAME .
 
 if [[ $PUSH == 1 ]]; then
     $OCI_BIN push $IMAGE
+fi
+
+
+# Rollback local changes made
+if [[ "$OSTYPE" == "darwin"* ]] && [[ "$DOCKER_FILE_NAME" == "Dockerfile.mcp" ]]; then
+    printf "${YELLOW}Replacing in package.json and values.yaml${ENDCOLOR}\n"
+    sed -i 's/"name": "monitoring-console-plugin",/"name": "monitoring-plugin",/g' web/package.json
+    printf "${YELLOW}Renaming translations to the original plugin name${ENDCOLOR}\n"
+    cd web/locales/ && for dir in *; do if cd $dir; then  for filename in *; do mv plugin__monitoring-console-plugin.json plugin__monitoring-plugin.json; done; cd ..; fi; done
 fi

--- a/scripts/deploy-acm.sh
+++ b/scripts/deploy-acm.sh
@@ -10,36 +10,20 @@ if ! [ -x "$(command -v yq)" ]; then
   exit 1
 fi
 
-
-
 if [[ "$OSTYPE" == "darwin"* ]]
 then
     # due to mac limitation with installing packages inside of dockerfiles, builds of the frontend must be done outside the dockerfile.
-    printf "${YELLOW}Updateing plugin-name ${ENDCOLOR}\n"
+    printf "${YELLOW}Enabling ACM plugin-name ${ENDCOLOR}\n"
     yq -i '.plugin.acm.enabled = true' charts/openshift-console-plugin/values.yaml
-    make update-plugin-name
-    export I18N_NAMESPACE='plugin__monitoring-console-plugin'
-
-    printf "${YELLOW}Building Frontend${ENDCOLOR}\n"
-    make build-frontend
 fi
 
-
-export DOCKER_FILE_NAME=Dockerfile.acm
+export DOCKER_FILE_NAME=Dockerfile.mcp
 make deploy
 
 if [[ "$OSTYPE" == "darwin"* ]]
 then
-    osascript -e 'display notification "Plugin Deployed" with title "Monitoring Plugin"'
-fi
-
-
-if [[ "$OSTYPE" == "darwin"* ]]
-then
     # rollback changes
-    printf "${YELLOW}Replacing in package.json and values.yaml${ENDCOLOR}\n"
-    sed -i 's/"name": "monitoring-console-plugin",/"name": "monitoring-plugin",/g' web/package.json
-    printf "${YELLOW}Renaming translations to the original plugin name${ENDCOLOR}\n"
+    printf "${YELLOW}Disabling ACM features${ENDCOLOR}\n"
     yq -i '.plugin.acm.enabled = false' charts/openshift-console-plugin/values.yaml
-    cd web/locales/ && for dir in *; do if cd $dir; then  for filename in *; do mv plugin__monitoring-console-plugin.json plugin__monitoring-plugin.json; done; cd ..; fi; done
+    osascript -e 'display notification "Plugin Deployed" with title "Monitoring Plugin"'
 fi


### PR DESCRIPTION
This PR looks to decouple the monitoring-console-plugin information and scripts from the acm-alerting feature