### PR TITLE
NO-JIRA: Add monitoring-plugin exclusive reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Once the code has been updated, make sure to update the helm chart and variables
 
 ### Redux Store
 
-Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.mcp` path. A combination of the `useFeatures` hook and the `getObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
+Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.mcp` path. A combination of the `useFeatures` hook and the `getLegacyObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
 
 ### Local Development
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Once the code has been updated, make sure to update the helm chart and variables
 
 ### Redux Store
 
-Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.monitoring` path. A combination of the `useFeatures` hook and the `getObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
+Since the store for the `monitoring-plugin` is stored in the `openshift/console` codebase and updates to the store that are aren't tied directly to the OCP are needed, when the default extension points are removed due to the presense of a feature flag a duplicate store is created at the `.state.plugins.mcp` path. A combination of the `useFeatures` hook and the `getObserveState` (which is dependant on the perspective) can be used to retrieve the state from the redux store based on the mode the plugin was deployed in.
 
 ### Local Development
 

--- a/config/clear-extensions.patch.json
+++ b/config/clear-extensions.patch.json
@@ -6,7 +6,7 @@
       {
         "type": "console.redux-reducer",
         "properties": {
-          "scope": "monitoring",
+          "scope": "mcp",
           "reducer": { "$codeRef": "MonitoringReducer" }
         }
       }

--- a/config/dev-config.patch.json
+++ b/config/dev-config.patch.json
@@ -5,7 +5,7 @@
     "value": {
       "type": "console.redux-reducer",
       "properties": {
-        "scope": "monitoring",
+        "scope": "mcp",
         "reducer": { "$codeRef": "MonitoringReducer" }
       }
     }

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -154,5 +154,12 @@
         "$codeRef": "MonitoringUI"
       }
     }
+  },
+  {
+    "type": "console.redux-reducer",
+    "properties": {
+      "scope": "mp",
+      "reducer": { "$codeRef": "MonitoringReducer" }
+    }
   }
 ]

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -40,7 +40,7 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
   const dateValues = generateDateArray(chartDays);
 
   const selectedId = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentGroupId']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentGroupId']),
   );
 
   const isHidden = (group_id) => selectedId !== '' && selectedId !== group_id;
@@ -88,12 +88,12 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
                 <CursorVoronoiContainer
                   mouseFollowTooltips
                   labels={({ datum }) =>
-                    `Severity: ${datum.name}\nComponent: ${datum.componentList?.join(", ")}\nIncident ID: ${
-                      datum.group_id
-                    }\nStart: ${formatDate(new Date(datum.y0), true)}\nEnd: ${formatDate(
-                      new Date(datum.y),
+                    `Severity: ${datum.name}\nComponent: ${datum.componentList?.join(
+                      ', ',
+                    )}\nIncident ID: ${datum.group_id}\nStart: ${formatDate(
+                      new Date(datum.y0),
                       true,
-                    )}`
+                    )}\nEnd: ${formatDate(new Date(datum.y), true)}`
                   }
                 />
               }

--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -78,27 +78,25 @@ const IncidentsPage = () => {
   };
 
   const incidentsInitialState = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentsInitialState']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentsInitialState']),
   );
 
-  const incidents = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidents']),
-  );
+  const incidents = useSelector((state) => state.plugins.mcp.getIn(['incidentsData', 'incidents']));
 
   const incidentsActiveFilters = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentsActiveFilters']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentsActiveFilters']),
   );
 
   const incidentGroupId = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'incidentGroupId']),
