### PR TITLE
OU-703: fix states filter in aggregated row

### DIFF
--- a/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
+++ b/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
@@ -38,6 +38,8 @@ const AggregateAlertTableRow: AggregateAlertTableRowProps = ({
     [aggregatedAlert.alerts, selectedFilters],
   );
 
+  const filteredStates = Array.from(new Set(filteredAlerts.map((alert) => alert.state)));
+
   const columns: Array<TableColumn<Alert>> = [
     {
       title: t('Name'),
@@ -115,7 +117,7 @@ const AggregateAlertTableRow: AggregateAlertTableRowProps = ({
           </Badge>
         </Td>
         <Td title={title}>
-          {Array.from(aggregatedAlert.states).map((state) => (
+          {filteredStates.map((state) => (
             <AlertState state={state} key={state} />
           ))}
         </Td>

--- a/web/src/components/alerting/AlertList/hooks/utils.ts
+++ b/web/src/components/alerting/AlertList/hooks/utils.ts
@@ -18,16 +18,16 @@ export const alertFilters: Record<string, (selectedInput: string[], alert: Alert
 } as const;
 
 export const filterAlerts = (alerts: Alert[], selectedFilters: SelectedFilters) => {
-  if (!Object.keys(selectedFilters).length) return alerts;
+  if (!Object.keys(selectedFilters)?.length) return alerts;
 
-  return alerts.filter((iface) =>
+  return (alerts || []).filter((alert) =>
     Object.keys(selectedFilters).every((filterType) => {
       const selectedValues = selectedFilters[filterType];
       const filter = alertFilters[filterType];
 
       if (!filter) return true;
 
-      return filter(selectedValues, iface);
+      return filter(selectedValues, alert);
     }),
   );
 };


### PR DESCRIPTION
The aggregated alert row was showing filtered states 
In the example `VMCannotBeEvicted`

**DEMO BEFORE**

Silenced state is there even tho we filtered by state firing 

<img width="1639" alt="Screenshot 2025-04-22 at 17 09 28" src="https://github.com/user-attachments/assets/6c990518-a7b6-4485-a735-71bef06d0d9f" />



**DEMO AFTER**


https://github.com/user-attachments/assets/5df643eb-fced-4422-a8c7-43ecf1951b53

