### PR TITLE
OU-765: Don't break if cluster doesn't exist

### DIFF
--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -119,7 +119,7 @@ const AlertsPage_: React.FC = () => {
       filterGroupName: t('Cluster'),
       items: clusters.map((clusterName) => ({
         id: clusterName,
-        title: clusterName.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
+        title: clusterName?.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
       })),
       reducer: alertCluster,
     } as RowFilter);

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -103,19 +103,19 @@ const SilencesPage_: React.FC = () => {
         filter.selected.some((selectedFilter) =>
           fuzzyCaseInsensitive(
             selectedFilter,
-            silence.matchers.find((label) => label.name === 'cluster').value,
+            silence.matchers.find((label) => label.name === 'cluster')?.value,
           ),
         ),
       filterGroupName: t('Cluster'),
       items: clusters.map((clusterName) => ({
         id: clusterName,
-        title: clusterName.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
+        title: clusterName?.length > 50 ? clusterName.slice(0, 50) + '...' : clusterName,
       })),
       reducer: silenceCluster,
       isMatch: (silence: Silence, clusterName: string) =>
         fuzzyCaseInsensitive(
           clusterName,
-          silence.matchers.find((label) => label.name === 'cluster').value,
+          silence.matchers.find((label) => label.name === 'cluster')?.value,
         ),
     } as RowFilter);
   }


### PR DESCRIPTION
This PR looks to provide guards on alerts and silences which prevent breaking pages when the cluster label or matcher doesn't exist