### PR TITLE
OCPBUGS-56095: "Negative matcher" is checked by default on Create silence page

### DIFF
--- a/web/src/components/alerting/SilenceForm.tsx
+++ b/web/src/components/alerting/SilenceForm.tsx
@@ -176,7 +176,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
   const [inProgress, setInProgress] = React.useState(false);
   const [isStartNow, setIsStartNow] = React.useState(defaultIsStartNow);
   const [matchers, setMatchers] = React.useState<Array<Matcher>>(
-    defaults.matchers ?? [{ isRegex: false, isEqual: false, name: '', value: '' }],
+    defaults.matchers ?? [{ isRegex: false, isEqual: true, name: '', value: '' }],
   );
   const [startsAt, setStartsAt] = React.useState(defaults.startsAt ?? formatDate(now));
   const user = useSelector(getUser);


### PR DESCRIPTION
see [OCPBUGS-56095](https://issues.redhat.com/browse/OCPBUGS-56095)
"Negative matcher" is checked by default on Create silence page
this PR changes isEqual default value from false to true
before the fix(4.19/4.20 builds), "Negative matcher" is checked by default on Create silence page, see
![Image](https://github.com/user-attachments/assets/062ed0bc-6def-4dc0-8755-b6784938f058)
after fix, "Negative matcher" is not checked by default on Create silence page, see
![Image](https://github.com/user-attachments/assets/ccf16992-90e2-45f1-9a78-139612c6cf1a)