+    state.plugins.mcp.getIn(['incidentsData', 'incidentGroupId']),
   );
 
   const alertsData = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsData']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsData']),
   );
 
   const alertsAreLoading = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsAreLoading']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsAreLoading']),
   );
 
   React.useEffect(() => {

--- a/web/src/components/Incidents/IncidentsTable.jsx
+++ b/web/src/components/Incidents/IncidentsTable.jsx
@@ -30,7 +30,7 @@ export const IncidentsTable = ({ namespace }) => {
     });
   const isAlertExpanded = (alert) => expandedAlerts.includes(alert.component);
   const alertsTableData = useSelector((state) =>
-    state.plugins.monitoring.getIn(['incidentsData', 'alertsTableData']),
+    state.plugins.mcp.getIn(['incidentsData', 'alertsTableData']),
   );
 
   return (

--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -71,7 +71,7 @@ import {
   getAlertUrl,
   getIncidentsUrl,
   getNewSilenceAlertUrl,
-  getObserveState,
+  getLegacyObserveState,
   getQueryBrowserUrl,
   getRuleUrl,
   getSilencesUrl,
@@ -205,12 +205,12 @@ const AlertRulesDetailsPage_: React.FC<AlertRulesDetailsPageProps> = ({ match })
   const namespace = match.params?.ns;
 
   const rules: Rule[] = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.get(rulesKey),
+    getLegacyObserveState(perspective, state)?.get(rulesKey),
   );
   const rule = _.find(rules, { id: _.get(match, 'params.id') });
 
   const { loaded, loadError }: Alerts = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(alertsKey) || {},
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(alertsKey) || {},
   );
 
   const sourceId = rule?.sourceId;
@@ -483,13 +483,14 @@ const RulesPage_: React.FC = () => {
   const { alertsKey, silencesKey, rulesKey, perspective, defaultAlertTenant } = usePerspective();
 
   const data: Rule[] = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.get(rulesKey),
+    getLegacyObserveState(perspective, state)?.get(rulesKey),
   );
   const { loaded = false, loadError }: Alerts = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(alertsKey) || {},
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(alertsKey) || {},
   );
   const silencesLoadError = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(silencesKey)?.loadError,
+    (state: MonitoringState) =>
+      getLegacyObserveState(perspective, state)?.get(silencesKey)?.loadError,
   );
 
   const ruleAdditionalSources = React.useMemo(

--- a/web/src/components/alerting/AlertsDetailPage.tsx
+++ b/web/src/components/alerting/AlertsDetailPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import {
   getAlertsUrl,
   getNewSilenceAlertUrl,
-  getObserveState,
+  getLegacyObserveState,
   getRuleUrl,
   usePerspective,
 } from '../hooks/usePerspective';
@@ -87,16 +87,16 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
   const [namespace] = useActiveNamespace();
 
   const hideGraphs = useSelector(
-    (state: MonitoringState) => !!getObserveState(perspective, state)?.get('hideGraphs'),
+    (state: MonitoringState) => !!getLegacyObserveState(perspective, state)?.get('hideGraphs'),
   );
 
   const dispatch = useDispatch();
   const alerts: Alerts = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.get(alertsKey),
+    getLegacyObserveState(perspective, state)?.get(alertsKey),
   );
 
   const silencesLoaded = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(silencesKey)?.loaded,
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(silencesKey)?.loaded,
   );
 
   const ruleAlerts = _.filter(alerts?.data, (a) => a.rule.id === match?.params?.ruleID);

--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   getAlertUrl,
   getNewSilenceAlertUrl,
-  getObserveState,
+  getLegacyObserveState,
   getRuleUrl,
   usePerspective,
 } from '../hooks/usePerspective';
@@ -65,10 +65,11 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
     loaded = false,
     loadError,
   }: Alerts = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(alertsKey) || {},
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(alertsKey) || {},
   );
   const silencesLoadError = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(silencesKey)?.loadError,
