### PR TITLE
NO-JIRA: feat: improve loading state and project dropdown re-rendering

### DIFF
--- a/web/src/components/console/console-shared/src/components/loading/Loading.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/Loading.tsx
@@ -1,16 +1,9 @@
+import { Spinner } from '@patternfly/react-core';
 import * as React from 'react';
-import classNames from 'classnames';
 
 export const Loading: React.FCC<LoadingProps> = ({ className }) => (
-  // Leave to keep compatibility with console looks
-  // Should be removed in the 4.19 update
-  <div
-    className={classNames('co-m-loader co-an-fade-in-out', className)}
-    data-test="loading-indicator"
-  >
-    <div className="co-m-loader-dot__one" />
-    <div className="co-m-loader-dot__two" />
-    <div className="co-m-loader-dot__three" />
+  <div className={className} data-test="loading-indicator">
+    <Spinner size="lg" />
   </div>
 );
 Loading.displayName = 'Loading';

--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -40,6 +40,7 @@ import { usePersesRefreshInterval } from './hooks/usePersesRefreshInterval';
 import { QueryParams } from '../../query-params';
 import { StringParam, useQueryParam } from 'use-query-params';
 import { useTranslation } from 'react-i18next';
+import { LoadingBox } from '../../../components/console/console-shared/src/components/loading/LoadingBox';
 
 // Override eChart defaults with PatternFly colors.
 const patternflyBlue300 = '#2b9af3';
@@ -170,7 +171,7 @@ function InnerWrapper({ children, project, dashboardName }) {
   }, [data, project, dashboardName]);
 
   if (persesDashboardLoading) {
-    return null;
+    return <LoadingBox />;
   }
 
   let clearedDashboardResource: DashboardResource | undefined;

--- a/web/src/components/dashboards/perses/dashboard-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-page.tsx
@@ -1,10 +1,10 @@
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as React from 'react';
+import { LoadingBox } from '../../console/console-shared/src/components/loading/LoadingBox';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
 import withFallback from '../../console/console-shared/error/fallbacks/withFallback';
-import { LoadingInline } from '../../console/console-shared/src/components/loading/LoadingInline';
 import DashboardSkeleton from '../shared/dashboard-skeleton';
 import { PersesContext } from '../shared/useIsPerses';
 import { PersesWrapper } from './PersesWrapper';
@@ -34,7 +34,7 @@ const MonitoringDashboardsPage_: React.FC = () => {
   } = useDashboardsData();
 
   if (combinedIntialLoad) {
-    return <LoadingInline />;
+    return <LoadingBox />;
   }
 
   if (!activeProject) {
@@ -43,22 +43,24 @@ const MonitoringDashboardsPage_: React.FC = () => {
   }
 
   return (
-    <PersesWrapper project={activeProject}>
+    <>
       <ProjectBar activeProject={activeProject} setActiveProject={setActiveProject} />
-      {activeProjectDashboardsMetadata.length === 0 ? (
-        <DashboardEmptyState />
-      ) : (
-        <DashboardSkeleton
-          boardItems={activeProjectDashboardsMetadata}
-          changeBoard={changeBoard}
-          dashboardName={dashboardName}
-        >
-          <Overview>
-            <PersesBoard />
-          </Overview>
-        </DashboardSkeleton>
-      )}
-    </PersesWrapper>
+      <PersesWrapper project={activeProject}>
+        {activeProjectDashboardsMetadata.length === 0 ? (
+          <DashboardEmptyState />
+        ) : (
+          <DashboardSkeleton
+            boardItems={activeProjectDashboardsMetadata}
+            changeBoard={changeBoard}
+            dashboardName={dashboardName}
+          >
+            <Overview>
+              <PersesBoard />
+            </Overview>
+          </DashboardSkeleton>
+        )}
+      </PersesWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
This PR:

- uses the spinner (PF6) instead of the 3 dots as loading indicator
- moves the project dropdown outside the perses wrapper to avoid re-rendering when selecting a new project.


https://github.com/user-attachments/assets/58262464-7f34-4f14-947b-dd2fd6577ac4

