### PR TITLE
OU-760: Requests UX changes post PF-6

### DIFF
--- a/web/src/components/alerting/AlertDetail/SilencedByTable.tsx
+++ b/web/src/components/alerting/AlertDetail/SilencedByTable.tsx
@@ -24,6 +24,7 @@ import { useBoolean } from '../../hooks/useBoolean';
 import { SilenceResource } from '../../utils';
 import { Link } from 'react-router-dom';
 import { SeverityCounts, StateTimestamp } from '../AlertUtils';
+import { t_global_spacer_xs } from '@patternfly/react-tokens';
 
 export const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -65,7 +66,11 @@ export const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) 
     {
       cell: (
         <>
-          <Flex spaceItems={{ default: 'spaceItemsNone' }} flexWrap={{ default: 'nowrap' }}>
+          <Flex
+            spaceItems={{ default: 'spaceItemsNone' }}
+            flexWrap={{ default: 'nowrap' }}
+            style={{ paddingBottom: t_global_spacer_xs.var }}
+          >
             <FlexItem>
               <ResourceIcon kind={SilenceResource.kind} />
             </FlexItem>

--- a/web/src/components/alerting/SilencesUtils.tsx
+++ b/web/src/components/alerting/SilencesUtils.tsx
@@ -15,6 +15,7 @@ import {
   Flex,
   FlexItem,
   Label,
+  LabelGroup,
   MenuToggle,
   MenuToggleElement,
   Modal,
@@ -55,6 +56,7 @@ import {
 } from '../utils';
 import { SeverityCounts, StateTimestamp } from './AlertUtils';
 import { Td } from '@patternfly/react-table';
+import { t_global_spacer_xs } from '@patternfly/react-tokens';
 
 export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -97,7 +99,11 @@ export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheck
         </Td>
       )}
       <Td width={40}>
-        <Flex spaceItems={{ default: 'spaceItemsNone' }} flexWrap={{ default: 'nowrap' }}>
+        <Flex
+          spaceItems={{ default: 'spaceItemsNone' }}
+          flexWrap={{ default: 'nowrap' }}
+          style={{ paddingBottom: t_global_spacer_xs.var }}
+        >
           <FlexItem>
             <ResourceIcon kind={SilenceResource.kind} />
           </FlexItem>
@@ -154,7 +160,7 @@ export const SelectedSilencesContext = React.createContext({
 });
 
 export const SilenceMatchersList = ({ silence }) => (
-  <div>
+  <LabelGroup numLabels={20}>
     {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
       <Label key={i}>
         <span>{name}</span>
@@ -162,7 +168,7 @@ export const SilenceMatchersList = ({ silence }) => (
         <span>{value}</span>
       </Label>
     ))}
-  </div>
+  </LabelGroup>
 );
 
 export type ExpireSilenceModalProps = {

--- a/web/src/components/labels.tsx
+++ b/web/src/components/labels.tsx
@@ -17,12 +17,10 @@ export const Labels = ({ labels }) => {
   return _.isEmpty(labels) ? (
     <div>{t('No labels')}</div>
   ) : (
-    <div>
-      <PfLabelGroup numLabels={20}>
-        {_.map(labels, (v, k) => (
-          <Label key={k} k={k} v={v} />
-        ))}
-      </PfLabelGroup>
-    </div>
+    <PfLabelGroup numLabels={20}>
+      {_.map(labels, (v, k) => (
+        <Label key={k} k={k} v={v} />
+      ))}
+    </PfLabelGroup>
   );
 };

--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -102,7 +102,11 @@ import { PrometheusAPIError } from './types';
 import { TypeaheadSelect } from './TypeaheadSelect';
 import { LoadingInline } from './console/console-shared/src/components/loading/LoadingInline';
 import withFallback from './console/console-shared/error/fallbacks/withFallback';
-import { t_global_spacer_md, t_global_spacer_sm } from '@patternfly/react-tokens';
+import {
+  t_global_spacer_md,
+  t_global_spacer_sm,
+  t_global_font_family_mono,
+} from '@patternfly/react-tokens';
 
 // Stores information about the currently focused query input
 let focusedQuery;
@@ -789,7 +793,10 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace, custom
           {tableRows.map((row, rowIndex) => (
             <Tr key={`row-${rowIndex}`}>
               {row.cells?.map((cell, cellIndex) => (
-                <Td key={`cell-${rowIndex}-${cellIndex}`}>
+                <Td
+                  style={{ fontFamily: t_global_font_family_mono.var }}
+                  key={`cell-${rowIndex}-${cellIndex}`}
+                >
                   {typeof cell === 'string' ? cell : cell?.title}
                 </Td>
               ))}


### PR DESCRIPTION
There were 3 changes requested from UX after our [PF-6](https://issues.redhat.com//browse/PF-6) upgrade:
1. Add spacing around the silences matchers
![Screenshot From 2025-04-22 12-34-06](https://github.com/user-attachments/assets/8fbebf67-68bf-4b17-b6d8-727d30d678fc)
![Screenshot From 2025-04-22 12-34-43](https://github.com/user-attachments/assets/97791a93-73ac-4bf2-a5aa-1b1c952b86d1)
![Screenshot From 2025-04-22 12-36-35](https://github.com/user-attachments/assets/484ba4ea-39bb-4891-8e6d-c083925d1924)

2. Use a monospace font on the metrics table
![Screenshot From 2025-04-22 12-37-03](https://github.com/user-attachments/assets/2b99550f-09b6-4629-bebc-fc713d2aa7e1)

3. Place the "clear filters" button on the same line as the filters.
After reviewing Patternfly components, these filters fell under the "toolbar" umbrella, which places the filters on a separate line, so this change wasn't needed. 
https://www.patternfly.org/components/toolbar#with-filters