### PR TITLE
OCPBUGS-48533: Reset variables when making orthongonal selections

### DIFF
--- a/web/src/components/console/utils/single-typeahead-dropdown.tsx
+++ b/web/src/components/console/utils/single-typeahead-dropdown.tsx
@@ -119,6 +119,11 @@ export const SingleTypeaheadDropdown: React.FC<SingleTypeaheadDropdownProps> = (
   const CREATE_NEW = 'typeahead-dropdown__create-new';
 
   React.useEffect(() => {
+    // check if the incoming items are the same as those currently held in the selectOptions
+    // If they are, don't setSelectOptions to prevent losing current filter
+    if (_.isEmpty(_.xorWith(items, selectOptions, _.isEqual))) {
+      return;
+    }
     let newSelectOptions = [];
     if (clearOnNewItems) {
       newSelectOptions = [...items];

--- a/web/src/components/console/utils/single-typeahead-dropdown.tsx
+++ b/web/src/components/console/utils/single-typeahead-dropdown.tsx
@@ -93,7 +93,7 @@ export const SingleTypeaheadDropdown: React.FC<SingleTypeaheadDropdownProps> = (
   OptionComponent,
   menuToggleProps = {},
   selectProps = {},
-  clearOnNewItems = false,
+  clearOnNewItems = true,
 }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const [isOpen, setIsOpen] = React.useState(false);

--- a/web/src/components/dashboards/shared/dashboard-dropdown.tsx
+++ b/web/src/components/dashboards/shared/dashboard-dropdown.tsx
@@ -77,7 +77,6 @@ export const DashboardDropdown: React.FC<DashboardDropdownProps> = ({
           selectedKey={selectedKey}
           hideClearButton
           resizeToFit
-          clearOnNewItems
         />
       </StackItem>
     </Stack>


### PR DESCRIPTION
This PR looks to fix an issue which caused the new variables to be appended onto the old variable values. 

The SingleTypeaheadDropdown is currently used in 3 places: 
- DashboardDropdown
- LegacyVariableDropdown
- VariableDropdown (Perses)

All three of theses locations want the new values to replace the old ones whenever new data is found, so the `clearOnNewItems` has been set to default to true


https://github.com/user-attachments/assets/330cce6b-9543-46ee-bed3-b94d4665c701

