### PR TITLE
CNV-51386: observe page blank on virt perspective

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -38,6 +38,35 @@
     }
   },
   {
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
+    "properties": {
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-monitoring"
+      },
+      "id": "observe-virt-perspective",
+      "insertBefore": ["compute-virt-perspective", "usermanagement-virt-perspective"],
+      "name": "%console-app~Observe%",
+      "perspective": "virtualization-perspective"
+    },
+    "type": "console.navigation/section"
+  },
+  {
+    "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
+    "properties": {
+      "id": "alerting-virt",
+      "name": "%plugin__monitoring-plugin~Alerting%",
+      "href": "/virt-monitoring/alerts",
+      "perspective": "virtualization-perspective",
+      "section": "observe-virt-perspective",
+      "startsWith": ["virt-monitoring/alertrules", "virt-monitoring/silences"]
+    }
+  },
+  {
     "type": "console.navigation/href",
     "flags": {
       "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
@@ -48,6 +77,20 @@
       "href": "/monitoring/query-browser",
       "perspective": "admin",
       "section": "observe",
+      "insertAfter": "alerts"
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
+    "properties": {
+      "id": "metrics-virt",
+      "name": "%plugin__monitoring-plugin~Metrics%",
+      "href": "/virt-monitoring/query-browser",
+      "perspective": "virtualization-perspective",
+      "section": "observe-virt-perspective",
       "insertAfter": "alerts"
     }
   },
@@ -71,12 +114,40 @@
       "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
     },
     "properties": {
+      "id": "dashboards-virt",
+      "name": "%plugin__monitoring-plugin~Dashboards%",
+      "href": "/virt-monitoring/dashboards",
+      "perspective": "virtualization-perspective",
+      "section": "observe-virt-perspective",
+      "insertAfter": "metrics-virt"
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
+    "properties": {
       "id": "targets",
       "name": "%plugin__monitoring-plugin~Targets%",
       "href": "/monitoring/targets",
       "perspective": "admin",
       "section": "observe",
       "insertAfter": "dashboards"
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
+    },
+    "properties": {
+      "id": "targets-virt",
+      "name": "%plugin__monitoring-plugin~Targets%",
+      "href": "/virt-monitoring/targets",
+      "perspective": "virtualization-perspective",
+      "section": "observe-virt-perspective",
+      "insertAfter": "dashboards-virt"
     }
   },
   {

--- a/web/src/actions/observe.ts
+++ b/web/src/actions/observe.ts
@@ -38,10 +38,10 @@ export enum ActionType {
   SetIncidentsChartSelection = 'setIncidentsChartSelection',
 }
 
-export type Perspective = 'admin' | 'dev' | 'acm';
-export type alertKey = 'alerts' | 'devAlerts' | 'acmAlerts';
-export type silencesKey = 'silences' | 'devSilences' | 'acmSilences';
-export type rulesKey = 'rules' | 'devRules' | 'acmRules' | 'notificationAlerts';
+export type Perspective = 'admin' | 'dev' | 'acm' | 'virtualization-perspective';
+export type alertKey = 'alerts' | 'devAlerts' | 'acmAlerts' | 'virtAlerts';
+export type silencesKey = 'silences' | 'devSilences' | 'acmSilences' | 'virtSilences';
+export type rulesKey = 'rules' | 'devRules' | 'acmRules' | 'notificationAlerts' | 'virtRules';
 
 type AlertingKey = alertKey | silencesKey | rulesKey;
 

--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -714,6 +714,20 @@ const PollerPages = () => {
     );
   }
 
