### PR TITLE
OU-645: Fix virtualization perspective routes and routing

### DIFF
--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -713,9 +713,13 @@ const PollerPages = () => {
   if (perspective === 'virtualization-perspective') {
     return (
       <Switch>
-        <Route path="/virt-monitoring/alerts" exact component={AlertsPage} />
-        <Route path="/virt-monitoring/rules/:id" exact component={AlertRulesDetailsPage} />
-        <Route path="/virt-monitoring/alerts/:ruleID" component={AlertsDetailsPage} />
+        <Route
+          path="/virt-monitoring/(alerts|alertrules|silences)"
+          exact
+          component={AlertingPage}
+        />
+        <Route path="/virt-monitoring/alertrules/:id" exact component={AlertRulesDetailsPage} />
+        <Route path="/virt-monitoring/alerts/:ruleID" exact component={AlertsDetailsPage} />
         <Route path="/virt-monitoring/query-browser" exact component={QueryBrowserPage} />
         <Route path="/virt-monitoring/silences" exact component={SilencesPage} />
         <Route path="/virt-monitoring/silences/:id" exact component={SilencesDetailsPage} />

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -113,8 +113,10 @@ export const getAlertRulesUrl = (perspective: Perspective) => {
   switch (perspective) {
     case 'acm':
       return `/multicloud${RuleResource.plural}`;
-    default:
+    case 'virtualization-perspective':
+      return `/virt-monitoring/alertrules`;
     case 'admin':
+    default:
       return RuleResource.plural;
   }
 };
@@ -170,7 +172,7 @@ export const getRuleUrl = (perspective: Perspective, rule: Rule, namespace?: str
     case 'acm':
       return `/multicloud${RuleResource.plural}/${_.get(rule, 'id')}`;
     case 'virtualization-perspective':
-      return `/virt-monitoring/rules/${rule?.id}`;
+      return `/virt-monitoring/alertrules/${rule?.id}`;
     case 'admin':
       return `${RuleResource.plural}/${_.get(rule, 'id')}`;
     case 'dev':
@@ -328,7 +330,7 @@ export const getDashboardsUrl = (
 ) => {
   switch (perspective) {
     case 'virtualization-perspective':
-      return `/monitoring/dashboards/${boardName}`;
+      return `/virt-monitoring/dashboards/${boardName}`;
     case 'admin':
       return `/monitoring/dashboards/${boardName}`;
     case 'dev':


### PR DESCRIPTION
During the last rebase and merge a number of small issues cropped up with the virtualization perspective routes and routing which makes them generally unsynced. This PR looks to bring them back in line. 

Virtualization perspectives after these changes can be seen [here](https://drive.google.com/file/d/1aTznX2F82wUVBJOqkdV1DqMDt0eAmLwc/view?usp=sharing).

This PR should be merged before #306 to prevent issues with backporting to 4.18. 