+    (state: MonitoringState) =>
+      getLegacyObserveState(perspective, state)?.get(silencesKey)?.loadError,
   );
 
   const alertAdditionalSources = React.useMemo(

--- a/web/src/components/alerting/SilencesDetailPage.tsx
+++ b/web/src/components/alerting/SilencesDetailPage.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import { useActiveNamespace } from '../console/console-shared/hooks/useActiveNamespace';
 import {
   getAlertUrl,
-  getObserveState,
+  getLegacyObserveState,
   getRuleUrl,
   getSilencesUrl,
   usePerspective,
@@ -34,11 +34,11 @@ const SilencesDetailsPage_: React.FC<RouteComponentProps<{ id: string }>> = ({ m
   const { alertsKey, perspective, silencesKey } = usePerspective();
 
   const alertsLoaded = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(alertsKey)?.loaded,
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(alertsKey)?.loaded,
   );
 
   const silences: Silences = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.get(silencesKey),
+    getLegacyObserveState(perspective, state)?.get(silencesKey),
   );
   const silence = _.find(silences?.data, { id: _.get(match, 'params.id') });
 

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
   getNewSilenceUrl,
-  getObserveState,
+  getLegacyObserveState,
   getFetchSilenceUrl,
   usePerspective,
 } from '../hooks/usePerspective';
@@ -47,7 +47,7 @@ const SilencesPage_: React.FC = () => {
     loaded = false,
     loadError,
   }: Silences = useSelector(
-    (state: MonitoringState) => getObserveState(perspective, state)?.get(silencesKey) || {},
+    (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(silencesKey) || {},
   );
 
   const rowFilters: RowFilter[] = [

--- a/web/src/components/dashboards/custom-time-range-modal.tsx
+++ b/web/src/components/dashboards/custom-time-range-modal.tsx
@@ -16,7 +16,7 @@ import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../
 
 import { setQueryArguments } from '../console/utils/router';
 import { MonitoringState } from '../../reducers/observe';
-import { getObserveState } from '../hooks/usePerspective';
+import { getLegacyObserveState } from '../hooks/usePerspective';
 
 const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
 
@@ -47,10 +47,10 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
 
   const dispatch = useDispatch();
   const endTime = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
   );
 
   // If a time is already set in Redux, default to that, otherwise default to a time range that

--- a/web/src/components/dashboards/graph.tsx
+++ b/web/src/components/dashboards/graph.tsx
@@ -7,7 +7,7 @@ import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
 import { DEFAULT_GRAPH_SAMPLES } from './monitoring-dashboard-utils';
 import { MonitoringState } from '../../reducers/observe';
-import { getObserveState } from '../hooks/usePerspective';
+import { getLegacyObserveState } from '../hooks/usePerspective';
 
 type Props = {
   customDataSource?: CustomDataSource;
@@ -38,10 +38,10 @@ const Graph: React.FC<Props> = ({
 }) => {
   const dispatch = useDispatch();
   const endTime = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
   );
   const timespan = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
   );
 
   const onZoom = React.useCallback(

--- a/web/src/components/dashboards/index.tsx
+++ b/web/src/components/dashboards/index.tsx
@@ -76,7 +76,7 @@ import { getTimeRanges, isTimeoutError, QUERY_CHUNK_SIZE } from '../utils';
 import {
   getDeashboardsUrl,
   getMutlipleQueryBrowserUrl,
-  getObserveState,
+  getLegacyObserveState,
   usePerspective,
 } from '../hooks/usePerspective';
 import KebabDropdown from '../kebab-dropdown';
@@ -159,11 +159,11 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const timespan = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
   );
 
   const variables = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
   );
   const variable = variables.toJS()[name];
   const query = evaluateTemplate(variable.query, variables, timespan);
@@ -359,7 +359,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({
 const AllVariableDropdowns: React.FC<{ perspective: Perspective }> = ({ perspective }) => {
   const namespace = React.useContext(NamespaceContext);
   const variables = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
   );
 
   return (
@@ -549,13 +549,13 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
 
   const namespace = React.useContext(NamespaceContext);
   const pollInterval = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'pollInterval']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'pollInterval']),
   );
   const timespan = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
   );
   const variables = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
   );
 
   const ref = React.useRef();

--- a/web/src/components/dashboards/timespan-dropdown.tsx
+++ b/web/src/components/dashboards/timespan-dropdown.tsx
@@ -8,7 +8,7 @@ import { getQueryArgument, removeQueryArgument, setQueryArgument } from '../cons
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../actions/observe';
 import { useBoolean } from '../hooks/useBoolean';
 import CustomTimeRangeModal from './custom-time-range-modal';
-import { getObserveState, usePerspective } from '../hooks/usePerspective';
+import { getLegacyObserveState, usePerspective } from '../hooks/usePerspective';
 import { SimpleSelect, SimpleSelectOption } from '../SimpleSelect';
 import { MonitoringState } from '../../reducers/observe';
 
@@ -24,10 +24,10 @@ const TimespanDropdown: React.FC = () => {
   const [selected, setSelected] = React.useState<string | undefined>(DEFAULT_TIMERANGE);
 
   const timespan = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespen']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespen']),
   );
   const endTime = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
+    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
   );
 
   const timeSpanFromParams = getQueryArgument('timeRange');

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -235,7 +235,8 @@ export const getFetchSilenceUrl = (
   }
 };
 
