### PR TITLE
RHINENG-15096: incidents page reset filters fix

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -257,6 +257,7 @@ const IncidentsPage = () => {
             id="toolbar-with-filter"
             className="pf-m-toggle-group-container"
             collapseListedFiltersBreakpoint="xl"
+            clearFiltersButtonText="Reset all filters"
             clearAllFilters={() =>
               onDeleteIncidentFilterChip('', '', incidentsActiveFilters, dispatch)
             }


### PR DESCRIPTION
Rename clear all filters button to reset all filters because it fits better with the function