### PR TITLE
OU-700: don't show metrics links in acm perspective

### DIFF
--- a/web/src/components/alerting/AlertRulesDetailsPage.tsx
+++ b/web/src/components/alerting/AlertRulesDetailsPage.tsx
@@ -275,7 +275,7 @@ const AlertRulesDetailsPage_: React.FC<AlertRulesDetailsPageProps> = ({ match })
                   <dt>{t('Expression')}</dt>
                   <dd>
                     {/* display a link only if its a metrics based alert */}
-                    {!sourceId || sourceId === 'prometheus' ? (
+                    {(!sourceId || sourceId === 'prometheus') && perspective !== 'acm' ? (
                       <Link to={getQueryBrowserUrl(perspective, rule?.query, namespace)}>
                         <CodeBlock>
                           <CodeBlockCode>{rule?.query}</CodeBlockCode>

--- a/web/src/components/alerting/AlertUtils.tsx
+++ b/web/src/components/alerting/AlertUtils.tsx
@@ -233,7 +233,7 @@ export const Graph: React.FC<GraphProps> = ({
   const timespan = Math.max(3 * ruleDuration, 30 * 60) * 1000;
 
   const GraphLink = () =>
-    query ? (
+    query && perspective !== 'acm' ? (
       <Link
         aria-label={t('View in Metrics')}
         to={getQueryBrowserUrl(perspective, query, namespace)}


### PR DESCRIPTION
Don't show metrics links in the acm perspective since the metrics page isn't present