### PR TITLE
RHINENG-15284: Sync alerts chart and incidents table with days filter

### DIFF
--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import * as React from 'react';
 
 import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
@@ -71,14 +70,13 @@ const AlertsChart = ({ chartDays }) => {
                 <CursorVoronoiContainer
                   mouseFollowTooltips
                   labels={({ datum }) =>
-                    `Alert severity: ${datum.severity}\nAlert name: ${datum.name ? datum.name : '---'}\nNamespace: ${
-                      datum.namespace ? datum.namespace : '---'
-                    }\nLayer: ${datum.layer ? datum.layer : '---'}\nComponent: ${
-                      datum.component
-                    }\nStart time: ${formatDate(new Date(datum.y0), true)}\nStop time: ${formatDate(
-                      new Date(datum.y),
-                      true,
-                    )}`
+                    `Alert severity: ${datum.severity}
+                    Alert name: ${datum.name ? datum.name : '---'}
+                    Namespace: ${datum.namespace ? datum.namespace : '---'}
+                    Layer: ${datum.layer ? datum.layer : '---'}
+                    Component: ${datum.component}
+                    Start time: ${formatDate(new Date(datum.y0), true)}
+                    Stop time: ${formatDate(new Date(datum.y), true)}`
                   }
                 />
               }

--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -1,26 +1,33 @@
+/* eslint-disable prettier/prettier */
 import * as React from 'react';
 
 import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
 import { Card, CardTitle, EmptyState, EmptyStateBody } from '@patternfly/react-core';
