### PR TITLE
OCPBUGS-45174: Fix bounds on bar chart

### DIFF
--- a/web/src/components/console/graphs/bar.tsx
+++ b/web/src/components/console/graphs/bar.tsx
@@ -97,7 +97,7 @@ const BarChart: React.FC<BarChartProps> = ({
                 theme={theme}
                 height={barWidth + padding.bottom}
                 width={width}
-                domain={{ y: [0, data[0].y] }}
+                domain={{ y: [0, data.reduce((max, datum) => Math.max(max, datum.y), 0)] }}
                 padding={padding}
               />
             </div>


### PR DESCRIPTION
This PR looks to solve an issue which led the length of an individual bar on a bar chart to exceed the bounds of the bar chart. 

Before: 
![Screenshot 2024-12-11 at 9 40 51 AM](https://github.com/user-attachments/assets/ce901a91-2bc9-47f5-badd-6b8041f125bd)


After:
![Screenshot 2024-12-11 at 9 40 08 AM](https://github.com/user-attachments/assets/32c87499-f11f-4e72-b7ea-d4c185e55caf)

Minimum Dashboard Reproduction:
<details>
<summary><b>Minimum Dashboard Reproduction</b></summary>

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  labels:
    console.openshift.io/dashboard: 'true'
    console.openshift.io/odc-dashboard: 'true'
  name: world-dashboard
  namespace: openshift-config-managed
data:
  etcd.json: |-
    {
      "description": "Test Dashboard to load in the hello world metric",
      "editable": true,
      "gnetId": null,
      "hideControls": false,
      "refresh": "10s",
      "panels": [
        {
          "targets": [
            {
              "expr": "sum(rate(container_network_receive_bytes_total[1m])) by (node)"
            }
          ],
          "title": "title",
          "type": "grafana-piechart-panel"
        }
      ]
    }

```

</details>