### PR TITLE
OU-786 and OU-775: Perses Dropdowns 

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -13,7 +13,9 @@ import {
   dynamicImportPluginLoader,
   PluginModuleResource,
   PluginRegistry,
-  TimeRangeProvider,
+  TimeRangeProviderWithQueryParams,
+  useInitialRefreshInterval,
+  useInitialTimeRange,
   usePluginBuiltinVariableDefinitions,
 } from '@perses-dev/plugin-system';
 import {
@@ -35,8 +37,7 @@ import { usePatternFlyTheme } from '../../hooks/usePatternflyTheme';
 import { CachedDatasourceAPI } from './perses/datasource-api';
 import { OcpDatasourceApi } from './datasource-api';
 import { PERSES_PROXY_BASE_PATH, useFetchPersesDashboard } from './perses-client';
-import { usePersesTimeRange } from './hooks/usePersesTimeRange';
-import { usePersesRefreshInterval } from './hooks/usePersesRefreshInterval';
+
 import { QueryParams } from '../../query-params';
 import { StringParam, useQueryParam } from 'use-query-params';
 import { useTranslation } from 'react-i18next';
@@ -87,7 +88,7 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
       fontFamily: 'var(--pf-t--global--font--family--body)',
     },
     shape: {
-      borderRadius: 0,
+      borderRadius: 6,
     },
   });
 
