### PR TITLE
OU-774: bound table scroll and column alignment

### DIFF
--- a/web/src/components/MetricsPage.tsx
+++ b/web/src/components/MetricsPage.tsx
@@ -42,6 +42,7 @@ import {
 } from '@patternfly/react-core';
 import { ChartLineIcon, CompressIcon } from '@patternfly/react-icons';
 import {
+  InnerScrollContainer,
   ISortBy,
   sortable,
   Table,
@@ -762,48 +763,50 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace, custom
       <Button variant="link" isInline onClick={toggleAllSeries}>
         {isDisabledSeriesEmpty ? t('Unselect all') : t('Select all')}
       </Button>
-      <Table
-        aria-label={t('query results table')}
-        gridBreakPoint={TableGridBreakpoint.none}
-        rows={tableRows.length}
-        variant={TableVariant.compact}
-      >
-        <Thead>
-          <Tr>
-            {columns.map((col, columnIndex) => {
-              const sortParams =
-                columnIndex !== 0
-                  ? {
-                      sort: {
-                        sortBy,
-                        onSort,
-                        columnIndex,
-                      },
-                    }
-                  : {};
-              return (
-                <Th modifier="fitContent" key={`${col.title}-${columnIndex}`} {...sortParams}>
-                  {col.title}
-                </Th>
-              );
-            })}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {tableRows.map((row, rowIndex) => (
-            <Tr key={`row-${rowIndex}`}>
-              {row.cells?.map((cell, cellIndex) => (
-                <Td
-                  style={{ fontFamily: t_global_font_family_mono.var }}
-                  key={`cell-${rowIndex}-${cellIndex}`}
-                >
-                  {typeof cell === 'string' ? cell : cell?.title}
-                </Td>
-              ))}
+      <InnerScrollContainer>
+        <Table
+          aria-label={t('query results table')}
+          gridBreakPoint={TableGridBreakpoint.none}
+          rows={tableRows.length}
+          variant={TableVariant.compact}
+        >
+          <Thead>
+            <Tr>
+              {columns.map((col, columnIndex) => {
+                const sortParams =
+                  columnIndex !== 0
+                    ? {
+                        sort: {
+                          sortBy,
+                          onSort,
+                          columnIndex,
+                        },
+                      }
+                    : {};
+                return (
+                  <Th modifier="nowrap" key={`${col.title}-${columnIndex}`} {...sortParams}>
+                    {col.title}
+                  </Th>
+                );
+              })}
             </Tr>
-          ))}
-        </Tbody>
-      </Table>
+          </Thead>
+          <Tbody>
+            {tableRows.map((row, rowIndex) => (
+              <Tr key={`row-${rowIndex}`}>
+                {row.cells?.map((cell, cellIndex) => (
+                  <Td
+                    style={{ fontFamily: t_global_font_family_mono.var }}
+                    key={`cell-${rowIndex}-${cellIndex}`}
+                  >
+                    {typeof cell === 'string' ? cell : cell?.title}
+                  </Td>
+                ))}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </InnerScrollContainer>
       <TablePagination
         itemCount={rows.length}
         page={page}


### PR DESCRIPTION
This PR looks to fix an issue causing columns to be right aligned. This was triggered by the usage of the `<Th modifier="fitContent">` parameter which was added to fix [OCPBUGS-54292](https://issues.redhat.com/browse/OCPBUGS-54292).

We swap to using the `nowrap` which shows the full column title and prevents the right alignment.

Additionally this PR binds the table to the page size, placing a horizontal scroll bar around only the table when neccessary.


https://github.com/user-attachments/assets/ebe09fce-3339-4fdb-8299-78ce2ee4afd0

