### PR TITLE
OU-588: Move Incidents Tab to Alerting Page 

### DIFF
--- a/config/incidents.patch.json
+++ b/config/incidents.patch.json
@@ -10,23 +10,5 @@
         "component": { "$codeRef": "IncidentsPage" }
       }
     }
-  },
-  {
-    "op": "add",
-    "path": "/extensions/0",
-    "value": {
-      "type": "console.navigation/href",
-      "flags": {
-        "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
-      },
-      "properties": {
-        "id": "incidents",
-        "name": "%plugin__monitoring-console-plugin~Incidents%",
-        "href": "/monitoring/incidents",
-        "perspective": "admin",
-        "section": "observe",
-        "insertAfter": "targets"
-      }
-    }
   }
 ]

--- a/scripts/start-console.sh
+++ b/scripts/start-console.sh
@@ -41,7 +41,7 @@ if [ -x "$(command -v podman)" ]; then
         podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM \
         --rm -p "$CONSOLE_PORT":9000 \
         --env-file <(set | grep BRIDGE) \
-        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/monitoring-console-plugin/perses/", "endpoint":"http://host.containers.internal:8080","authorize":true}]}' \
+        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/monitoring-console-plugin/perses/", "endpoint":"http://host.containers.internal:8080","authorize":true}, {"consoleAPIPath": "/api/proxy/plugin/monitoring-console-plugin/backend/", "endpoint":"http://host.containers.internal:9443","authorize":true}]}' \
         $CONSOLE_IMAGE
     fi
 else

--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -69,6 +69,7 @@ import {
   getAlertRulesUrl,
   getAlertsUrl,
   getAlertUrl,
+  getIncidentsUrl,
   getNewSilenceAlertUrl,
   getObserveState,
   getQueryBrowserUrl,
@@ -99,6 +100,7 @@ import { useSilencesPoller } from './hooks/useSilencesPoller';
 import { MonitoringState } from '../reducers/observe';
 import SilencesPage from './alerting/SilencesPage';
 import SilencesDetailsPage from './alerting/SilencesDetailPage';
+import { useFeatures } from './hooks/useFeatures';
 
 const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -613,10 +615,12 @@ const Tab: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active,
 const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
+  const { areIncidentsActive } = useFeatures();
 
   const alertsPath = getAlertsUrl(perspective);
   const rulesPath = getAlertRulesUrl(perspective);
   const silencesPath = getSilencesUrl(perspective);
+  const incidentsPath = getIncidentsUrl(perspective);
 
   const { url } = match;
 
@@ -641,6 +645,11 @@ const AlertingPage: React.FC<RouteComponentProps<{ url: string }>> = ({ match })
         <Tab active={url === rulesPath}>
           <Link to={rulesPath}>{t('Alerting rules')}</Link>
         </Tab>
+        {areIncidentsActive && (
+          <Tab active={url === incidentsPath}>
+            <Link to={incidentsPath}>Incidents</Link>
+          </Tab>
+        )}
       </ul>
       <Switch>
         <Route path={alertsPath} exact component={AlertsPage} />

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -98,6 +98,18 @@ export const getAlertRulesUrl = (perspective: Perspective) => {
   }
 };
 
+// There is no equivalent rules list page in the developer perspective
+export const getIncidentsUrl = (perspective: Perspective) => {
+  const baseURL = '/monitoring/incidents';
+  switch (perspective) {
+    case 'acm':
+      return `/multicloud${baseURL}`;
+    default:
+    case 'admin':
+      return baseURL;
+  }
+};
+
 export const getSilencesUrl = (perspective: Perspective, namespace?: string) => {
   switch (perspective) {
     case 'acm':


### PR DESCRIPTION
### Related JIRA 
https://issues.redhat.com/browse/OU-588

### Description 
- Relocate the Incidents tab from Observe > Incidents to Observe > Alerting > Incidents tab. 
    - the frontend use a proxy `/api/proxy/plugin/monitoring-console-plugin/backend/features` to fetch the list of features enabled from the golang [backend](https://github.com/openshift/monitoring-plugin/blob/1d2e50f162df985768a7faaa2e6f47740bfb87a6/pkg/server.go#L185). Cluster Observability Operator configures the proxy [here](https://github.com/rhobs/observability-operator/blob/28ac1ba9e179d25cae60e8223bcf61816e23a311/pkg/controllers/uiplugin/monitoring.go#L44).


This is an initial solution. The [long-term solution](https://issues.redhat.com/browse/OU-625) is to modify the openshift/console-dynamic-plugin-sdk > [horizontalNav](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/api.md#horizontalnav) so that the prop `contextId` is exposed. This will allow the file `incidents.patch.json` to create a extension that will hook into the horizontalNav by the contextId. 

### Testing 
Locally tested using the following instructions : 
1. In the first terminal run `make start-frontend`
2. In the second terminal run `make start-feature-backend`
3. In the third terminal run `make start-feature-console`
4. Incidents feature should now be enabled. Navigate to Admin perspective > Observe > Alerts > Alerts Tab should now show 'Incidents' 

In-cluster testing using the following instructions: 
1. With ClusterBot run the command: `launch 4.18,openshift/monitoring-plugin#303 aws` 
2. Enable Incidents in the cluster: 
   -  Use this branch for testing: https://github.com/zhuje/monitoring-plugin/tree/deploy_incidents. It hacks the `script > deploy-acm.sh` to deploy incidents instead. OR use this command to enable incidents `helm template charts/openshift-console-plugin --set plugin.image=quay.io/rh-ee-pyurkovi/incidents:latest --set plugin.features.incidents.enabled=true`
   -  Run in the terminal `$ make deploy-acm` (this deploys the incident because we hack-ily modified `deploy-acm.sh` in step 2) 

### Screenshots/Demos 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f965a3ae-0eb2-48e8-9ff0-cc60871f8dac" />

**Figure 1.** BEFORE - Incidents is under the Observe section. 

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/c9f7edd8-851c-405c-b801-ed860bd95e0a" />

**Figure 2** AFTER - The screenshot shows that the 'Incidents' Tab is now under Observe > Alerting. The section Observe > Incidents has been removed. 


https://github.com/user-attachments/assets/9878c354-3f94-40b5-9cd8-d4b0f29d2b8d


**Figure 3.** Video (~0:22 seconds duration), show Incidents Tab relocation with local testing (at localhost:9000).



https://github.com/user-attachments/assets/b5cd747c-4882-48e3-891b-168c5dbd1e86


**Figure 4.** Video (~0:27 second duration) shows Incidents Tab relocation within cluster testing. 