-export const getObserveState = (perspective: Perspective, state: MonitoringState) => {
+// Redux state defined in the openshift/console repo
+export const getLegacyObserveState = (perspective: Perspective, state: MonitoringState) => {
   switch (perspective) {
     case 'acm':
       return state.plugins?.mcp;
@@ -243,6 +244,18 @@ export const getObserveState = (perspective: Perspective, state: MonitoringState
     case 'dev':
     default:
       return state.observe;
+  }
+};
+
+// Redux state defined in the openshift/monitoring-plugin repo
+export const getObserveState = (perspective: Perspective, state: MonitoringState) => {
+  switch (perspective) {
+    case 'acm':
+      return state.plugins?.mcp;
+    case 'admin':
+    case 'dev':
+    default:
+      return state.plugins?.mp;
   }
 };
 

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -238,7 +238,7 @@ export const getFetchSilenceUrl = (
 export const getObserveState = (perspective: Perspective, state: MonitoringState) => {
   switch (perspective) {
     case 'acm':
-      return state.plugins?.monitoring;
+      return state.plugins?.mcp;
     case 'admin':
     case 'dev':
     default:

--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -88,7 +88,7 @@ import {
   DataSource,
   isDataSource,
 } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
-import { getObserveState, usePerspective } from './hooks/usePerspective';
+import { getLegacyObserveState, usePerspective } from './hooks/usePerspective';
 import { useActiveNamespace } from './console/console-shared/hooks/useActiveNamespace';
 import { MonitoringState } from '../reducers/observe';
 import { DropDownPollInterval } from './dropdown-poll-interval';
@@ -216,7 +216,7 @@ export const PreDefinedQueriesDropdown = () => {
   const dispatch = useDispatch();
 
   const queriesList = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']),
   );
 
   const insertPredefinedQuery = (query: string) => {
@@ -288,7 +288,7 @@ const MetricsActionsMenu: React.FC = () => {
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
   const isAllExpanded = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)
+    getLegacyObserveState(perspective, state)
       ?.getIn(['queryBrowser', 'queries'])
       .every((q) => q.get('isExpanded')),
   );
@@ -334,7 +334,7 @@ export const ToggleGraph: React.FC = () => {
   const { perspective } = usePerspective();
 
   const hideGraphs = useSelector(
-    (state: MonitoringState) => !!getObserveState(perspective, state)?.get('hideGraphs'),
+    (state: MonitoringState) => !!getLegacyObserveState(perspective, state)?.get('hideGraphs'),
   );
 
   const dispatch = useDispatch();
@@ -380,7 +380,7 @@ const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
   const { perspective } = usePerspective();
 
   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector((state: MonitoringState) => {
-    const observe = getObserveState(perspective, state);
+    const observe = getLegacyObserveState(perspective, state);
     const disabledSeries = observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries']);
     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
       return [null, true, false];
@@ -434,7 +434,7 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
 
   const isDisabledSeriesEmpty = useSelector((state: MonitoringState) =>
     _.isEmpty(
-      getObserveState(perspective, state)?.getIn([
+      getLegacyObserveState(perspective, state)?.getIn([
         'queryBrowser',
         'queries',
         index,
@@ -443,15 +443,20 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
     ),
   );
   const isEnabled = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
+    getLegacyObserveState(perspective, state)?.getIn([
+      'queryBrowser',
+      'queries',
+      index,
+      'isEnabled',
+    ]),
   );
 
   const query = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'query']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'query']),
   );
 
   const queryTableData = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn([
+    getLegacyObserveState(perspective, state)?.getIn([
       'queryBrowser',
       'queries',
       index,
@@ -604,26 +609,36 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace, custom
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
 
   const isEnabled = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
+    getLegacyObserveState(perspective, state)?.getIn([
+      'queryBrowser',
+      'queries',
+      index,
+      'isEnabled',
+    ]),
   );
   const isExpanded = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isExpanded']),
+    getLegacyObserveState(perspective, state)?.getIn([
+      'queryBrowser',
+      'queries',
+      index,
+      'isExpanded',
+    ]),
   );
   const pollInterval = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'pollInterval'], 15 * 1000),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'pollInterval'], 15 * 1000),
   );
   const query = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'query']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'query']),
   );
   const series = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'series']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'series']),
   );
   const span = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'timespan']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'timespan']),
   );
 
   const lastRequestTime = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'lastRequestTime']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'lastRequestTime']),
   );
 
   const dispatch = useDispatch();
@@ -635,7 +650,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace, custom
 
   const isDisabledSeriesEmpty = useSelector((state: MonitoringState) =>
     _.isEmpty(
-      getObserveState(perspective, state)?.getIn([
+      getLegacyObserveState(perspective, state)?.getIn([
         'queryBrowser',
         'queries',
         index,
@@ -839,16 +854,29 @@ const Query: React.FC<{ index: number; customDatasource?: CustomDataSource }> = 
   const { perspective } = usePerspective();
 
   const id = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'id']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'id']),
   );
   const isEnabled = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
+    getLegacyObserveState(perspective, state)?.getIn([
+      'queryBrowser',
+      'queries',
+      index,
+      'isEnabled',
+    ]),
   );
   const isExpanded = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'isExpanded']),
