### PR TITLE
OU-842: fix: override notistack dependency to avoid conflict

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -20,6 +20,9 @@ if [[ "$OSTYPE" == "darwin"* ]] && [[ "$DOCKER_FILE_NAME" == "Dockerfile.mcp" ]]
     make update-plugin-name
     export I18N_NAMESPACE='plugin__monitoring-console-plugin'
 
+    printf "${YELLOW}Installing Frontend${ENDCOLOR}\n"
+    make install-frontend
+
     printf "${YELLOW}Building Frontend${ENDCOLOR}\n"
     make build-frontend
 fi

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,11 +31,11 @@
         "@patternfly/react-icons": "^6.2.0",
         "@patternfly/react-table": "^6.2.0",
         "@patternfly/react-templates": "^6.2.0",
-        "@perses-dev/components": "^0.50.0",
-        "@perses-dev/dashboards": "^0.50.0",
-        "@perses-dev/panels-plugin": "^0.50.0",
-        "@perses-dev/plugin-system": "^0.50.0",
-        "@perses-dev/prometheus-plugin": "^0.50.0",
+        "@perses-dev/components": "^0.50.3",
+        "@perses-dev/dashboards": "^0.50.3",
+        "@perses-dev/panels-plugin": "^0.50.3",
+        "@perses-dev/plugin-system": "^0.50.3",
+        "@perses-dev/prometheus-plugin": "^0.50.3",
         "@prometheus-io/codemirror-promql": "^0.37.0",
         "@tanstack/react-query": "^4.36.1",
         "classnames": "2.x",
@@ -2241,9 +2241,9 @@
       "license": "MIT"
     },
     "node_modules/@perses-dev/components": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.50.2.tgz",
-      "integrity": "sha512-PexBs6q0PjnYc4eTrj83yWpBVuE0K63hVZhM6ywvvX5H6UnHdgwS7YaFtT/jbpDmlAQyNX21k0iLhtKM8ZGAaA==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.50.3.tgz",
+      "integrity": "sha512-X53/tFRPjZUgv6EWM3ot+5l82li/k4zBxbTnsQA2vb7YrOJvrUzidWf0+jHSxS/3ua8Tfd8HHxdGk1HhpoIftg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
@@ -2251,7 +2251,7 @@
         "@codemirror/lang-json": "^6.0.1",
         "@fontsource/lato": "^4.5.10",
         "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.50.2",
+        "@perses-dev/core": "0.50.3",
         "@tanstack/react-table": "^8.20.5",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
@@ -2299,9 +2299,9 @@
       }
     },
     "node_modules/@perses-dev/core": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.50.2.tgz",
-      "integrity": "sha512-v74hBWP/hh+a4+3PscnC9oicqAg/fQ/UAmv0hUAK2puo9d9gKmpr59OUMXH61rwnmH6zmRuwzz/YVSXxh9ao5Q==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.50.3.tgz",
+      "integrity": "sha512-z3D/hJkAM9zzn1NZnBtMxSlj2ycTkrkbn0mYwgWFKra61kzUKbP0MIK/m9MTfkmyL8G2TPs3qxozirirX84nDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "date-fns": "^2.28.0",
@@ -2316,14 +2316,14 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.50.2.tgz",
-      "integrity": "sha512-T5a79EWsNE1wtaFiwCxRZbtLDiElgL77h13lEQ7ZERhiN6B4nTSmkVu+k6Pny68gFxRzZucVZJjhAxbUlO1GOw==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.50.3.tgz",
+      "integrity": "sha512-B8ZI3iFCwWqYe8kMO6OJMJcbFY/1F44ZYMq+lmGR3bQzpvHquQdwkDYinNn+SjNt6vXkNlw8qA9s2i1V/fr8FA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/components": "0.50.2",
-        "@perses-dev/core": "0.50.2",
-        "@perses-dev/plugin-system": "0.50.2",
+        "@perses-dev/components": "0.50.3",
+        "@perses-dev/core": "0.50.3",
+        "@perses-dev/plugin-system": "0.50.3",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^2.28.0",
         "immer": "^9.0.15",
@@ -2345,15 +2345,15 @@
       }
     },
     "node_modules/@perses-dev/panels-plugin": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/panels-plugin/-/panels-plugin-0.50.2.tgz",
