### PR TITLE
RHINENG-10537: fixed broken delete chip group for incidents filters

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.jsx
+++ b/web/src/components/Incidents/IncidentsPage.jsx
@@ -303,8 +303,8 @@ const IncidentsPage = () => {
                   deleteLabel={(category, chip) =>
                     onDeleteIncidentFilterChip(category, chip, incidentsActiveFilters, dispatch)
                   }
-                  deleteLabelGroup={(category) =>
-                    onDeleteGroupIncidentFilterChip(category, incidentsActiveFilters, dispatch)
+                  deleteLabelGroup={() =>
+                    onDeleteGroupIncidentFilterChip(incidentsActiveFilters, dispatch)
                   }
                   categoryName="Filters"
                 >


### PR DESCRIPTION
We don't need to pass category to the onDeleteGroupIncidentFilterChip, it was causing issues, so I removed it