### PR TITLE
OU-584: Fix issues preventing the incidents tab from showing

### DIFF
--- a/config/incidents.patch.json
+++ b/config/incidents.patch.json
@@ -1,4 +1,5 @@
-[{
+[
+  {
     "op": "add",
     "path": "/extensions/0",
     "value": {
@@ -6,7 +7,7 @@
       "properties": {
         "exact": false,
         "path": "/monitoring/incidents",
-        "component": { "$codeRef": "MonitoringUI" }
+        "component": { "$codeRef": "IncidentsPage" }
       }
     }
   },
@@ -16,15 +17,16 @@
     "value": {
       "type": "console.navigation/href",
       "flags": {
-      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
-    },
+        "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+      },
       "properties": {
-        "id": "alerting",
-        "name": "%plugin__monitoring-plugin~Alerting%",
-        "href": "/monitoring/alerts",
+        "id": "incidents",
+        "name": "%plugin__monitoring-plugin~Incidents%",
+        "href": "/monitoring/incidents",
         "perspective": "admin",
         "section": "observe",
-        "startsWith": ["monitoring/incidents"]
+        "insertAfter": "targets"
       }
     }
-  }]
+  }
+]

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -137,13 +137,6 @@
     }
   },
   {
-    "type": "console.redux-reducer",
-    "properties": {
-      "scope": "monitoring",
-      "reducer": { "$codeRef": "MonitoringReducer" }
-    }
-  },
-  {
     "type": "console.tab",
     "properties": {
       "contextId": "dev-console-observe",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:openshift/monitoring-plugin.git",
   "scripts": {
-    "build": "npm run clean && NODE_ENV=production npm run ts-node node_modules/.bin/webpack",
+    "build": "npm run clean && NODE_ENV=production CONSOLE_PLUGIN_SKIP_EXT_VALIDATOR=true npm run ts-node node_modules/.bin/webpack",
     "build:dev": "npm run clean && npm run ts-node node_modules/.bin/webpack",
     "build:standalone": "npm run clean && npm run ts-node node_modules/.bin/webpack --config webpack.standalone.config.ts",
     "clean": "rm -rf dist",
@@ -106,7 +106,8 @@
     "description": "This plugin adds the monitoring UI to the OpenShift web console",
     "exposedModules": {
       "MonitoringUI": "./components/alerting",
-      "MonitoringReducer": "./reducers/observe"
+      "MonitoringReducer": "./reducers/observe",
+      "IncidentsPage": "./components/Incidents/IncidentsPage"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -42,6 +42,7 @@ import {
   setIncidentsActiveFilters,
 } from '../../actions/observe';
 import { useLocation } from 'react-router-dom';
+import { withFallback } from '../console/console-shared/error/error-boundary';
 
 const IncidentsPage = ({ customDataSource, namespace = '#ALL_NS#' }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -329,4 +330,6 @@ const IncidentsPage = ({ customDataSource, namespace = '#ALL_NS#' }) => {
   );
 };
 
-export default IncidentsPage;
+const incidentsPageWithFallback = withFallback(IncidentsPage);
+
+export default incidentsPageWithFallback;

--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -99,7 +99,6 @@ import { useSilencesPoller } from './hooks/useSilencesPoller';
 import { MonitoringState } from '../reducers/observe';
 import SilencesPage from './alerting/SilencesPage';
 import SilencesDetailsPage from './alerting/SilencesDetailPage';
-import IncidentsPage from '../components/Incidents/IncidentsPage';
 
 const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -602,8 +601,6 @@ const Tab: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active,
   </li>
 );
 
-const incidentsPageWithFallback = withFallback(IncidentsPage);
-
 const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
@@ -611,7 +608,6 @@ const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match })
   const alertsPath = getAlertsUrl(perspective);
   const rulesPath = getAlertRulesUrl(perspective);
   const silencesPath = getSilencesUrl(perspective);
-  const incidentsPath = '/monitoring/incidents';
 
   const { url } = match;
 
@@ -630,9 +626,6 @@ const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match })
         <Tab active={url === alertsPath}>
           <Link to={alertsPath}>{t('Alerts')}</Link>
         </Tab>
-        <Tab active={url === incidentsPath}>
-          <Link to={incidentsPath}>{t('Incidents')}</Link>
-        </Tab>
         <Tab active={url === silencesPath}>
           <Link to={silencesPath}>{t('Silences')}</Link>
         </Tab>
@@ -644,7 +637,6 @@ const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match })
         <Route path={alertsPath} exact component={AlertsPage} />
         <Route path={rulesPath} exact component={RulesPage} />
         <Route path={silencesPath} exact component={SilencesPage} />
-        <Route path={incidentsPath} exact component={incidentsPageWithFallback} />
       </Switch>
     </>
   );

--- a/web/src/components/hooks/useFeatures.ts
+++ b/web/src/components/hooks/useFeatures.ts
@@ -5,13 +5,16 @@ const URL_POLL_DEFAULT_DELAY = 60000; // 60 seconds
 
 type features = {
   'acm-alerting': boolean;
+  incidents: boolean;
 };
 type featuresResponse = {
   'acm-alerting'?: boolean;
+  incidents?: boolean;
 };
 
 const noFeatures: features = {
   'acm-alerting': false,
+  incidents: false,
 };
 
 export const useFeatures = () => {
@@ -32,5 +35,6 @@ export const useFeatures = () => {
   return {
     features,
     acmAlertingActive: features['acm-alerting'],
+    incidentsActive: features.incidents,
   };
 };


### PR DESCRIPTION
This PR looks to fix the extension points used by the incidents tab.

It no longer places incidents as a tab under Alerting, but instead as a new Tab under Observe.

It also removes the monitoring-plugin reducer from the CMO deployment, as the CMO reducer interferes with the creation of the incidents state in the plugin store.

Finally, it prevents the validation of the console-extension.json file during build in the package.json, as the validation doesn't allow for exposed modules without them being used. However, we need to do this, so that the extension patches can have access to things that the monitoring-plugin doesn't need. 