### PR TITLE
OU-767: Allow filtering by cluster name

### DIFF
--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -82,7 +82,9 @@ const AlertsPage_: React.FC = () => {
     {
       defaultSelected: [AlertStates.Firing],
       filter: (filter, alert: Alert) =>
-        filter.selected?.includes(alertState(alert)) || _.isEmpty(filter.selected),
+        filter.selected.length === 0 ||
+        filter.selected?.includes(alertState(alert)) ||
+        _.isEmpty(filter.selected),
       filterGroupName: t('Alert State'),
       items: [
         { id: AlertStates.Firing, title: t('Firing') },
@@ -96,7 +98,9 @@ const AlertsPage_: React.FC = () => {
     {
       defaultSelected: defaultAlertTenant,
       filter: (filter, alert: Alert) =>
-        filter.selected?.includes(alertSource(alert)) || _.isEmpty(filter.selected),
+        filter.selected.length === 0 ||
+        filter.selected?.includes(alertSource(alert)) ||
+        _.isEmpty(filter.selected),
       filterGroupName: t('Source'),
       items: [
         { id: AlertSource.Platform, title: t('Platform') },
@@ -112,16 +116,23 @@ const AlertsPage_: React.FC = () => {
     rowFilters = rowFilters.filter((filter) => filter.type !== 'alert-source');
   } else if (perspective === 'acm') {
     rowFilters.splice(-1, 0, {
-      filter: (filter, alert: Alert) =>
-        filter.selected.some((selectedFilter) =>
-          fuzzyCaseInsensitive(selectedFilter, alert.labels?.cluster),
-        ),
+      filter: (filter, alert: Alert) => {
+        return (
+          filter.selected.length === 0 ||
+          filter.selected.some((selectedFilter) =>
+            fuzzyCaseInsensitive(selectedFilter, alert.labels?.cluster),
+          )
+        );
+      },
       filterGroupName: t('Cluster'),
       items: clusters.map((clusterName) => ({
         id: clusterName,
         title: clusterName.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
       })),
       reducer: alertCluster,
+      isMatch: (alert: Alert, clusterName: string) =>
+        fuzzyCaseInsensitive(clusterName, alert.labels?.cluster),
+      type: 'alert-cluster',
     } as RowFilter);
   }
 


### PR DESCRIPTION
This PR looks to recover from a regression of a previous bug. It adds back a type so that the filter is able to be used, and then also allows for all items to be matched when no filters are set. 


https://github.com/user-attachments/assets/49092fb3-65e7-4b9b-805f-fe52d87fc1fe

