### PR TITLE
OCPBUGS-45801: Allow editing the until field on the silence edit page

### DIFF
--- a/web/src/components/silence-form.tsx
+++ b/web/src/components/silence-form.tsx
@@ -283,7 +283,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
                   <DatetimeTextInput
                     data-test="silence-from"
                     isRequired
-                    onChange={(v: string) => setStartsAt(v)}
+                    onChange={(_event, value: string) => setStartsAt(value)}
                     value={startsAt}
                   />
                 )}
@@ -319,7 +319,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, history, Info, tit
                   <DatetimeTextInput
                     data-test="silence-until"
                     isRequired
-                    onChange={(v: string) => setEndsAt(v)}
+                    onChange={(_event, value: string) => setEndsAt(value)}
                     value={endsAt}
                   />
                 ) : (


### PR DESCRIPTION
This PR looks to bring the fix added in openshift/console#13926 to the monitoring plugin. As correctly predicted by @kyoto [here](https://github.com/openshift/console/pull/13926#issuecomment-2151200540) now that we have moved from Patternfly 4 to 5, this fix is needed in the monitoring-plugin as well. 