### PR TITLE
COO-768: add plugin proxy to perses proxy path

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -38,7 +38,7 @@ import { LoadingInline } from '../../console/utils/status-box';
 import { usePatternFlyTheme } from './hooks/usePatternflyTheme';
 import { CachedDatasourceAPI } from './perses/datasource-api';
 import { OcpDatasourceApi } from './datasource-api';
-import { useFetchPersesDashboard } from './perses-client';
+import { PERSES_PROXY_BASE_PATH, useFetchPersesDashboard } from './perses-client';
 import { usePersesTimeRange } from './hooks/usePersesTimeRange';
 import { usePersesRefreshInterval } from './hooks/usePersesRefreshInterval';
 import { QueryParams } from '../../query-params';
@@ -231,7 +231,7 @@ export function PersesPrometheusDatasourceWrapper({
   const csrfToken = useCookieWatcher('csrf-token', { valueOnly: true });
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const datasourceApi = React.useMemo(() => {
-    return new CachedDatasourceAPI(new OcpDatasourceApi(csrfToken, t));
+    return new CachedDatasourceAPI(new OcpDatasourceApi(csrfToken, t, PERSES_PROXY_BASE_PATH));
   }, [csrfToken, t]);
 
   return (

--- a/web/src/components/dashboards/perses/datasource-api.ts
+++ b/web/src/components/dashboards/perses/datasource-api.ts
@@ -5,7 +5,7 @@ import { fetchGlobalDatasourceList } from './perses/global-datasource-client';
 import { TFunction } from 'i18next';
 
 export class OcpDatasourceApi implements DatasourceApi {
-  constructor(public csrfToken: string, public t: TFunction) {}
+  constructor(public csrfToken: string, public t: TFunction, public basePath: string) {}
   /**
    * Helper function for getting a proxy URL from separate input parameters.
    * Give the following output according to the definition or not of the input.
@@ -37,7 +37,7 @@ export class OcpDatasourceApi implements DatasourceApi {
     if (project) {
       url = `projects/${encodeURIComponent(project)}/${url}`;
     }
-    return `/proxy/${url}`;
+    return `${this.basePath}/proxy/${url}`;
   }
 
   getDatasource(

--- a/web/src/components/dashboards/perses/perses-client.ts
+++ b/web/src/components/dashboards/perses/perses-client.ts
@@ -4,18 +4,18 @@ import { DashboardResource, ProjectResource, fetchJson } from '@perses-dev/core'
 import { NumberParam, useQueryParam } from 'use-query-params';
 import { QueryParams } from '../../query-params';
 
-const baseURL = '/api/proxy/plugin/monitoring-console-plugin/perses';
+export const PERSES_PROXY_BASE_PATH = '/api/proxy/plugin/monitoring-console-plugin/perses';
 
 export const fetchPersesDashboardsMetadata = (): Promise<DashboardResource[]> => {
   const listDashboardsMetadata = '/api/v1/dashboards';
-  const persesURL = `${baseURL}${listDashboardsMetadata}`;
+  const persesURL = `${PERSES_PROXY_BASE_PATH}${listDashboardsMetadata}`;
 
   return ocpPersesFetchJson<DashboardResource[]>(persesURL);
 };
 
 export const fetchPersesProjects = (): Promise<ProjectResource[]> => {
   const listProjectURL = '/api/v1/projects';
-  const persesURL = `${baseURL}${listProjectURL}`;
+  const persesURL = `${PERSES_PROXY_BASE_PATH}${listProjectURL}`;
 
   return ocpPersesFetchJson<ProjectResource[]>(persesURL);
 };
@@ -34,7 +34,7 @@ export const fetchPersesDashboard = async (
   dashboardName: string,
 ): Promise<DashboardResource> => {
   const getDashboardURL = `/api/v1/projects/${project}/dashboards/${dashboardName}`;
-  const persesURL = `${baseURL}${getDashboardURL}`;
+  const persesURL = `${PERSES_PROXY_BASE_PATH}${getDashboardURL}`;
 
   return await ocpPersesFetchJson<DashboardResource>(persesURL);
 };

--- a/web/src/components/dashboards/perses/perses/datasource-api.ts
+++ b/web/src/components/dashboards/perses/perses/datasource-api.ts
@@ -112,7 +112,7 @@ export class CachedDatasourceAPI implements DatasourceApi {
   constructor(client: DatasourceApi) {
     this.client = client;
     this.cache = new Cache();
-    this.buildProxyUrl = this.client.buildProxyUrl;
+    this.buildProxyUrl = this.client.buildProxyUrl?.bind(this.client);
   }
 
   getDatasource(


### PR DESCRIPTION
This PR, adds the plugin proxy path before the perses proxy so requests to datasources are proxied correctly