### PR TITLE
OCPBUGS-54211: fix issue preventing dev silences from loading

### DIFF
--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -480,11 +480,12 @@ const SilencesDetailsPage_: React.FC<RouteComponentProps<{ id: string }>> = ({ m
 
   const namespace = useActiveNamespace();
   const { isDev, alertsKey } = usePerspective();
-  useSilencesPoller({ namespace });
 
   const alertsLoaded = useSelector(({ observe }: RootState) => observe.get(alertsKey)?.loaded);
 
-  const silences: Silences = useSelector(({ observe }: RootState) => observe.get('silences'));
+  const silences: Silences = useSelector(({ observe }: RootState) =>
+    observe.get(isDev ? 'devSilences' : 'silences'),
+  );
   const silence = _.find(silences?.data, { id: _.get(match, 'params.id') });
 
   return (
@@ -674,13 +675,15 @@ const RuleTableRow: React.FC<RowProps<Rule>> = ({ obj }) => {
 
 const RulesPage_: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev } = usePerspective();
 
   const data: Rule[] = useSelector(({ observe }: RootState) => observe.get('rules'));
   const { loaded = false, loadError }: Alerts = useSelector(
     ({ observe }: RootState) => observe.get('alerts') || {},
   );
+
   const silencesLoadError = useSelector(
-    ({ observe }: RootState) => observe.get('silences')?.loadError,
+    ({ observe }: RootState) => observe.get(isDev ? 'devSilences' : 'silences')?.loadError,
   );
 
   const ruleAdditionalSources = React.useMemo(
@@ -895,6 +898,7 @@ const SelectAllCheckbox: React.FC<{ silences: Silence[] }> = ({ silences }) => {
 
 const SilencesPage_: React.FC = () => {
   const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev } = usePerspective();
 
   const [selectedSilences, setSelectedSilences] = React.useState(new Set());
   const [errorMessage, setErrorMessage] = React.useState();
@@ -903,7 +907,9 @@ const SilencesPage_: React.FC = () => {
     data,
     loaded = false,
     loadError,
-  }: Silences = useSelector(({ observe }: RootState) => observe.get('silences') || {});
+  }: Silences = useSelector(
+    ({ observe }: RootState) => observe.get(isDev ? 'devSilences' : 'silences') || {},
+  );
 
   const rowFilters: RowFilter[] = [
     // TODO: The "name" filter doesn't really fit useListPageFilter's idea of a RowFilter, but
@@ -1111,6 +1117,7 @@ const PollerPages = () => {
   );
 
   useRulesAlertsPoller(namespace, dispatch, alertsSource);
+  useSilencesPoller({ namespace });
 
   if (isDev) {
     return (

--- a/web/src/components/alerting/AlertsDetailPage.tsx
+++ b/web/src/components/alerting/AlertsDetailPage.tsx
@@ -76,7 +76,6 @@ import {
   newSilenceAlertURL,
 } from './SilencesUtils';
 import { useRulesAlertsPoller } from '../hooks/useRulesAlertsPoller';
-import { useSilencesPoller } from '../hooks/useSilencesPoller';
 
 const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
@@ -89,7 +88,7 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
   const dispatch = useDispatch();
   const alerts: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey));
 
-  const silencesLoaded = ({ observe }) => observe.get('silences')?.loaded;
+  const silencesLoaded = ({ observe }) => observe.get(isDev ? 'devSilences' : 'silences')?.loaded;
 
   const ruleAlerts = _.filter(alerts?.data, (a) => a.rule.id === match?.params?.ruleID);
   const rule = ruleAlerts?.[0]?.rule;
@@ -136,7 +135,6 @@ const AlertsDetailsPage_: React.FC<AlertsDetailsPageProps> = ({ history, match }
   );
 
   useRulesAlertsPoller(namespace, dispatch, alertsSource);
-  useSilencesPoller({ namespace });
 
   return (
     <>

--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -66,7 +66,7 @@ const AlertsPage_: React.FC<AlertsPageProps> = () => {
     loadError,
   }: Alerts = useSelector(({ observe }: RootState) => observe.get(alertsKey) || {});
   const silencesLoadError = useSelector(
-    ({ observe }: RootState) => observe.get('silences')?.loadError,
+    ({ observe }: RootState) => observe.get(isDev ? 'devSilences' : 'silences')?.loadError,
   );
 
   const alertAdditionalSources = React.useMemo(

--- a/web/src/components/hooks/useSilencesPoller.ts
+++ b/web/src/components/hooks/useSilencesPoller.ts
@@ -21,7 +21,9 @@ export const useSilencesPoller = ({ namespace }) => {
   );
   const dispatch = useDispatch();
   React.useEffect(() => {
-    if (loadError) {
+    if (!isDev) {
+      return;
+    } else if (loadError) {
       dispatch(alertingErrored('devSilences', loadError, 'dev'));
     } else if (loading) {
       dispatch(alertingLoading('devSilences', 'dev'));

--- a/web/src/components/silence-form.tsx
+++ b/web/src/components/silence-form.tsx
@@ -461,8 +461,11 @@ const EditInfo = () => {
 
 export const EditSilence = ({ match }) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
+  const { isDev } = usePerspective();
 
-  const silences: Silences = useSelector(({ observe }: RootState) => observe.get('silences'));
+  const silences: Silences = useSelector(({ observe }: RootState) =>
+    observe.get(isDev ? 'devSilences' : 'silences'),
+  );
 
   const silence: Silence = _.find(silences?.data, { id: match.params.id });
   const isExpired = silenceState(silence) === SilenceStates.Expired;


### PR DESCRIPTION
The alerts were actually being fetched correctly. However the silences state was being pulled from the admin perspective state store, which was failing (correctly) to poll the non-tenancy API for the notification bell. In addition, the silences poller wasn't being called on all pages that needed it.

The tenancy API is not returning alerts, which is addressed in openshift/cluster-monitoring-operator#2585