### PR TITLE
OU-829: fix ACM filtering and 'Export as CSV' link

### DIFF
--- a/web/src/components/alerting/AlertList/DownloadCSVButton.tsx
+++ b/web/src/components/alerting/AlertList/DownloadCSVButton.tsx
@@ -1,0 +1,70 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePerspective } from '../../hooks/usePerspective';
+import { AggregatedAlert } from '../AlertsAggregates';
+
+type DownloadCSVButtonProps = {
+  loaded: boolean;
+  filteredData: AggregatedAlert[];
+};
+
+const DownloadCSVButton: FC<DownloadCSVButtonProps> = ({ loaded, filteredData }) => {
+  const { perspective } = usePerspective();
+  const { t } = useTranslation(process.env.I18N_NAMESPACE);
+
+  const getTableData = () => {
+    const csvColumns = ['Name', 'Severity', 'State', 'Total'];
+    if (perspective === 'acm') {
+      csvColumns.push('Cluster');
+    }
+    const getCsvRows = () => {
+      return filteredData?.map((row) => {
+        const name = row?.name ?? '';
+        const severity = row?.severity ?? '';
+        const state = Array.from(row?.states || [])?.join(', ');
+        const total = row?.alerts?.length ?? 0;
+        const rowData = [name, severity, state, total];
+        if (perspective === 'acm') {
+          const clusters = Array.from(
+            new Set(row?.alerts?.map((alert) => alert.labels?.cluster) || []),
+          );
+          rowData.push(clusters?.join(', ') ?? '');
+        }
+        return rowData;
+      });
+    };
+    return [csvColumns, ...getCsvRows()];
+  };
+
+  const formatToCsv = (tableData, delimiter = ',') =>
+    tableData
+      ?.map((row) =>
+        row?.map((rowItem) => (isNaN(rowItem) ? `"${rowItem}"` : rowItem)).join(delimiter),
+      )
+      ?.join('\n');
+
+  let csvData: string;
+  if (loaded) {
+    csvData = formatToCsv(getTableData()) ?? undefined;
+  }
+
+  const downloadCsv = () => {
+    // csvData should be formatted as comma-seperated values
+    // (e.g. `"a","b","c", \n"d","e","f", \n"h","i","j"`)
+    const blobCsvData = new Blob([csvData], { type: 'text/csv' });
+    const csvURL = URL.createObjectURL(blobCsvData);
+    const link = document.createElement('a');
+    link.href = csvURL;
+    link.download = `openshift.csv`;
+    link.click();
+  };
+
+  return (
+    <Button onClick={downloadCsv} variant={ButtonVariant.link}>
+      {t('Export as CSV')}
+    </Button>
+  );
+};
+
+export default DownloadCSVButton;


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/OU-829

### Description 
This is a backport of fixes resolved in the main branch. 
- ACM Alerting filtering 
- Add 'Export as CSV'

#### Process 
- Copy/Paste Changes from main branch > AlertsPage, which has already fixed these issues for 4.19. 
- Adjust for Patternfly 5 (HTML is slightly different to accommodate Patternfly 5 instead of Patternfly 6). Business logic should be the same as [main branch > AlertsPage](https://github.com/openshift/monitoring-plugin/blob/main/web/src/components/alerting/AlertsPage.tsx) (as of May 30). 


