### PR TITLE
rhineng-16008: add cutoff for alerts timestamps

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -178,7 +178,11 @@ const IncidentsPage = () => {
       )
         .then((results) => {
           const aggregatedData = results.reduce((acc, result) => acc.concat(result), []);
-          dispatch(setAlertsData({ alertsData: processAlerts(aggregatedData) }));
+          dispatch(
+            setAlertsData({
+              alertsData: processAlerts(aggregatedData, incidentForAlertProcessing),
+            }),
+          );
           dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
         })
         .catch((err) => {


### PR DESCRIPTION
Due to the limitations of how the API works when we request alerts data we can "catch" alerts data for the other incidents. Specifically the time before/after the chosen/selected incident starts/ends. To avoid showing this data I need to introduce a cut-off time, and make sure we're not showing alerts for the time when the chosen incident is not "happening"

Before
![image](https://github.com/user-attachments/assets/0d23e971-c26e-44f0-8842-0b4faa243ed0)

After
![image](https://github.com/user-attachments/assets/90639c21-999f-4885-a3bf-91cb81c7664d)
