### PR TITLE
RHINENG-15501: Fixing incidents filter issues with severeties and long standing

### DIFF
--- a/web/src/components/Incidents/processIncidents.ts
+++ b/web/src/components/Incidents/processIncidents.ts
@@ -54,6 +54,18 @@ export function processIncidents(data: Incident[]): ProcessedIncident[] {
       return [date, value[1]] as [Date, string];
     });
 
+    // Determine severity flags based on values array
+    let critical = false;
+    let warning = false;
+    let informative = false;
+
+    incident.values.forEach((value) => {
+      const severity = value[1]; // Second index of the value array
+      if (severity === '2') critical = true;
+      if (severity === '1') warning = true;
+      if (severity === '0') informative = true;
+    });
+
     const timestamps = incident.values.map((value) => value[0]); // Extract timestamps
     const lastTimestamp = Math.max(...timestamps); // Last timestamp in seconds
     const firstTimestamp = Math.min(...timestamps); // First timestamp in seconds
@@ -77,9 +89,9 @@ export function processIncidents(data: Incident[]): ProcessedIncident[] {
       layer: incident.metric.layer,
       values: processedValues,
       x: incidents.length - index,
-      critical: incident.metric.src_severity === 'critical',
-      warning: incident.metric.src_severity === 'warning',
-      informative: incident.metric.src_severity === 'info',
+      critical, // Updated based on 'values' array
+      warning, // Updated based on 'values' array
+      informative, // Updated based on 'values' array
       'Long standing': longStanding,
       resolved: resolved,
       firing: firing,

--- a/web/src/components/Incidents/utils.js
+++ b/web/src/components/Incidents/utils.js
@@ -215,44 +215,28 @@ export function generateDateArray(days) {
 export function filterIncident(filters, incidents) {
   const conditions = {
     'Long standing': 'Long standing',
-    Critical: 'Critical',
-    Warning: 'Warning',
-    Informative: 'Informative',
-    Firing: 'Firing',
-    Resolved: 'Resolved',
+    Critical: 'critical',
+    Warning: 'warning',
+    Informative: 'informative',
+    Firing: 'firing',
+    Resolved: 'resolved',
   };
 
   return incidents.filter((incident) => {
-    // If there are no incidentFilters filters applied, return all incidents
+    // If no filters are applied, return all incidents except those marked 'Long standing'
     if (!filters.incidentFilters.length) {
       return incident[conditions['Long standing']] !== true;
     }
-
-    // Separate filters into categories
     const longStandingFilter = filters.incidentFilters.includes('Long standing');
-    const severityFilters = ['Critical', 'Warning', 'Informative'].filter((key) =>
-      filters.incidentFilters.includes(key),
-    );
-    const statusFilters = ['Firing', 'Resolved'].filter((key) =>
-      filters.incidentFilters.includes(key),
-    );
-
-    // Check for each category
-    const isLongStanding = longStandingFilter
+    const otherFilters = filters.incidentFilters.filter((key) => key !== 'Long standing');
+    const isLongStandingMatch = longStandingFilter
       ? incident[conditions['Long standing']] === true
-      : true;
-
-    const isSeverityMatch =
-      severityFilters.length > 0
-        ? severityFilters.some((key) => incident[conditions[key].toLowerCase()] === true)
-        : true;
-
-    const isStatusMatch =
-      statusFilters.length > 0
-        ? statusFilters.some((key) => incident[conditions[key].toLowerCase()] === true)
-        : true;
-
-    return isLongStanding && isSeverityMatch && isStatusMatch;
+      : false;
+    const isOtherFiltersMatch = otherFilters.some(
+      (filter) => conditions[filter] && incident[conditions[filter]] === true,
+    );
+    // Include the incident if it matches 'Long standing' OR any other filter
+    return isLongStandingMatch || isOtherFiltersMatch;
   });
 }
 


### PR DESCRIPTION
1) The old logic for processing severity was dependent on src_severity, it is unreliable. With how we combine incidents into 1 object depending on group id the src_severity could be "warning" even though there are timestamps with "2" in the second index which marks 'critical'. I updated the logic to mark the incident as critical/warning/info if we have at least 1 timestamp with critical/warning/info. 
2)Updated filter logic to make sure that long standing is Additive. That means by default we return everything except long standing