-      "integrity": "sha512-55hq+nvDADJcJY+yNgd+z9nVub6JlEOCRyunIxZInZr16VeLO2YoS/ghP8nppSb095NAPZ56iM2l5992/S/3qQ==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/panels-plugin/-/panels-plugin-0.50.3.tgz",
+      "integrity": "sha512-MuiSj/wXofU7MI1/oBR/yebqZcG3omwFcqzD7xAR6TmieU5venSzK45yW4GJdta1CH5sTE9RcdmYgbledHHQxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/x-data-grid": "^7.23.1",
-        "@perses-dev/components": "0.50.2",
-        "@perses-dev/core": "0.50.2",
-        "@perses-dev/plugin-system": "0.50.2",
+        "@perses-dev/components": "0.50.3",
+        "@perses-dev/core": "0.50.3",
+        "@perses-dev/plugin-system": "0.50.3",
         "color-hash": "^2.0.2",
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
@@ -2394,13 +2394,13 @@
       }
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.50.2.tgz",
-      "integrity": "sha512-fKkfrwqHiya5SfksHywkB/gjUf5ereeQ6RCh5vOZCCrzyD6qliTz4d+uTp3vMZ/tDx3cxN589uB8Yjvxh2EGwQ==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.50.3.tgz",
+      "integrity": "sha512-ISlPxF86VazoaplFqnky9V/e7rsGoEaFiDDJVwHCS5SwUEF+SXz6W7wWnNlt70eKrVtb0m71FWlVg7+XQrdEMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/components": "0.50.2",
-        "@perses-dev/core": "0.50.2",
+        "@perses-dev/components": "0.50.3",
+        "@perses-dev/core": "0.50.3",
         "date-fns": "^2.30.0",
         "immer": "^9.0.15",
         "react-hook-form": "^7.46.1",
@@ -2416,16 +2416,16 @@
       }
     },
     "node_modules/@perses-dev/prometheus-plugin": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@perses-dev/prometheus-plugin/-/prometheus-plugin-0.50.2.tgz",
-      "integrity": "sha512-VSirxFqgbvT8O91zr9LqdA7wnU48u0EaWiuREFz770ODEPfnxJdKlVOwglP+uFmp3/bVy/P55HZtScNHtOWcSw==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@perses-dev/prometheus-plugin/-/prometheus-plugin-0.50.3.tgz",
+      "integrity": "sha512-3sy1oZT74aPZdttYBU7KsLjMuo2rdxNq5Cujvq1iA0kpzKbdTBBoriGM0ege8wGC6/xUQV9N9sp/VhTVECtZGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.2.0",
-        "@perses-dev/components": "0.50.2",
-        "@perses-dev/core": "0.50.2",
-        "@perses-dev/plugin-system": "0.50.2",
+        "@perses-dev/components": "0.50.3",
+        "@perses-dev/core": "0.50.3",
+        "@perses-dev/plugin-system": "0.50.3",
         "@prometheus-io/codemirror-promql": "^0.43.0",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
@@ -7983,6 +7983,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10565,32 +10574,25 @@
       }
     },
     "node_modules/notistack": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
-      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
+      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.0",
-        "hoist-non-react-statics": "^3.3.0"
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/notistack"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": "^5.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/notistack/node_modules/clsx": {

--- a/web/package.json
+++ b/web/package.json
@@ -48,11 +48,11 @@
     "@patternfly/react-icons": "^6.2.0",
     "@patternfly/react-table": "^6.2.0",
     "@patternfly/react-templates": "^6.2.0",
-    "@perses-dev/components": "^0.50.0",
-    "@perses-dev/dashboards": "^0.50.0",
-    "@perses-dev/panels-plugin": "^0.50.0",
-    "@perses-dev/plugin-system": "^0.50.0",
-    "@perses-dev/prometheus-plugin": "^0.50.0",
+    "@perses-dev/components": "^0.50.3",
+    "@perses-dev/dashboards": "^0.50.3",
+    "@perses-dev/panels-plugin": "^0.50.3",
+    "@perses-dev/plugin-system": "^0.50.3",
+    "@perses-dev/prometheus-plugin": "^0.50.3",
     "@prometheus-io/codemirror-promql": "^0.37.0",
     "@tanstack/react-query": "^4.36.1",
     "classnames": "2.x",
@@ -113,7 +113,8 @@
     "tough-cookie": "^4.1.3",
     "sanitize-html": "^2.12.1",
     "path-to-regexp": "^1.9.0",
-    "cross-spawn": "^7.0.5"
+    "cross-spawn": "^7.0.5",
+    "notistack": "^3.0.2"
   },
   "resolutions": {
     "@types/react": "17.0.83"


### PR DESCRIPTION
Notistack v2 has a peer dependency of material ui V5, the current perses components depend on material UI 6. From notistack v3 this dependency was removed. Overwriting the dependency does not cause issues as the API is compatible.