+    getLegacyObserveState(perspective, state)?.getIn([
+      'queryBrowser',
+      'queries',
+      index,
+      'isExpanded',
+    ]),
   );
   const text = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries', index, 'text'], ''),
+    getLegacyObserveState(perspective, state)?.getIn(
+      ['queryBrowser', 'queries', index, 'text'],
+      '',
+    ),
   );
 
   const dispatch = useDispatch();
@@ -935,10 +963,10 @@ const QueryBrowserWrapper: React.FC<{
   const dispatch = useDispatch();
 
   const hideGraphs = useSelector(
-    (state: MonitoringState) => !!getObserveState(perspective, state)?.get('hideGraphs'),
+    (state: MonitoringState) => !!getLegacyObserveState(perspective, state)?.get('hideGraphs'),
   );
   const queriesList = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']),
   );
 
   const queries = queriesList.toJS();
@@ -1075,7 +1103,7 @@ const QueriesList: React.FC<{ customDatasource?: CustomDataSource }> = ({ custom
   const { perspective } = usePerspective();
   const count = useSelector(
     (state: MonitoringState) =>
-      getObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']).size,
+      getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'queries']).size,
   );
 
   return (

--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -73,7 +73,7 @@ import { queryBrowserTheme } from './query-browser-theme';
 import { PrometheusAPIError, TimeRange } from './types';
 import { getTimeRanges } from './utils';
 
-import { getObserveState, usePerspective } from './hooks/usePerspective';
+import { getLegacyObserveState, usePerspective } from './hooks/usePerspective';
 import { useActiveNamespace } from './console/console-shared/hooks/useActiveNamespace';
 import { MonitoringState } from '../reducers/observe';
 
@@ -692,14 +692,15 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const { perspective } = usePerspective();
 
   const hideGraphs = useSelector(
-    (state: MonitoringState) => !!getObserveState(perspective, state)?.get('hideGraphs'),
+    (state: MonitoringState) => !!getLegacyObserveState(perspective, state)?.get('hideGraphs'),
   );
   const tickInterval = useSelector(
     (state: MonitoringState) =>
-      pollInterval ?? getObserveState(perspective, state)?.getIn(['queryBrowser', 'pollInterval']),
+      pollInterval ??
+      getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'pollInterval']),
   );
   const lastRequestTime = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.getIn(['queryBrowser', 'lastRequestTime']),
+    getLegacyObserveState(perspective, state)?.getIn(['queryBrowser', 'lastRequestTime']),
   );
 
   const dispatch = useDispatch();

--- a/web/src/components/silence-form.tsx
+++ b/web/src/components/silence-form.tsx
@@ -44,7 +44,7 @@ import { Silences } from './types';
 import { refreshSilences, SilenceResource, silenceState } from './utils';
 import {
   getFetchSilenceAlertUrl,
-  getObserveState,
+  getLegacyObserveState,
   getSilenceAlertUrl,
   usePerspective,
 } from './hooks/usePerspective';
@@ -499,7 +499,7 @@ export const EditSilence = ({ match }) => {
   const { silencesKey, perspective } = usePerspective();
 
   const silences: Silences = useSelector((state: MonitoringState) =>
-    getObserveState(perspective, state)?.get(silencesKey),
+    getLegacyObserveState(perspective, state)?.get(silencesKey),
   );
 
   const silence: Silence = _.find(silences?.data, { id: match.params.id });

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -20,7 +20,8 @@ export type ObserveState = ImmutableMap<string, any>;
 export type MonitoringState = {
   observe: ObserveState;
   plugins: {
-    mcp: ObserveState;
+    mcp?: ObserveState;
+    mp?: ObserveState;
   };
 };
 

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -20,7 +20,7 @@ export type ObserveState = ImmutableMap<string, any>;
 export type MonitoringState = {
   observe: ObserveState;
   plugins: {
-    monitoring: ObserveState;
+    mcp: ObserveState;
   };
 };
 


### PR DESCRIPTION
Rebased on top of #308.

The PR looks to add a monitoring-plugin defined reducer, rather than using the one defined in the `openshift/console` codebase. Also change `getObserveState` to point to the new reducer, and rename the old function which points to the `openshift/console` reducer to `getLegacyObserveState`