### PR TITLE
NO-JIRA: add incidents header

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -275,6 +275,11 @@ const IncidentsPage = () => {
       <Helmet>
         <title>{title}</title>
       </Helmet>
+      <div className="co-m-nav-title">
+        <h1 className="co-m-pane__heading">
+          <span>{t('Incidents')}</span>
+        </h1>
+      </div>
       {alertsAreLoading && incidentsAreLoading ? (
         <Bullseye>
           <Spinner aria-label="incidents-chart-spinner" />


### PR DESCRIPTION
This PR looks to add a header for the incidents page.

![image](https://github.com/user-attachments/assets/28aa0d69-7efa-4210-8243-4ac413fa0715)
