### PR TITLE
OCPBUGS-45816: Fix inverted dropdown toggle

### DIFF
--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -433,12 +433,14 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
   const { perspective } = usePerspective();
 
   const isDisabledSeriesEmpty = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn([
-      'queryBrowser',
-      'queries',
-      index,
-      'disabledSeries',
-    ]),
+    _.isEmpty(
+      getObserveState(perspective, state)?.getIn([
+        'queryBrowser',
+        'queries',
+        index,
+        'disabledSeries',
+      ]),
+    ),
   );
   const isEnabled = useSelector((state: MonitoringState) =>
     getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isEnabled']),


### PR DESCRIPTION
When adding the ACM alerting UI, a new `getObserveState` function was needed to differentiate between the `monitoring-plugin` and the `monitoring-console-plugin`. In that transition, a _.isEmpty was left out thus leading to a non-empty state being truthy and the "Show all Series" and "Hide all Series" labels being inverted.

Diff for the ACM alerting UI change [here](https://github.com/PeterYurkovich/monitoring-plugin/commit/7c5041011bc907e38dbd17444fcf6e3a5ef71f89#diff-a2a8476ebef76322a9d8bb44354180785556a35b0719cfcea420bb7386a1de7bR432). This will link to the right line, but its a large webpage so may take a second to load