### PR TITLE
NO-JIRA: Account for store version drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Once the code has been updated, make sure to update the helm chart and variables
 
 ### Redux Store
 
-Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.monitoring` path. A combination of the `useFeatures` hook and the `getObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
+Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.mcp` path. A combination of the `useFeatures` hook and the `getObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
 
 ### Local Development
 

--- a/config/clear-extensions.patch.json
+++ b/config/clear-extensions.patch.json
@@ -6,7 +6,7 @@
       {
         "type": "console.redux-reducer",
         "properties": {
-          "scope": "monitoring",
+          "scope": "mcp",
           "reducer": { "$codeRef": "MonitoringReducer" }
         }
       }

--- a/config/dev-config.patch.json
+++ b/config/dev-config.patch.json
@@ -5,7 +5,7 @@
     "value": {
       "type": "console.redux-reducer",
       "properties": {
-        "scope": "monitoring",
+        "scope": "mcp",
         "reducer": { "$codeRef": "MonitoringReducer" }
       }
     }

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -40,7 +40,7 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
   const dateValues = generateDateArray(chartDays);
 
   const selectedId = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentGroupId']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentGroupId']),
   );
 
   const isHidden = (group_id) => selectedId !== '' && selectedId !== group_id;
@@ -88,12 +88,12 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
                 <CursorVoronoiContainer
                   mouseFollowTooltips
                   labels={({ datum }) =>
-                    `Severity: ${datum.name}\nComponent: ${datum.componentList?.join(", ")}\nIncident ID: ${
-                      datum.group_id
-                    }\nStart: ${formatDate(new Date(datum.y0), true)}\nEnd: ${formatDate(
-                      new Date(datum.y),
+                    `Severity: ${datum.name}\nComponent: ${datum.componentList?.join(
+                      ', ',
+                    )}\nIncident ID: ${datum.group_id}\nStart: ${formatDate(
+                      new Date(datum.y0),
                       true,
-                    )}`
+                    )}\nEnd: ${formatDate(new Date(datum.y), true)}`
                   }
                 />
               }

--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -78,27 +78,25 @@ const IncidentsPage = () => {
   };
 
   const incidentsInitialState = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentsInitialState']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentsInitialState']),
   );
 
-  const incidents = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidents']),
-  );
+  const incidents = useSelector((state) => state.plugins.mcp.getIn(['incidentsData', 'incidents']));
 
   const incidentsActiveFilters = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentsActiveFilters']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentsActiveFilters']),
   );
 
   const incidentGroupId = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentGroupId']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentGroupId']),
   );
 
   const alertsData = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsData']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsData']),
   );
 
   const alertsAreLoading = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsAreLoading']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsAreLoading']),
   );
 
   React.useEffect(() => {

--- a/web/src/components/Incidents/IncidentsTable.jsx
+++ b/web/src/components/Incidents/IncidentsTable.jsx
@@ -30,7 +30,7 @@ export const IncidentsTable = ({ namespace }) => {
     });
   const isAlertExpanded = (alert) => expandedAlerts.includes(alert.component);
   const alertsTableData = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsTableData']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsTableData']),
   );
 
   return (

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -238,7 +238,7 @@ export const getFetchSilenceUrl = (
 export const getObserveState = (perspective: Perspective, state: MonitoringState) => {
   switch (perspective) {
     case 'acm':
-      return state.plugins?.monitoring;
+      return state.plugins?.mcp;
     case 'admin':
     case 'dev':
     default:

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -20,7 +20,7 @@ export type ObserveState = ImmutableMap<string, any>;
 export type MonitoringState = {
   observe: ObserveState;
   plugins: {
-    monitoring: ObserveState;
+    mcp: ObserveState;
   };
 };
 


### PR DESCRIPTION
As the `openshift/console` currently shackles the `monitoring-plugin` store, so too will the `monitoring-plugin` store shackle the `monitoring-console-plugin` store, as the `monitoring-console-plugin` will deployed across OCP versions while the `monitoring-plugin` version will be pegged to the OCP version. This change looks to plan for the future so separate out the `monitoring-console-plugin` store to a unique name, so that when the store is removed from the `openshift/console` and brought into the `monitoring-plugin` they will have unique but understandable names.

I'm also open to changing the `monitoring-console-plugin` usage in the PR to instead be `mcp` so that we don't have the (kinda ugly) square bracket syntax