### PR TITLE
OCPBUGS-44447: Don't set property on undefined variable

### DIFF
--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -180,7 +180,11 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       const firingAlerts = _.filter(alerts?.data, isAlertFiring);
       silenceFiringAlerts(firingAlerts, silences);
       silenceFiringAlerts(_.filter(notificationAlerts?.data, isAlertFiring), silences);
-      notificationAlerts.data = _.reject(notificationAlerts?.data, { state: AlertStates.Silenced });
+      if (notificationAlerts?.data) {
+        notificationAlerts.data = _.reject(notificationAlerts?.data, {
+          state: AlertStates.Silenced,
+        });
+      }
       state = state.set(alertsKey, alerts);
       state = state.set('notificationAlerts', notificationAlerts);
 


### PR DESCRIPTION
Don't try to set the notificationAlerts.data until it has been initialized. 

Bug is able to be reproduced when refreshing the alerting page or opening the alerting page in a new tab.