### PR TITLE
NO-JIRA: Remove duplicate parameter

### DIFF
--- a/web/src/components/alerting/AlertUtils.tsx
+++ b/web/src/components/alerting/AlertUtils.tsx
@@ -242,7 +242,6 @@ export const Graph: React.FC<GraphProps> = ({
 
   return (
     <QueryBrowser
-      namespace={namespace}
       defaultTimespan={timespan}
       filterLabels={filterLabels}
       formatSeriesTitle={formatSeriesTitle}

--- a/web/src/components/dashboards/graph.tsx
+++ b/web/src/components/dashboards/graph.tsx
@@ -67,7 +67,6 @@ const Graph: React.FC<Props> = ({
       showLegend={showLegend}
       timespan={timespan}
       units={units}
-      namespace={namespace}
       onDataChange={onDataChange}
     />
   );

--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -679,7 +679,6 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   GraphLink,
   hideControls,
   isStack = false,
-  namespace,
   onZoom,
   pollInterval,
   queries,
@@ -757,7 +756,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // Clear any existing series data when the namespace is changed
   React.useEffect(() => {
     dispatch(queryBrowserDeleteAllSeries());
-  }, [dispatch, namespace]);
+  }, [dispatch, activeNamespace]);
 
   const tick = () => {
     if (hideGraphs) {
@@ -780,7 +779,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                 {
                   endpoint: PrometheusEndpoint.QUERY_RANGE,
                   endTime: timeRange.endTime,
-                  namespace: perspective === 'dev' ? activeNamespace : namespace,
+                  namespace: perspective === 'dev' ? activeNamespace : '',
                   query,
                   samples: Math.ceil(samples / timeRanges.length),
                   timeout: '60s',
@@ -908,14 +907,17 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     delay,
     endTime,
     filterLabels,
-    namespace,
+    activeNamespace,
     queriesKey,
     samples,
     span,
     lastRequestTime,
   );
 
-  React.useLayoutEffect(() => setUpdating(true), [endTime, namespace, queriesKey, samples, span]);
+  React.useLayoutEffect(
+    () => setUpdating(true),
+    [endTime, activeNamespace, queriesKey, samples, span],
+  );
 
   const onSpanChange = React.useCallback(
     (newSpan: number) => {
@@ -1112,7 +1114,6 @@ export type QueryBrowserProps = {
   GraphLink?: React.ComponentType;
   hideControls?: boolean;
   isStack?: boolean;
-  namespace?: string;
   onZoom?: GraphOnZoom;
   pollInterval?: number;
   queries: string[];


### PR DESCRIPTION
/hold Until #288 is merged

Clean up some tech debt when we are passing the namespace into the component as a prop, but the useActiveNamespace is already called. 