### PR TITLE
NO-JIRA: Fix PF5 single-typeahead-dropdown allow additional dashboards 

### DIFF
--- a/web/src/components/console/utils/single-typeahead-dropdown.tsx
+++ b/web/src/components/console/utils/single-typeahead-dropdown.tsx
@@ -115,10 +115,13 @@ export const SingleTypeaheadDropdown: React.FC<SingleTypeaheadDropdownProps> = (
   const CREATE_NEW = 'typeahead-dropdown__create-new';
 
   React.useEffect(() => {
-    setSelectOptions([...selectOptions, ..._.differenceBy(items, selectOptions, 'value')]);
-    inputValue === '' && setFilteredSelectOptions(selectOptions);
+    setSelectOptions([..._.differenceBy(items, selectOptions, 'value'), ...selectOptions]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items]);
+
+  React.useEffect(() => {
+    setFilteredSelectOptions(selectOptions);
+  }, [selectOptions]);
 
   React.useEffect(() => {
     let newSelectOptions: SelectOptionProps[] = selectOptions;


### PR DESCRIPTION
### JIRA Issue 
No JIRA. 

### Related JIRAs 
[monitoring-plugin#266 [OU-432](https://issues.redhat.com//browse/OU-432): Merge Perses dashboards with current dashboards list](https://github.com/openshift/monitoring-plugin/pull/266)
[montioring-plugin#282 [OU-499](https://issues.redhat.com//browse/OU-499): Port CONSOLE-4124, ODC-7655, [CONSOLE-4127](https://issues.redhat.com//browse/CONSOLE-4127) to dynamic plugin #282](https://github.com/openshift/monitoring-plugin/pull/282) 


### Description 
[OU-499 ](https://github.com/openshift/monitoring-plugin/pull/282) Updated the Dashboard Page > Dashboard Dropdown to use `single-typeahead-dropdown.tsx`. A condition in this file prevented additional Perses dashboards from being added `inputValue === '' && setFilteredSelectOptions(selectOptions);` . 

`inputValue === ''` is true when the dashboard has not been loaded yet and no initial dashboard has been selected.  After the OCP dashboards have been fetched `inputValue === "API Performance"` and selects the API Performance dashboards to be the initial dashboard that is loaded when the user visits `/monitoring/dashboards`. 

Removing `inputValue === ''` allows more dashboards to be added via `setFilteredSelectOptions(selectOptions)` when additional `items` like Perses dashboard are fetched after the OCP dashboards. 

### Demo 
https://drive.google.com/file/d/1KwLKKpqBs4PCzbD9cv1TuAAW0jZlPGyH/view?usp=sharing
Figure 1. Video demo of fix ~1:30 seconds. Local testing. Shows Perses Dashboards being listed in Observe > Dashboards > Dashboard dropdown. 

### Testing
This PR was only tested locally during development. To setup the test: 
1. Launch a perses container `docker run --name perses -d -p 127.0.0.1:8080:8080 persesdev/perses`. See https://github.com/perses/perses?tab=readme-ov-file#docker-images for information. 
2. Navigate to `http://localhost:8080`, which will take you to the local Perses instance. Create a project and a dashboard for it. 
3. Start the monitoring-plugin (`make start-frontend` and in a separate terminal `make start-console`). `make start-console` is proxying localhost:8080 (our local perses instance). 
4. There is a bug in the OCP console that prevents the Dashboard page from fetching the OCP dashboards specs -- to circumvent (with a hack-y solution) I've created a mock API response that serves the specs in this branch which you can merge in to the PR : https://github.com/zhuje/monitoring-plugin/tree/mock_monitoring_dashboard_config.   
5. Navigate to `http://localhost:9000` (our local OCP instance). Go to Observe > Dashboards > Dropdown, the dashboards you created in the local perses instance should now be listed in the dropdown. 
