### PR TITLE
OU-712: fix: add missing alertname field to silence alert

### DIFF
--- a/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
@@ -44,11 +44,15 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
   );
 
   function findMatchingAlertsWithId(alertsArray, rulesArray) {
-    // Map over alerts and find matching rules
     return alertsArray.map((alert) => {
       const match = rulesArray.find((rule) => alert.alertname === rule.name);
-
       if (match) {
+        // Add alertname to rule.labels if not already present
+        if (match.labels) {
+          match.labels.alertname = alert.alertname;
+        } else {
+          match.labels = { alertname: alert.alertname };
+        }
         return { ...alert, rule: match };
       }
       return alert;

--- a/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.jsx
@@ -92,7 +92,12 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
                   <Link
                     to={
                       alertDetails?.rule
-                        ? getAlertUrl(perspective, alertDetails, alertDetails.rule.id, namespace)
+                        ? getAlertUrl(
+                            perspective,
+                            alertDetails,
+                            alertDetails?.rule?.rule.id,
+                            namespace,
+                          )
                         : '#'
                     }
                     style={
@@ -151,9 +156,12 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
                       >
                         {t('Silence alert')}
                       </DropdownItem>,
-                      <DropdownItem key="view-rule" isDisabled={!alertDetails?.rule}>
+                      <DropdownItem
+                        key="view-rule"
+                        isDisabled={alertDetails?.alertstate === 'resolved' ? true : false}
+                      >
                         <Link
-                          to={getRuleUrl(perspective, alertDetails.rule)}
+                          to={getRuleUrl(perspective, alertDetails?.rule?.rule)}
                           style={{ color: 'inherit', textDecoration: 'inherit' }}
                         >
                           {t('View alerting rule')}


### PR DESCRIPTION
Add a missing alert name field to labels, so it would populate the alert name field when the user clicks on a "silence alert" button.