### PR TITLE
RHINENG-15582: Incidents dark theme support

### DIFF
--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -9,7 +9,7 @@ import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_da
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 
-const AlertsChart = ({ chartDays }) => {
+const AlertsChart = ({ chartDays, theme }) => {
   const [chartData, setChartData] = React.useState([]);
   const [chartContainerHeight, setChartContainerHeight] = React.useState();
   const [chartHeight, setChartHeight] = React.useState();
@@ -82,9 +82,24 @@ const AlertsChart = ({ chartDays }) => {
               }
               domainPadding={{ x: [30, 25] }}
               legendData={[
-                { name: 'Critical', symbol: { fill: global_danger_color_100.var } },
-                { name: 'Info', symbol: { fill: global_info_color_100.var } },
-                { name: 'Warning', symbol: { fill: global_warning_color_100.var } },
+                {
+                  name: 'Critical',
+                  symbol: {
+                    fill: theme === 'light' ? global_danger_color_100.var : '#C9190B',
+                  },
+                },
+                {
+                  name: 'Info',
+                  symbol: {
+                    fill: theme === 'light' ? global_info_color_100.var : '#F0AB00',
+                  },
+                },
+                {
+                  name: 'Warning',
+                  symbol: {
+                    fill: theme === 'light' ? global_warning_color_100.var : '#06C',
+                  },
+                },
               ]}
               legendPosition="bottom-left"
               //this should be always less than the container height

--- a/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.jsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 
-import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartGroup,
+  ChartLabel,
+  ChartLegend,
+  createContainer,
+} from '@patternfly/react-charts';
 import { Card, CardTitle, EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { createAlertsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
@@ -27,7 +35,7 @@ const AlertsChart = ({ chartDays, theme }) => {
   const dateValues = generateDateArray(chartDays);
 
   React.useEffect(() => {
-    setChartData(alertsData.map((alert) => createAlertsChartBars(alert)));
+    setChartData(alertsData.map((alert) => createAlertsChartBars(alert, theme)));
   }, [alertsData]);
 
   const [width, setWidth] = React.useState(0);
@@ -91,16 +99,23 @@ const AlertsChart = ({ chartDays, theme }) => {
                 {
                   name: 'Info',
                   symbol: {
-                    fill: theme === 'light' ? global_info_color_100.var : '#F0AB00',
+                    fill: theme === 'light' ? global_info_color_100.var : '#06C',
                   },
                 },
                 {
                   name: 'Warning',
                   symbol: {
-                    fill: theme === 'light' ? global_warning_color_100.var : '#06C',
+                    fill: theme === 'light' ? global_warning_color_100.var : '#F0AB00',
                   },
                 },
               ]}
+              legendComponent={
+                <ChartLegend
+                  labelComponent={
+                    <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
+                  }
+                />
+              }
               legendPosition="bottom-left"
               //this should be always less than the container height
               height={chartHeight}
@@ -119,6 +134,9 @@ const AlertsChart = ({ chartDays, theme }) => {
                   new Date(t).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
                 }
                 tickValues={dateValues}
+                tickLabelComponent={
+                  <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
+                }
               />
               <ChartGroup horizontal>
                 {chartData.map((bar, index) => {

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 
-import { Chart, ChartAxis, ChartBar, ChartGroup, createContainer } from '@patternfly/react-charts';
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartGroup,
+  ChartLabel,
+  ChartLegend,
+  ChartThemeColor,
+  createContainer,
+} from '@patternfly/react-charts';
 import { Bullseye, Card, CardTitle, Spinner } from '@patternfly/react-core';
 import { createIncidentsChartBars, formatDate, generateDateArray } from '../utils';
 import { getResizeObserver } from '@patternfly/react-core';
@@ -35,7 +44,7 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
   }, []);
   React.useEffect(() => {
     setIsLoading(false);
-    setChartData(incidentsData.map((incident) => createIncidentsChartBars(incident)));
+    setChartData(incidentsData.map((incident) => createIncidentsChartBars(incident, theme)));
   }, [incidentsData]);
   const dateValues = generateDateArray(chartDays);
 
@@ -61,18 +70,8 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
     }
   };
 
-  function getAdjustedFillColor(datum) {
-    if (isHidden(datum.group_id)) {
-      switch (datum.fill) {
-        case 'var(--pf-v5-global--warning-color--100)':
-          return '#F8DFA7'; // Less transparent for warning
-        case 'var(--pf-v5-global--info-color--100)':
-          return '#B2D1F0'; // Less transparent for info
-        case 'var(--pf-v5-global--danger-color--100)':
-          return '#EFBAB6'; // Less transparent for danger
-      }
-    }
-    return datum.fill;
+  function getOpacity(datum) {
+    return (datum.fillOpacity = isHidden(datum.group_id) ? '0.3' : '1');
   }
 
   const CursorVoronoiContainer = createContainer('voronoi');
@@ -116,16 +115,23 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
                 {
                   name: 'Info',
                   symbol: {
-                    fill: theme === 'light' ? global_info_color_100.var : '#F0AB00',
+                    fill: theme === 'light' ? global_info_color_100.var : '#06C',
                   },
                 },
                 {
                   name: 'Warning',
                   symbol: {
-                    fill: theme === 'light' ? global_warning_color_100.var : '#06C',
+                    fill: theme === 'light' ? global_warning_color_100.var : '#F0AB00',
                   },
                 },
               ]}