+  if (perspective === 'virtualization-perspective') {
+    return (
+      <Switch>
+        <Route path="/virt-monitoring/alerts" exact component={AlertsPage} />
+        <Route path="/virt-monitoring/rules/:id" exact component={AlertRulesDetailsPage} />
+        <Route path="/virt-monitoring/alerts/:ruleID" component={AlertsDetailsPage} />
+        <Route path="/virt-monitoring/metrics" exact component={QueryBrowserPage} />
+        <Route path="/virt-monitoring/silences" exact component={SilencesPage} />
+        <Route path="/virt-monitoring/silences/:id" exact component={SilencesDetailsPage} />
+        <Route path="/virt-monitoring/silences/:id/edit" exact component={EditSilence} />
+      </Switch>
+    );
+  }
+
   return (
     <Switch>
       <Route

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -15,40 +15,55 @@ type usePerspectiveReturn = {
   rulesKey: rulesKey;
   alertsKey: alertKey;
   silencesKey: silencesKey;
-  alertingContextId: 'dev-observe-alerting' | 'observe-alerting' | 'acm-observe-alerting';
+  alertingContextId:
+    | 'dev-observe-alerting'
+    | 'observe-alerting'
+    | 'acm-observe-alerting'
+    | 'virt-observe-alerting';
   defaultAlertTenant: Array<AlertSource>;
 };
 
 export const usePerspective = (): usePerspectiveReturn => {
   const [perspective] = useActivePerspective();
 
-  if (perspective === 'dev') {
-    return {
-      perspective: 'dev',
-      rulesKey: 'devRules',
-      alertsKey: 'devAlerts',
-      silencesKey: 'devSilences',
-      alertingContextId: 'dev-observe-alerting',
-      defaultAlertTenant: [AlertSource.User],
-    };
-  } else if (perspective === 'admin') {
-    return {
-      perspective: 'admin',
-      rulesKey: 'rules',
-      alertsKey: 'alerts',
-      silencesKey: 'silences',
-      alertingContextId: 'observe-alerting',
-      defaultAlertTenant: [AlertSource.Platform],
-    };
+  switch (perspective) {
+    case 'dev':
+      return {
+        perspective: 'dev',
+        rulesKey: 'devRules',
+        alertsKey: 'devAlerts',
+        silencesKey: 'devSilences',
+        alertingContextId: 'dev-observe-alerting',
+        defaultAlertTenant: [AlertSource.User],
+      };
+    case 'admin':
+      return {
+        perspective: 'admin',
+        rulesKey: 'rules',
+        alertsKey: 'alerts',
+        silencesKey: 'silences',
+        alertingContextId: 'observe-alerting',
+        defaultAlertTenant: [AlertSource.Platform],
+      };
+    case 'virtualization-perspective':
+      return {
+        perspective: 'virtualization-perspective',
+        rulesKey: 'virtRules',
+        alertsKey: 'virtAlerts',
+        silencesKey: 'virtSilences',
+        alertingContextId: 'virt-observe-alerting',
+        defaultAlertTenant: [AlertSource.Platform],
+      };
+    default:
+      return {
+        perspective: 'acm',
+        rulesKey: 'acmRules',
+        alertsKey: 'acmAlerts',
+        silencesKey: 'acmSilences',
+        alertingContextId: 'acm-observe-alerting',
+        defaultAlertTenant: [],
+      };
   }
-  return {
-    perspective: 'acm',
-    rulesKey: 'acmRules',
-    alertsKey: 'acmAlerts',
-    silencesKey: 'acmSilences',
-    alertingContextId: 'acm-observe-alerting',
-    defaultAlertTenant: [],
-  };
 };
 
 export const getAlertsKey = (perspective: Perspective): alertKey => {
@@ -57,6 +72,8 @@ export const getAlertsKey = (perspective: Perspective): alertKey => {
       return 'acmAlerts';
     case 'admin':
       return 'alerts';
+    case 'virtualization-perspective':
+      return 'virtAlerts';
     case 'dev':
     default:
       return 'devAlerts';
@@ -69,6 +86,8 @@ export const getSilencesKey = (perspective: Perspective): silencesKey => {
       return 'acmSilences';
     case 'admin':
       return 'silences';
+    case 'virtualization-perspective':
+      return 'virtSilences';
     case 'dev':
     default:
       return 'devSilences';
@@ -81,6 +100,8 @@ export const getAlertsUrl = (perspective: Perspective, namespace?: string) => {
       return `/multicloud${AlertResource.plural}`;
     case 'admin':
       return AlertResource.plural;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/alerts`;
     case 'dev':
     default:
       return `/dev-monitoring/ns/${namespace}/alerts`;
@@ -116,6 +137,8 @@ export const getSilencesUrl = (perspective: Perspective, namespace?: string) => 
       return `/multicloud${SilenceResource.plural}`;
     case 'admin':
       return SilenceResource.plural;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/silences`;
     case 'dev':
     default:
       return `/dev-monitoring/ns/${namespace}/silences`;
@@ -132,6 +155,8 @@ export const getNewSilenceAlertUrl = (
       return `/multicloud${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
     case 'admin':
       return `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/silences/~new?${labelsToParams(alert.labels)}`;
     case 'dev':
     default:
       return `/dev-monitoring/ns/${namespace}/silences/~new?${labelsToParams(alert.labels)}`;
@@ -142,6 +167,8 @@ export const getNewSilenceUrl = (perspective: Perspective, namespace?: string) =
   switch (perspective) {
     case 'acm':
       return `/multicloud${SilenceResource.plural}/~new`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/~new`;
     case 'admin':
       return `${SilenceResource.plural}/~new`;
     case 'dev':
@@ -154,6 +181,8 @@ export const getRuleUrl = (perspective: Perspective, rule: Rule, namespace?: str
   switch (perspective) {
     case 'acm':
       return `/multicloud${RuleResource.plural}/${_.get(rule, 'id')}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/rules/${rule?.id}`;
     case 'admin':
       return `${RuleResource.plural}/${_.get(rule, 'id')}`;
     case 'dev':
@@ -166,6 +195,8 @@ export const getSilenceAlertUrl = (perspective: Perspective, id: string, namespa
   switch (perspective) {
     case 'acm':
       return `/multicloud${SilenceResource.plural}/${id}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/silences/${id}`;
     case 'admin':
       return `${SilenceResource.plural}/${id}`;
     case 'dev':
@@ -184,6 +215,8 @@ export const getEditSilenceAlertUrl = (
       return `/multicloud${SilenceResource.plural}/${id}/edit`;
     case 'admin':
       return `${SilenceResource.plural}/${id}/edit`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/silences/${id}/edit`;
     case 'dev':
     default:
       return `/dev-monitoring/ns/${namespace}/silences/${id}/edit`;
@@ -195,6 +228,8 @@ export const getFetchSilenceAlertUrl = (perspective: Perspective, namespace?: st
     case 'acm':
       return `${ALERTMANAGER_PROXY_PATH}/api/v2/silences`;
     case 'admin':
+      return `${ALERTMANAGER_BASE_PATH}/api/v2/silences`;
+    case 'virtualization-perspective':
       return `${ALERTMANAGER_BASE_PATH}/api/v2/silences`;
     case 'dev':
     default:
@@ -211,6 +246,8 @@ export const getAlertUrl = (
   switch (perspective) {
     case 'acm':
       return `/multicloud${AlertResource.plural}/${ruleID}?${labelsToParams(alert.labels)}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/alerts/${ruleID}?${labelsToParams(alert.labels)}`;
     case 'admin':
       return `${AlertResource.plural}/${ruleID}?${labelsToParams(alert.labels)}`;
     case 'dev':
@@ -228,6 +265,8 @@ export const getFetchSilenceUrl = (
     case 'acm':
       return `${ALERTMANAGER_PROXY_PATH}/api/v2/silence/${silenceID}`;
     case 'admin':
+      return `${ALERTMANAGER_BASE_PATH}/api/v2/silence/${silenceID}`;
+    case 'virtualization-perspective':
       return `${ALERTMANAGER_BASE_PATH}/api/v2/silence/${silenceID}`;
     case 'dev':
     default:
@@ -252,6 +291,8 @@ export const getQueryBrowserUrl = (perspective: Perspective, query: string, name
       return `/monitoring/query-browser?query0=${encodeURIComponent(query)}`;
     case 'dev':
       return `/dev-monitoring/ns/${namespace}/metrics?query0=${encodeURIComponent(query)}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/query-browser?query0=${encodeURIComponent(query)}`;
     case 'acm':
     default:
       return '';
@@ -268,6 +309,8 @@ export const getMutlipleQueryBrowserUrl = (
       return `/monitoring/query-browser?${params.toString()}`;
     case 'dev':
       return `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`;
+    case 'virtualization-perspective':
+      return `/virt-monitoring/query-browser?${params.toString()}`;
     case 'acm':
     default:
       return '';
@@ -280,6 +323,8 @@ export const getDeashboardsUrl = (
   namespace?: string,
 ) => {
   switch (perspective) {
+    case 'virtualization-perspective':
+      return `/monitoring/dashboards/${boardName}`;
     case 'admin':
       return `/monitoring/dashboards/${boardName}`;
     case 'dev':


### PR DESCRIPTION
We added a new perspective called 'Virtualization'.
In this perspective we added the observe links in the sidebar menu to go directly in the alerts metrics, dashboard and targets page. 
But when we are in this perspective the page is blank. This will fix the issue. 
I'm not sure if you guys want to fix that even for other custom perspective. This is the fix to just make it work for our perspective. 

Steps: 


<img width="293" alt="Screenshot 2024-12-16 at 15 27 26" src="https://github.com/user-attachments/assets/20769a58-5718-43ad-a9f7-ca9672dc5869" />

<img width="293" alt="Screenshot 2024-12-16 at 15 27 30" src="https://github.com/user-attachments/assets/33d519ea-f462-465c-87bf-b5adaeaa6761" />

<img width="1911" alt="Screenshot 2024-12-16 at 15 20 47" src="https://github.com/user-attachments/assets/64b5cb1d-591a-422e-a209-0838bec8a346" />