@@ -126,13 +127,19 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
 
 function InnerWrapper({ children, project, dashboardName }) {
   const { data } = usePluginBuiltinVariableDefinitions();
-
   const { persesDashboard, persesDashboardLoading } = useFetchPersesDashboard(
     project,
     dashboardName,
   );
-  const persesTimeRange = usePersesTimeRange();
-  const persesRefrshInterval = usePersesRefreshInterval();
+  const DEFAULT_DASHBOARD_DURATION = '30m';
+  const DEFAULT_REFRESH_INTERVAL = '0s';
+
+  const dashboardDuration = persesDashboard?.spec?.duration ?? DEFAULT_DASHBOARD_DURATION;
+  const dashboardRefreshInterval =
+    persesDashboard?.spec?.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
+
+  const initialTimeRange = useInitialTimeRange(dashboardDuration);
+  const initialRefreshInterval = useInitialRefreshInterval(dashboardRefreshInterval);
 
   const builtinVariables = useMemo(() => {
     const result = [
@@ -185,7 +192,10 @@ function InnerWrapper({ children, project, dashboardName }) {
   }
 
   return (
-    <TimeRangeProvider refreshInterval={persesRefrshInterval} timeRange={persesTimeRange}>
+    <TimeRangeProviderWithQueryParams
+      initialTimeRange={initialTimeRange}
+      initialRefreshInterval={initialRefreshInterval}
+    >
       <VariableProviderWithQueryParams
         builtinVariableDefinitions={builtinVariables}
         initialVariableDefinitions={persesDashboard?.spec?.variables}
@@ -208,7 +218,7 @@ function InnerWrapper({ children, project, dashboardName }) {
           )}
         </PersesPrometheusDatasourceWrapper>
       </VariableProviderWithQueryParams>
-    </TimeRangeProvider>
+    </TimeRangeProviderWithQueryParams>
   );
 }
 

--- a/web/src/components/dashboards/perses/variable-dropdowns.tsx
+++ b/web/src/components/dashboards/perses/variable-dropdowns.tsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { Tooltip, SelectOption, Stack, StackItem } from '@patternfly/react-core';
+import { Tooltip, SelectOption, Stack, StackItem, SplitItem, Split } from '@patternfly/react-core';
 import {
   DEFAULT_ALL_VALUE,
   ListVariableDefinition,
@@ -144,11 +144,13 @@ export const AllVariableDropdowns: React.FC = () => {
   }
 
   return (
-    <>
+    <Split hasGutter isWrappable>
       {variableDefinitions.map((v) => (
-        <VariableComponent key={v.spec.name} name={v.spec.name} />
+        <SplitItem key={v.spec.name + '-split-item'}>
+          <VariableComponent key={v.spec.name} name={v.spec.name} />
+        </SplitItem>
       ))}
-    </>
+    </Split>
   );
 };
 

--- a/web/src/components/dashboards/shared/dashboard-dropdown.tsx
+++ b/web/src/components/dashboards/shared/dashboard-dropdown.tsx
@@ -69,7 +69,7 @@ export const DashboardDropdown: React.FC<DashboardDropdownProps> = ({
       <StackItem>
         <label htmlFor="monitoring-board-dropdown">{t('Dashboard')}</label>
       </StackItem>
-      <StackItem>
+      <StackItem isFilled>
         <SingleTypeaheadDropdown
           items={selectItems}
           onChange={onChange}

--- a/web/src/components/dashboards/shared/dashboard-skeleton.tsx
+++ b/web/src/components/dashboards/shared/dashboard-skeleton.tsx
@@ -10,7 +10,16 @@ import { PollIntervalDropdown, TimespanDropdown } from './time-dropdowns';
 import { CombinedDashboardMetadata } from '../perses/hooks/useDashboardsData';
 import { AllVariableDropdowns } from '../perses/variable-dropdowns';
 import { useIsPerses } from './useIsPerses';
-import { Divider, PageSection, Split, SplitItem, Title } from '@patternfly/react-core';
+import {
+  Divider,
+  PageSection,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { TimeRangeControls } from '@perses-dev/plugin-system';
 
 const HeaderTop: React.FC = React.memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -23,10 +32,8 @@ const HeaderTop: React.FC = React.memo(() => {
       <SplitItem>
         <Split hasGutter isWrappable>
           <SplitItem>
-            <TimespanDropdown />
-          </SplitItem>
-          <SplitItem>
-            <PollIntervalDropdown />
+            <b> Time Range Controls </b>
+            <TimeRangeControls />
           </SplitItem>
         </Split>
       </SplitItem>
@@ -60,35 +67,45 @@ const DashboardSkeleton: React.FC<MonitoringDashboardsPageProps> = ({
       )}
       <PageSection hasBodyWrapper={false}>
         {perspective !== 'dev' && <HeaderTop />}
-        <Split hasGutter isWrappable>
+        <Stack hasGutter>
           {!_.isEmpty(boardItems) && (
-            <SplitItem>
+            <StackItem>
               <DashboardDropdown
                 items={boardItems}
                 onChange={changeBoard}
                 selectedKey={dashboardName}
               />
-            </SplitItem>
+            </StackItem>
           )}
           {isPerses ? (
-            <AllVariableDropdowns key={dashboardName} />
+            <StackItem>
+              <AllVariableDropdowns key={dashboardName} />
+            </StackItem>
           ) : (
-            <LegacyDashboardsAllVariableDropdowns key={dashboardName} />
+            <StackItem>
+              <LegacyDashboardsAllVariableDropdowns key={dashboardName} />
+            </StackItem>
           )}
           {perspective === 'dev' ? (
-            <>
-              <SplitItem isFilled />
-              <SplitItem>
-                <TimespanDropdown />
-              </SplitItem>
-              <SplitItem>
-                <PollIntervalDropdown />
-              </SplitItem>
-            </>
+            <StackItem>
+              <Split hasGutter>
+                <SplitItem isFilled />
+                <SplitItem>
+                  <TimespanDropdown />
+                </SplitItem>
+                <SplitItem>
+                  <PollIntervalDropdown />
+                </SplitItem>
+              </Split>
+            </StackItem>
           ) : (
-            <SplitItem isFilled />
+            <StackItem>
+              <Split>
+                <SplitItem isFilled />
+              </Split>
+            </StackItem>
           )}
-        </Split>
+        </Stack>
       </PageSection>
       <Divider />
       {children}


### PR DESCRIPTION
### Description 
- Multiple Variables Wrap 
- Time Range and Refresh Interval dropdowns replaced by Perses TimeRangeControl 
<img width="1514" alt="Screenshot 2025-06-12 at 5 39 17 PM" src="https://github.com/user-attachments/assets/564fcdc4-20fd-4f3e-82c8-3195e94f8016" />

#### Note:
- PR does not support TextVariable 
- PR does not support 'spec.duration' and 'spec.timeInterval' from a PersesDashboard definition/ .yaml to set the initial timerange (duration) and time interval.  This will be included in a later fix

### JIRA 
[OU-786](https://issues.redhat.com/browse/OU-786) [Perses] Use Perses variable selectors and skin them with Patternfly guidelines

[OU-775](https://issues.redhat.com/browse/OU-775) [Perses dashboards] Multiple variables don't wrap