+              legendComponent={
+                <ChartLegend
+                  labelComponent={
+                    <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
+                  }
+                />
+              }
               legendPosition="bottom-left"
               //this should be always less than the container height
               height={chartHeight}
@@ -136,6 +142,7 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
                 top: 0,
               }}
               width={width}
+              themeColor={ChartThemeColor.purple}
             >
               <ChartAxis
                 dependentAxis
@@ -144,6 +151,9 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
                   new Date(t).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
                 }
                 tickValues={dateValues}
+                tickLabelComponent={
+                  <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
+                }
               />
               <ChartGroup horizontal>
                 {chartData.map((bar) => {
@@ -154,8 +164,9 @@ const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
                       key={bar.group_id}
                       style={{
                         data: {
-                          fill: ({ datum }) => getAdjustedFillColor(datum),
+                          fill: ({ datum }) => datum.fill,
                           stroke: ({ datum }) => datum.fill,
+                          fillOpacity: ({ datum }) => getOpacity(datum),
                         },
                       }}
                       events={[

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.jsx
@@ -11,7 +11,7 @@ import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info
 import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 import { setAlertsAreLoading } from '../../../actions/observe';
 
-const IncidentsChart = ({ incidentsData, chartDays }) => {
+const IncidentsChart = ({ incidentsData, chartDays, theme }) => {
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = React.useState(true);
   const [chartData, setChartData] = React.useState();
@@ -107,9 +107,24 @@ const IncidentsChart = ({ incidentsData, chartDays }) => {
               }
               domainPadding={{ x: [30, 25] }}
               legendData={[
-                { name: 'Critical', symbol: { fill: global_danger_color_100.var } },
-                { name: 'Info', symbol: { fill: global_info_color_100.var } },
-                { name: 'Warning', symbol: { fill: global_warning_color_100.var } },
+                {
+                  name: 'Critical',
+                  symbol: {
+                    fill: theme === 'light' ? global_danger_color_100.var : '#C9190B',
+                  },
+                },
+                {
+                  name: 'Info',
+                  symbol: {
+                    fill: theme === 'light' ? global_info_color_100.var : '#F0AB00',
+                  },
+                },
+                {
+                  name: 'Warning',
+                  symbol: {
+                    fill: theme === 'light' ? global_warning_color_100.var : '#06C',
+                  },
+                },
               ]}
               legendPosition="bottom-left"
               //this should be always less than the container height

--- a/web/src/components/Incidents/IncidentsHeader/IncidentsHeader.jsx
+++ b/web/src/components/Incidents/IncidentsHeader/IncidentsHeader.jsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import IncidentsChart from '../IncidentsChart/IncidentsChart';
 import AlertsChart from '../AlertsChart/AlertsChart';
 
-export const IncidentsHeader = ({ incidentsData, chartDays }) => {
+export const IncidentsHeader = ({ incidentsData, chartDays, theme }) => {
   return (
     <div className="incidents-chart-card-container">
-      <IncidentsChart incidentsData={incidentsData} chartDays={chartDays} />
-      <AlertsChart chartDays={chartDays} />
+      <IncidentsChart incidentsData={incidentsData} chartDays={chartDays} theme={theme} />
+      <AlertsChart chartDays={chartDays} theme={theme} />
     </div>
   );
 };

--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -357,7 +357,7 @@ const IncidentsPage = () => {
           )}
           <div className="row">
             <div className="col-xs-12">
-              <IncidentsTable theme={theme} />
+              <IncidentsTable />
             </div>
           </div>
         </div>

--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -33,6 +33,7 @@ import {
   onIncidentFiltersSelect,
   parseUrlParams,
   updateBrowserUrl,
+  usePatternFlyTheme,
 } from './utils';
 import { groupAlertsForTable, processAlerts } from './processAlerts';
 import {
@@ -59,6 +60,7 @@ const IncidentsPage = () => {
   const location = useLocation();
   const urlParams = parseUrlParams(location.search);
   const { perspective } = usePerspective();
+  const { theme } = usePatternFlyTheme();
   // loading states
   const [incidentsAreLoading, setIncidentsAreLoading] = React.useState(true);
   // days span is where we store the value for creating time ranges for
@@ -350,11 +352,12 @@ const IncidentsPage = () => {
               alertsData={alertsData}
               incidentsData={filteredData}
               chartDays={timeRanges.length}
+              theme={theme}
             />
           )}
           <div className="row">
             <div className="col-xs-12">
-              <IncidentsTable />
+              <IncidentsTable theme={theme} />
             </div>
           </div>
         </div>

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import { useEffect, useState } from 'react';
 import { setAlertsAreLoading, setIncidentsActiveFilters } from '../../actions/observe';
 import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import global_info_color_100 from '@patternfly/react-tokens/dist/esm/global_info_color_100';
@@ -372,3 +373,30 @@ export const parseUrlParams = (search) => {
 
   return result;
 };
+
+const PF_THEME_DARK_CLASS = 'pf-v5-theme-dark';
+const PF_THEME_DARK_CLASS_LEGACY = 'pf-theme-dark'; // legacy class name needed to support PF4
+/**
+ * The @openshift-console/dynamic-plugin-sdk package does not expose the theme setting of the user preferences,
+ * therefore check if the root <html> element has the PatternFly css class set for the dark theme.
+ */
+function getTheme() {
+  const classList = document.documentElement.classList;
+  if (classList.contains(PF_THEME_DARK_CLASS) || classList.contains(PF_THEME_DARK_CLASS_LEGACY)) {
+    return 'dark';
+  }
+  return 'light';
+}
+/**
+ * In case the user sets "system default" theme in the user preferences, update the theme if the system theme changes.
+ */
+export function usePatternFlyTheme() {
+  const [theme, setTheme] = useState(getTheme());
+  useEffect(() => {
+    const reloadTheme = () => setTheme(getTheme());
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', reloadTheme);
+    return () => mq.removeEventListener('change', reloadTheme);
+  }, [setTheme]);
+  return { theme };
+}

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -53,11 +53,16 @@ function consolidateAndMergeIntervals(data) {
  * @param {Object} incident - The incident data containing values with timestamps and severity levels.
  * @returns {Array} - An array of incident objects with `y0`, `y`, `x`, and `name` fields representing the bars for the chart.
  */
-export const createIncidentsChartBars = (incident) => {
+export const createIncidentsChartBars = (incident, theme) => {
   const groupedData = consolidateAndMergeIntervals(incident);
   const data = [];
   const getSeverityName = (value) => {
     return value === '2' ? 'Critical' : value === '1' ? 'Warning' : 'Info';
+  };
+  const barChartColorScheme = {
+    critical: theme === 'light' ? global_danger_color_100.var : '#C9190B',
+    info: theme === 'light' ? global_info_color_100.var : '#06C',
+    warning: theme === 'light' ? global_warning_color_100.var : '#F0AB00',
   };
 
   for (let i = 0; i < groupedData.length; i++) {
@@ -72,10 +77,10 @@ export const createIncidentsChartBars = (incident) => {
       group_id: incident.group_id,
       fill:
         severity === 'Critical'
-          ? global_danger_color_100.var
+          ? barChartColorScheme.critical
           : severity === 'Warning'
-          ? global_warning_color_100.var
-          : global_info_color_100.var,
+          ? barChartColorScheme.warning
+          : barChartColorScheme.info,
     });
   }
 
@@ -104,9 +109,14 @@ function consolidateAndMergeAlertIntervals(data) {
   return intervals;
 }
 
-export const createAlertsChartBars = (alert) => {
+export const createAlertsChartBars = (alert, theme) => {
   // Consolidate intervals
   const groupedData = consolidateAndMergeAlertIntervals(alert);
+  const barChartColorScheme = {
+    critical: theme === 'light' ? global_danger_color_100.var : '#C9190B',
+    info: theme === 'light' ? global_info_color_100.var : '#06C',
+    warning: theme === 'light' ? global_warning_color_100.var : '#F0AB00',
+  };
 
   const data = [];
 
@@ -122,10 +132,10 @@ export const createAlertsChartBars = (alert) => {
       component: alert.component,
       fill:
         alert.severity === 'critical'
-          ? global_danger_color_100.var
+          ? barChartColorScheme.critical
           : alert.severity === 'warning'
-          ? global_warning_color_100.var
-          : global_info_color_100.var,
+          ? barChartColorScheme.warning
+          : barChartColorScheme.info,
     });
   }
 


### PR DESCRIPTION
Dark theme support for incidents page:
1) added hook made by Andreas for other openshift project https://github.com/openshift/distributed-tracing-console-plugin/commit/38dae4c768d9ac3cb03bffa8e06d2224f4515bea
2)Pass theme value to the charts and calculate the following things:
1. Color of chart bars for all 3 types
2. Text of axis
3. Text of legend
4. Legend's color

Also, I updated the logic for the OnClick functionality in the Incidents chart.  Now, we use fillOpacity props instead of using switch-case and fill props.

![image](https://github.com/user-attachments/assets/e3ef54b1-5538-4192-9555-be4ef29e2241)