-import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
-import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 import { createAlertsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
 
-const AlertsChart = ({ alertsData = [], chartDays }) => {
+const AlertsChart = ({ chartDays }) => {
   const [chartData, setChartData] = React.useState([]);
   const [chartContainerHeight, setChartContainerHeight] = React.useState();
   const [chartHeight, setChartHeight] = React.useState();
+  const alertsData = useSelector((state) =>
+    state.plugins.mcp.getIn(['incidentsData', 'alertsData']),
+  );
+  const alertsAreLoading = useSelector((state) =>
+    state.plugins.mcp.getIn(['incidentsData', 'alertsAreLoading']),
+  );
+
   React.useEffect(() => {
     setChartContainerHeight(chartData?.length < 5 ? 250 : chartData?.length * 40);
     setChartHeight(chartData?.length < 5 ? 200 : chartData?.length * 35);
   }, [chartData]);
   const dateValues = generateDateArray(chartDays);
+
   React.useEffect(() => {
     setChartData(alertsData.map((alert) => createAlertsChartBars(alert)));
   }, [alertsData]);
-  const isLoading = alertsData.length === 0 ? true : false;
+
   const [width, setWidth] = React.useState(0);
   const containerRef = React.useRef(null);
   const handleResize = () => {
@@ -40,7 +47,7 @@ const AlertsChart = ({ alertsData = [], chartDays }) => {
     <Card className="alerts-chart-card">
       <div ref={containerRef}>
         <CardTitle>Alerts Timeline</CardTitle>
-        {isLoading ? (
+        {alertsAreLoading ? (
           <EmptyState
             variant="large"
             style={{
@@ -61,9 +68,9 @@ const AlertsChart = ({ alertsData = [], chartDays }) => {
                 <CursorVoronoiContainer
                   mouseFollowTooltips
                   labels={({ datum }) =>
-                    `Alert severity: ${datum.severity}\nAlert name: ${datum.name}\nNamespace: ${
-                      datum.namespace
-                    }\nLayer: ${datum.layer}\nComponent: ${
+                    `Alert severity: ${datum.severity}\nAlert name: ${datum.name ? datum.name : '---'}\nNamespace: ${
+                      datum.namespace ? datum.namespace : '---'
+                    }\nLayer: ${datum.layer ? datum.layer : '---'}\nComponent: ${
                       datum.component
                     }\nStart time: ${formatDate(new Date(datum.y0), true)}\nStop time: ${formatDate(
                       new Date(datum.y),
@@ -74,9 +81,9 @@ const AlertsChart = ({ alertsData = [], chartDays }) => {
               }
               domainPadding={{ x: [30, 25] }}
               legendData={[
-                { name: 'Critical', symbol: { fill: global_danger_color_100.var } },
-                { name: 'Info', symbol: { fill: global_info_color_100.var } },
-                { name: 'Warning', symbol: { fill: global_warning_color_100.var } },
+                { name: 'Critical', symbol: { fill: '#c9190b' } },
+                { name: 'Info', symbol: { fill: '#2b9af3' } },
+                { name: 'Warning', symbol: { fill: '#f0ab00' } },
               ]}
               legendPosition="bottom-left"
               //this should be always less than the container height

--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -6,6 +6,9 @@ import { Card, CardTitle, EmptyState, EmptyStateBody } from '@patternfly/react-c
 import { createAlertsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
 import { useSelector } from 'react-redux';
+import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
+import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
+import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 
 const AlertsChart = ({ chartDays }) => {
   const [chartData, setChartData] = React.useState([]);
@@ -81,9 +84,9 @@ const AlertsChart = ({ chartDays }) => {
               }
               domainPadding={{ x: [30, 25] }}
               legendData={[
-                { name: 'Critical', symbol: { fill: '#c9190b' } },
-                { name: 'Info', symbol: { fill: '#2b9af3' } },
-                { name: 'Warning', symbol: { fill: '#f0ab00' } },
+                { name: 'Critical', symbol: { fill: global_danger_color_100.var } },
+                { name: 'Info', symbol: { fill: global_info_color_100.var } },
+                { name: 'Warning', symbol: { fill: global_warning_color_100.var } },
               ]}
               legendPosition="bottom-left"
               //this should be always less than the container height

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -75,8 +75,6 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
           return '#EFBAB6'; // Less transparent for danger
       }
     }
-
-    return datum.fill; // Original fill color if the bar is selected
   }
 
   const CursorVoronoiContainer = createContainer('voronoi');

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -45,11 +45,20 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
 
   const isHidden = (group_id) => selectedId !== '' && selectedId !== group_id;
   const clickHandler = (data, datum) => {
-    dispatch(
-      setChooseIncident({
-        incidentGroupId: datum.datum.group_id,
-      }),
-    );
+    if(datum.datum.group_id === selectedId) {
+      dispatch(
+        setChooseIncident({
+          incidentGroupId: '',
+        }),
+      );
+    } else {
+      dispatch(
+        setChooseIncident({
+          incidentGroupId: datum.datum.group_id,
+        }),
+      );
+    }
+
   };
 
   function getAdjustedFillColor(datum) {

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 
 import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
 import { Bullseye, Card, CardTitle, Spinner } from '@patternfly/react-core';
-import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
-import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 import { createIncidentsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
 import { useDispatch, useSelector } from 'react-redux';
 import { setChooseIncident } from '../../../actions/observe';
+import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
+import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
+import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 
 const IncidentsChart = ({ incidentsData, chartDays }) => {
   const dispatch = useDispatch();

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import * as React from 'react';
 
 import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
@@ -46,13 +45,12 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
 
   const isHidden = (group_id) => selectedId !== '' && selectedId !== group_id;
   const clickHandler = (data, datum) => {
-    if(datum.datum.group_id === selectedId) {
+    if (datum.datum.group_id === selectedId) {
       dispatch(
         setChooseIncident({
           incidentGroupId: '',
         }),
-
-      )
+      );
       dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
     } else {
       dispatch(
@@ -61,7 +59,6 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
         }),
       );
     }
-
   };
 
   function getAdjustedFillColor(datum) {

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -10,6 +10,7 @@ import { setChooseIncident } from '../../../actions/observe';
 import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
+import { setAlertsAreLoading } from '../../../actions/observe';
 
 const IncidentsChart = ({ incidentsData, chartDays }) => {
   const dispatch = useDispatch();
@@ -50,7 +51,9 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
         setChooseIncident({
           incidentGroupId: '',
         }),
-      );
+
+      )
+      dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
     } else {
       dispatch(
         setChooseIncident({

--- a/web/src/components/Incidents/IncidentsHeader/IncidentsHeader.jsx
+++ b/web/src/components/Incidents/IncidentsHeader/IncidentsHeader.jsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import IncidentsChart from '../IncidentsChart/IncidentsChart';
 import AlertsChart from '../AlertsChart/AlertsChart';
 
-export const IncidentsHeader = ({ alertsData, incidentsData, chartDays }) => {
+export const IncidentsHeader = ({ incidentsData, chartDays }) => {
   return (
     <div className="incidents-chart-card-container">
       <IncidentsChart incidentsData={incidentsData} chartDays={chartDays} />
-      <AlertsChart alertsData={alertsData} chartDays={chartDays} />
+      <AlertsChart chartDays={chartDays} />
     </div>
   );
 };

--- a/web/src/components/Incidents/IncidentsTable.jsx
+++ b/web/src/components/Incidents/IncidentsTable.jsx
@@ -32,6 +32,9 @@ export const IncidentsTable = ({ namespace }) => {
   const alertsTableData = useSelector((state) =>
     state.plugins.mcp.getIn(['incidentsData', 'alertsTableData']),
   );
+  const alertsAreLoading = useSelector((state) =>
+    state.plugins.mcp.getIn(['incidentsData', 'alertsAreLoading']),
+  );
 
   return (
     <Card>
@@ -45,7 +48,7 @@ export const IncidentsTable = ({ namespace }) => {
               <Th width={25}>{columnNames.state}</Th>
             </Tr>
           </Thead>
-          {_.isEmpty(alertsTableData) ? (
+          {_.isEmpty(alertsTableData) || alertsAreLoading ? (
             <Tr>
               <Td colSpan={4}>
                 <EmptyState

--- a/web/src/components/Incidents/consts.js
+++ b/web/src/components/Incidents/consts.js
@@ -76,32 +76,40 @@ export const daysMenuItems = (filters) => [
   <SelectOption key="15-day-filter" value="15 days" isSelected={filters.days.includes('15d')} />,
 ];
 
-export const dropdownItems = (t, dispatch, incidentsActiveFilters) => [
+export const dropdownItems = (t, dispatch, incidentsActiveFilters, setIncidentsAreLoading) => [
   <DropdownItemDeprecated
     key="1-day-filter"
     component="button"
-    onClick={() => changeDaysFilter('1 day', dispatch, incidentsActiveFilters)}
+    onClick={() =>
+      changeDaysFilter('1 day', dispatch, incidentsActiveFilters, setIncidentsAreLoading)
+    }
   >
     {t('1 day')}
   </DropdownItemDeprecated>,
   <DropdownItemDeprecated
     key="3-day-filter"
     component="button"
-    onClick={() => changeDaysFilter('3 days', dispatch, incidentsActiveFilters)}
+    onClick={() =>
+      changeDaysFilter('3 days', dispatch, incidentsActiveFilters, setIncidentsAreLoading)
+    }
   >
     {t('3 days')}
   </DropdownItemDeprecated>,
   <DropdownItemDeprecated
     key="7-day-filter"
     component="button"
-    onClick={() => changeDaysFilter('7 days', dispatch, incidentsActiveFilters)}
+    onClick={() =>
+      changeDaysFilter('7 days', dispatch, incidentsActiveFilters, setIncidentsAreLoading)
+    }
   >
     {t('7 days')}
   </DropdownItemDeprecated>,
   <DropdownItemDeprecated
     key="15-day-filter"
     component="button"
-    onClick={() => changeDaysFilter('15 days', dispatch, incidentsActiveFilters)}
+    onClick={() =>
+      changeDaysFilter('15 days', dispatch, incidentsActiveFilters, setIncidentsAreLoading)
+    }
   >
     {t('15 days')}
   </DropdownItemDeprecated>,

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
+import { setAlertsAreLoading, setIncidentsActiveFilters } from '../../actions/observe';
 import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
-import { setIncidentsActiveFilters } from '../../actions/observe';
 
 function consolidateAndMergeIntervals(data) {
   const severityRank = { 2: 2, 1: 1, 0: 0 };
@@ -305,12 +305,14 @@ export const updateBrowserUrl = (params) => {
   window.history.replaceState(null, '', newUrl);
 };
 
-export const changeDaysFilter = (days, dispatch, filters) => {
+export const changeDaysFilter = (days, dispatch, filters, setIncidentsAreLoading) => {
   dispatch(
     setIncidentsActiveFilters({
       incidentsActiveFilters: { days: [days], incidentFilters: filters.incidentFilters },
     }),
   );
+  dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
+  setIncidentsAreLoading(true);
 };
 
 export const onIncidentFiltersSelect = (event, selection, dispatch, incidentsActiveFilters) => {

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -3,7 +3,6 @@ import { setAlertsAreLoading, setIncidentsActiveFilters } from '../../actions/ob
 import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
-
 function consolidateAndMergeIntervals(data) {
   const severityRank = { 2: 2, 1: 1, 0: 0 };
 

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -83,37 +83,34 @@ export const createIncidentsChartBars = (incident) => {
   return data;
 };
 
-function groupAlertTimestamps(data) {
-  if (data.length === 0) return [];
+function consolidateAndMergeAlertIntervals(data) {
+  const intervals = [];
+  const sortedValues = data.values.sort((a, b) => new Date(a[0]) - new Date(b[0]));
 
-  let result = [];
-  let start_time = data[0][0];
-  let current_value = data[0][1];
+  let currentStart = sortedValues[0][0];
 
-  for (let i = 1; i < data.length; i++) {
-    let timestamp = data[i][0];
-    let value = data[i][1];
+  for (let i = 1; i < sortedValues.length; i++) {
+    const previousTimestamp = new Date(sortedValues[i - 1][0]);
+    const currentTimestamp = new Date(sortedValues[i][0]);
+    const timeDifference = (currentTimestamp - previousTimestamp) / 1000 / 60;
 
-    // If the second index value changes
-    if (value !== current_value) {
-      // Push the grouped data into the result
-      result.push([start_time, data[i - 1][0], current_value]);
-
-      // Start a new group
-      start_time = timestamp;
-      current_value = value;
+    // If the gap is larger than 5 minutes, close the current interval
+    if (timeDifference > 5) {
+      intervals.push([currentStart, sortedValues[i - 1][0]]);
+      currentStart = sortedValues[i][0]; // Start a new interval
     }
   }
+  intervals.push([currentStart, sortedValues[sortedValues.length - 1][0]]);
 
-  // Push the last group
-  result.push([start_time, data[data.length - 1][0], current_value]);
-
-  return result;
+  return intervals;
 }
 
 export const createAlertsChartBars = (alert) => {
-  const groupedData = groupAlertTimestamps(alert.values);
+  // Consolidate intervals
+  const groupedData = consolidateAndMergeAlertIntervals(alert);
+
   const data = [];
+
   for (let i = 0; i < groupedData.length; i++) {
     data.push({
       y0: new Date(groupedData[i][0]),


### PR DESCRIPTION
The issue https://issues.redhat.com/browse/OU-628

This PR fixes 2 major things:
1) I updated the logic for creating bars for the alert chart. Now the bar respects the gaps in time and the bars are created accordingly and not smushed all together into 1 line
2) I added more logic to how we manage loading states for the alerts chart and incidents table. Now if the date changes -> we force loading states so the component won't render BEFORE we get new data from the API. Previously there was an issue that was causing the component to render again with old data, without waiting for the API calls to resolve.

Smaller things I added in this PR:
I added unselect logic to the "onclick" function that fires when the user clicks on an incident in the incident chart.
I replaced the PF color variables because of the bug when PF loses its styles and these variables doesn't work