### PR TITLE
OCPBUGS-45896: Fix admin console alert detail graph

### DIFF
--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -780,7 +780,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                 {
                   endpoint: PrometheusEndpoint.QUERY_RANGE,
                   endTime: timeRange.endTime,
-                  namespace: perspective === 'dev' ? activeNamespace : namespace,
+                  namespace: perspective === 'dev' ? activeNamespace : '',
                   query,
                   samples: Math.ceil(samples / timeRanges.length),
                   timeout: '60s',


### PR DESCRIPTION
When retrieving the prometheus URL to query, the embedded query-browser was using the passed in namespace in the admin console (which can exist) when it should instead not be passing in any namespace, as the query will go against the whole cluster not a specific namespace