### PR TITLE
RHINENG-14523: Fix expanded row won't render without rule details + firing logic update

### DIFF
--- a/web/src/components/Incidents/IncidentsTable.jsx
+++ b/web/src/components/Incidents/IncidentsTable.jsx
@@ -10,13 +10,12 @@ import {
   Label,
 } from '@patternfly/react-core';
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
-import { AlertStateIcon } from '../alerting/AlertUtils';
 import IncidentsDetailsRowTable from './IncidentsDetailsRowTable';
-import { SearchIcon } from '@patternfly/react-icons';
+import { BellIcon, BellSlashIcon, SearchIcon } from '@patternfly/react-icons';
 import { useSelector } from 'react-redux';
 import * as _ from 'lodash-es';
 
-export const IncidentsTable = () => {
+export const IncidentsTable = ({ namespace }) => {
   const columnNames = {
     checkbox: '',
     component: 'Component',
@@ -105,14 +104,21 @@ export const IncidentsTable = () => {
                       )}
                     </Td>
                     <Td dataLabel={columnNames.state}>
-                      <AlertStateIcon state={alert.alertstate} />
+                      {alert.alertstate === 'resolved' ? (
+                        <BellSlashIcon className="text-muted" />
+                      ) : (
+                        <BellIcon />
+                      )}
                     </Td>
                   </Tr>
                   {alert.alertsExpandedRowData && (
                     <Tr isExpanded={isAlertExpanded(alert)}>
                       <Td width={100} colSpan={6}>
                         <ExpandableRowContent>
-                          <IncidentsDetailsRowTable alerts={alert.alertsExpandedRowData} />
+                          <IncidentsDetailsRowTable
+                            alerts={alert.alertsExpandedRowData}
+                            namespace={namespace}
+                          />
                         </ExpandableRowContent>
                       </Td>
                     </Tr>

--- a/web/src/components/Incidents/api.js
+++ b/web/src/components/Incidents/api.js
@@ -69,7 +69,7 @@ export const fetchDataForIncidentsAndAlerts = (fetch, range, customQuery, perspe
         endTime: range.endTime,
         namespace: '',
         query: customQuery,
-        samples: 24,
+        samples: 288,
         timespan: range.duration - 1,
       },
       perspective,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-14523
1) Updated sample resolution to 288 per day, which allows us to see data from incidents much faster ~10 minutes now
2)  Updated logic that gathers rows for expanded details table. If, for some reason, there is no rule matching the alert name -> we disable the link to that rule + add a tooltip with helper text. We disable kebab actions as well.
3)Updated logic that renders firing/resolved icon in expanded details
4)Updated logic that gathers components for the main table. Now, it has an additional step - it reads the alerts assigned to the "component" and checks their "alertstate", if at least 1 alert has a firing status -> the component will have a firing status. If all of the alerts assigned to the "component" are resolved -> the component will have a resolved state.
Based on that firing/resolved we show a different icon in the main table.