### PR TITLE
RHINENG-15284: sync alert chart to main filter

### DIFF
--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -4,12 +4,15 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patter
 import { Card, CardTitle, EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { createAlertsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
+import * as _ from 'lodash-es';
+import { setAlertsAreLoading } from '../../../actions/observe';
 
 const AlertsChart = ({ chartDays }) => {
+  const dispatch = useDispatch();
   const [chartData, setChartData] = React.useState([]);
   const [chartContainerHeight, setChartContainerHeight] = React.useState();
   const [chartHeight, setChartHeight] = React.useState();
@@ -19,7 +22,12 @@ const AlertsChart = ({ chartDays }) => {
   const alertsAreLoading = useSelector((state) =>
     state.plugins.mcp.getIn(['incidentsData', 'alertsAreLoading']),
   );
-
+  const filteredData = useSelector((state) =>
+    state.plugins.mcp.getIn(['incidentsData', 'filteredIncidentsData']),
+  );
+  const incidentGroupId = useSelector((state) =>
+    state.plugins.mcp.getIn(['incidentsData', 'incidentGroupId']),
+  );
   React.useEffect(() => {
     setChartContainerHeight(chartData?.length < 5 ? 250 : chartData?.length * 40);
     setChartHeight(chartData?.length < 5 ? 200 : chartData?.length * 35);
@@ -29,6 +37,20 @@ const AlertsChart = ({ chartDays }) => {
   React.useEffect(() => {
     setChartData(alertsData.map((alert) => createAlertsChartBars(alert)));
   }, [alertsData]);
+
+  React.useEffect(() => {
+    //state when chosen incident not passing filters or the is no data
+    if (
+      _.isEmpty(filteredData) ||
+      !filteredData.find((incident) => incident.group_id === incidentGroupId)
+    ) {
+      dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
+    } //state when chosen incident passing filters
+    else if (filteredData.find((incident) => incident.group_id === incidentGroupId)) {
+      dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredData]);
 
   const [width, setWidth] = React.useState(0);
   const containerRef = React.useRef(null);

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -328,7 +328,6 @@ export const changeDaysFilter = (days, dispatch, filters, setIncidentsAreLoading
       incidentsActiveFilters: { days: [days], incidentFilters: filters.incidentFilters },
     }),
   );
-  dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
   setIncidentsAreLoading(true);
 };
 


### PR DESCRIPTION
I added 2 filter cases to manage the state of alerts chart:
1) state when the chosen incident is not passing filters or the is no data -> we force the empty state through alerts is loading
2) state when the chosen incident is in the filtered data -> we show the incident 

Also, I removed dispatch(setAlertsAreLoading({ alertsAreLoading: true })); from the days filter because it is causing issues (if you choose the same day filter - it forces the loading state. IncidentsPage sync is already updated in such way that it doesn't need it -> changing days already triggers everything we need.