### PR TITLE
RHINENG-16773: fixed silence alerts data form not filled with alert details

### DIFF
--- a/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
@@ -9,10 +9,9 @@ import {
   useActiveNamespace,
   useResolvedExtensions,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { BellIcon, ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { Bullseye, DropdownItem, Icon, Spinner, Tooltip } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { BellIcon } from '@patternfly/react-icons';
+import { Bullseye, DropdownItem, Spinner, Tooltip } from '@patternfly/react-core';
+import { Link, useHistory } from 'react-router-dom';
 import { AlertResource, getAlertsAndRules } from '../utils';
 import { getPrometheusURL } from '../console/graphs/helpers';
 import { fetchAlerts } from '../fetch-alerts';
@@ -29,6 +28,7 @@ import './incidents-styles.css';
 import { SeverityBadge } from '../alerting/AlertUtils';
 
 const IncidentsDetailsRowTable = ({ alerts }) => {
+  const history = useHistory();
   const [namespace] = useActiveNamespace();
   const { perspective } = usePerspective();
   const [alertsWithMatchedData, setAlertsWithMatchedData] = React.useState([]);
@@ -147,15 +147,15 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
                     dropdownItems={[
                       <DropdownItem
                         component="button"
-                        key="silence"
+                        key="silence alert"
                         isDisabled={!alertDetails?.rule}
+                        onClick={() =>
+                          history.push(
+                            getNewSilenceAlertUrl(perspective, alertDetails.rule, namespace),
+                          )
+                        }
                       >
-                        <Link
-                          to={getNewSilenceAlertUrl(perspective, alertDetails)}
-                          style={{ color: 'inherit', textDecoration: 'inherit' }}
-                        >
-                          {t('Silence alert')}
-                        </Link>
+                        {t('Silence alert')}
                       </DropdownItem>,
                       <DropdownItem key="view-rule" isDisabled={!alertDetails?.rule}>
                         <Link


### PR DESCRIPTION
1) fixed the issue that happened when user clicks on Silence alert button -> the silence alert form wasn't populated by data
2) did some cleanup and removed unused stuff from the file

![image](https://github.com/user-attachments/assets/e4926b6a-c4f3-4cb6-8dcd-230c5c06188a)
![image](https://github.com/user-attachments/assets/b11fde7f-5716-4341-ad67-4da301ff59e2)
