### PR TITLE
OU-729,OU-723: Add label typeahead

### DIFF
--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -117,7 +117,10 @@ const AlertsPage_: React.FC = () => {
           fuzzyCaseInsensitive(selectedFilter, alert.labels?.cluster),
         ),
       filterGroupName: t('Cluster'),
-      items: clusters.map((clusterName) => ({ id: clusterName, title: clusterName })),
+      items: clusters.map((clusterName) => ({
+        id: clusterName,
+        title: clusterName.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
+      })),
       reducer: alertCluster,
     } as RowFilter);
   }

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -107,7 +107,10 @@ const SilencesPage_: React.FC = () => {
           ),
         ),
       filterGroupName: t('Cluster'),
-      items: clusters.map((clusterName) => ({ id: clusterName, title: clusterName })),
+      items: clusters.map((clusterName) => ({
+        id: clusterName,
+        title: clusterName.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
+      })),
       reducer: silenceCluster,
       isMatch: (silence: Silence, clusterName: string) =>
         fuzzyCaseInsensitive(


### PR DESCRIPTION
Re-add label typeahead to the filters by only aggregating the alerts after the filtering has been done so that the labels on the individual alerts are available to be filtered on.


https://github.com/user-attachments/assets/fab156e8-5494-4c3b-a6c6-16264a16bed1

This PR also looks to add cluster name truncation after 50 characters to prevent dialog sprawl across the page.
![Screenshot From 2025-04-22 15-52-25](https://github.com/user-attachments/assets/d0dc0955-00d2-44ab-a5f6-dbcbe8ff0e91)
