### PR TITLE
OU-752: Clear out old queries when loading queries from URL

### DIFF
--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -974,8 +974,9 @@ const QueryBrowserWrapper: React.FC<{
 
   // Initialize queries from URL parameters
   React.useEffect(() => {
+    dispatch(queryBrowserDeleteAllQueries());
     const searchParams = getAllQueryArguments();
-    for (let i = 0; _.has(searchParams, `query${i}`); ++i) {
+    for (let i = 0; _.has(searchParams, `query${i}`); i++) {
       const query = searchParams[`query${i}`];
       dispatch(
         queryBrowserPatchQuery(i, {


### PR DESCRIPTION
This PR looks to clear out zombie queries from the store when loading queries from the URL in the query browser.


https://github.com/user-attachments/assets/01f241f5-34bd-443c-a97a-7acd3ef60547

