### PR TITLE
RHINENG-15594: fix tooltip in row details

### DIFF
--- a/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
@@ -102,14 +102,14 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
                         : '#'
                     }
                     style={
-                      !alertDetails?.rule
+                      !alertDetails?.rule || alertDetails.resolved
                         ? { pointerEvents: 'none', color: 'inherit', textDecoration: 'inherit' }
                         : {}
                     }
                   >
                     {alertDetails.alertname}
                   </Link>
-                  {!alertDetails?.rule && (
+                  {(!alertDetails?.rule || alertDetails.resolved) && (
                     <Tooltip content={<div>No details can be shown for inactive alerts.</div>}>
                       <OutlinedQuestionCircleIcon className="expanded-details-text-margin" />
                     </Tooltip>

--- a/web/src/components/Incidents/processAlerts.js
+++ b/web/src/components/Incidents/processAlerts.js
@@ -139,20 +139,18 @@ export function groupAlerts(objects) {
 
 export function processAlerts(data) {
   const firing = groupAlerts(data).filter((alert) => alert.metric.alertname !== 'Watchdog');
+
   return sortObjectsByEarliestTimestamp(firing).map((alert, index) => {
-    // Process each value
     const processedValues = alert.values.map((value) => {
       const timestamp = value[0];
-
-      // Convert timestamp to date
-      const date = new Date(timestamp * 1000);
+      const date = new Date(timestamp * 1000); // Convert timestamp to a Date object
       return [date, value[1]];
     });
+    const sortedValues = processedValues.sort((a, b) => a[0] - b[0]);
 
-    // Calculate alertsEndFiring and resolved status
-    const alertsStartFiring = processedValues[0][0];
-    const alertsEndFiring = processedValues[processedValues.length - 1][0];
-    const resolved = new Date() - alertsEndFiring > 10 * 60 * 1000;
+    const alertsStartFiring = sortedValues[0][0];
+    const alertsEndFiring = sortedValues[sortedValues.length - 1][0];
+    const resolved = new Date() - alertsEndFiring > 10 * 60 * 1000; // Check if resolved based on end time
 
     return {
       alertname: alert.metric.alertname,
@@ -162,7 +160,7 @@ export function processAlerts(data) {
       layer: alert.metric.layer,
       name: alert.metric.name,
       alertstate: resolved ? 'resolved' : 'firing',
-      values: processedValues,
+      values: sortedValues, // Use sorted values
       alertsStartFiring,
       alertsEndFiring,
       resolved,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-15594
1) fixed the logic of how we add the "alertsEndFiring" prop, previously, the values were not sorted, so it could differ from the actual last timestamp. Now it properly assigns it.
2) Improved logic of when we add the tooltip to the Link in the alert expanded details in the table. Now if we don't have rule OR if the alert is resolved -> we make the link non clickable and add a tooltip with helper text.