### PR TITLE
OU-788: [Auto][BVT] - excluding one scenario from bvt and fix installation coo

### DIFF
--- a/web/cypress/e2e/coo_bvt.cy.ts
+++ b/web/cypress/e2e/coo_bvt.cy.ts
@@ -106,7 +106,7 @@ describe('Monitoring: Alerts', () => {
           operatorHubPage.installOperator(MCP.packageName, 'redhat-operators');
           cy.get('.co-clusterserviceversion-install__heading', { timeout: 5 * 60 * 1000 }).should(
             'include.text',
-            'ready for use',
+            'Ready for use',
           );
         } else if (Cypress.env('KONFLUX_COO_BUNDLE_IMAGE')) {
           cy.log('KONFLUX_COO_BUNDLE_IMAGE is set. COO operator will be installed from Konflux bundle.');
@@ -164,7 +164,7 @@ describe('Monitoring: Alerts', () => {
         cy.log('Check Cluster Observability Operator status');
         nav.sidenav.clickNavLink(['Operators', 'Installed Operators']);
         cy.byTestID('name-filter-input').should('be.visible').type('Cluster Observability{enter}');
-        cy.get('[data-test="status-text"]', { timeout: 100000 }).eq(0).should('contain.text', 'Succeeded');
+        cy.get('[data-test="status-text"]', { timeout: 400000 }).eq(0).should('contain.text', 'Succeeded');
 
         cy.log('Set Monitoring Console Plugin image in operator CSV');
         if (Cypress.env('MCP_CONSOLE_IMAGE')) {


### PR DESCRIPTION
- Scripts works correctly on clusters provisioned outside the pipeline, however the ones provisioned inside the pipeline + the time testing is executed does not generate alert and on Overview / status-card I was not able to intercept and inject. So, for now, I am excluding / commenting Scenario 3 from BVT script
- For COO BVT, I was testing with FBC image and the assertion part if different from installation through OperatorHub with stable COO1.1.1.