### PR TITLE
NO-JIRA: Run webpack with a different port

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -80,7 +80,7 @@ const config: Configuration = {
   },
   devServer: {
     static: './dist',
-    port: 9001,
+    port: process.env.PORT || 9001,
     // Allow bridge running in a container to connect to the plugin dev server.
     allowedHosts: 'all',
     headers: {


### PR DESCRIPTION
We use some scripts to run monitoring plugin in a different port sometimes. 
It would be cool to have this env in the configuration so we don't have to manually edit the code locally. 