### PR TITLE
[release-4.17] OCPBUGS-51117: Fix overview links

### DIFF
--- a/web/src/components/hooks/useRulesAlertsPoller.ts
+++ b/web/src/components/hooks/useRulesAlertsPoller.ts
@@ -37,7 +37,7 @@ export const useRulesAlertsPoller = (
       const poller = (): void => {
         fetchAlerts(url, alertsSource, namespace)
           .then(({ data }) => {
-            const { alerts, rules } = getAlertsAndRules(data, isDev);
+            const { alerts, rules } = getAlertsAndRules(data, perspective === 'admin');
             dispatch(alertingLoaded(alertsKey, alerts, perspective));
             dispatch(alertingSetRules(rulesKey, rules, perspective));
           })


### PR DESCRIPTION
This PR looks to fix an issue with didn't add the external labels to the alerts in the admin perspective in 4.17.

This caused links with the external labels from correctly linking to the appropriate pages. The parameter for the `getAlertsAndRules` function is `isAdminPerspective`, while we were passing in `isDev`.