### PR TITLE
OU-757: Show cluster column heading on acm silences page

### DIFF
--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -170,6 +170,7 @@ const SilencesPage_: React.FC = () => {
           _.orderBy(silences, silenceClusterOrder(clusters), [direction]),
         title: t('Cluster'),
         transforms: [sortable],
+        props: { width: 15 },
       });
     }
     return cols;

--- a/web/src/components/alerting/SilencesUtils.tsx
+++ b/web/src/components/alerting/SilencesUtils.tsx
@@ -135,7 +135,7 @@ export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheck
         </Stack>
       </Td>
       <Td width={15}>{createdBy || '-'}</Td>
-      {perspective === 'acm' && <Td>{cluster}</Td>}
+      {perspective === 'acm' && <Td width={15}>{cluster}</Td>}
       <Td width={10}>
         <SilenceDropdown silence={obj} />
       </Td>


### PR DESCRIPTION
This PR look to give the acm silences page a column width for the cluster column so it shows up.

![Screenshot From 2025-04-22 15-38-48](https://github.com/user-attachments/assets/022fac1a-0c6a-401f-ac2d-edca3eb0343d)
