### PR TITLE
OCPBUGS-54292: Show column headings on metrics page

### DIFF
--- a/web/src/components/metrics.tsx
+++ b/web/src/components/metrics.tsx
@@ -782,7 +782,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace, custom
                     }
                   : {};
               return (
-                <Th key={`${col.title}-${columnIndex}`} {...sortParams}>
+                <Th modifier="fitContent" key={`${col.title}-${columnIndex}`} {...sortParams}>
                   {col.title}
                 </Th>
               );


### PR DESCRIPTION
This PR looks to fix the column headings on the metrics page such that the full titles are shown.

Before:
![Screenshot From 2025-04-23 21-26-53](https://github.com/user-attachments/assets/9e2d4f78-a4ac-4d35-a2d3-b9eb126d85d4)

After:
![Screenshot From 2025-04-23 21-27-28](https://github.com/user-attachments/assets/8d33c532-2dfc-4e5e-abbc-5d5e06b57431)
