### PR TITLE
OCPBUGS-52592: Fix "Export as CSV"

### DIFF
--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -459,7 +459,7 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
     dispatch(queryBrowserDuplicateQuery(index));
   }, [dispatch, index]);
 
-  const isSpan = (item) => item.title?.props?.children;
+  const isSpan = (item) => item?.title?.props?.children;
   const getSpanText = (item) => item.title.props.children;
 
   // Takes data from QueryTable and removes/replaces all html objects from columns and rows


### PR DESCRIPTION
JIRA 
https://issues.redhat.com/browse/OCPBUGS-52592

### Context 
`const isSpan = (item) => item?.title?.props?.children;`
The optional chaining operator `?.` gracefully handles undefined `item` by not throwing errors and allowing `item?.title?.props?.children` to result as `undefined`. 
