### PR TITLE
OU-786, OU-775:  Perses Dropdown integration for DashboardVariables and Time Range Controls

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -14,8 +14,10 @@ import {
   dynamicImportPluginLoader,
   PluginModuleResource,
   PluginRegistry,
-  TimeRangeProvider,
+  TimeRangeProviderWithQueryParams,
   useDataQueries,
+  useInitialRefreshInterval,
+  useInitialTimeRange,
   usePluginBuiltinVariableDefinitions,
 } from '@perses-dev/plugin-system';
 import {
@@ -38,8 +40,6 @@ import { usePatternFlyTheme } from './hooks/usePatternflyTheme';
 import { CachedDatasourceAPI } from './perses/datasource-api';
 import { OcpDatasourceApi } from './datasource-api';
 import { PERSES_PROXY_BASE_PATH, useFetchPersesDashboard } from './perses-client';
-import { usePersesTimeRange } from './hooks/usePersesTimeRange';
-import { usePersesRefreshInterval } from './hooks/usePersesRefreshInterval';
 import { QueryParams } from '../../query-params';
 import { StringParam, useQueryParam } from 'use-query-params';
 import { useCookieWatcher } from './hooks/useCookieWatcher';
@@ -135,8 +135,12 @@ function InnerWrapper({ children, project, dashboardName }) {
     project,
     dashboardName,
   );
-  const persesTimeRange = usePersesTimeRange();
-  const persesRefrshInterval = usePersesRefreshInterval();
+
+  const DEFAULT_DASHBOARD_DURATION = '30m';
+  const DEFAULT_REFRESH_INTERVAL = '0s';
+
+  const initialTimeRange = useInitialTimeRange(DEFAULT_DASHBOARD_DURATION);
+  const initialRefreshInterval = useInitialRefreshInterval(DEFAULT_REFRESH_INTERVAL);
 
   const builtinVariables = useMemo(() => {
     const result = [
@@ -189,7 +193,10 @@ function InnerWrapper({ children, project, dashboardName }) {
   }
 
   return (
-    <TimeRangeProvider refreshInterval={persesRefrshInterval} timeRange={persesTimeRange}>
+    <TimeRangeProviderWithQueryParams
+      initialTimeRange={initialTimeRange}
+      initialRefreshInterval={initialRefreshInterval}
+    >
       <VariableProviderWithQueryParams
         builtinVariableDefinitions={builtinVariables}
         initialVariableDefinitions={persesDashboard?.spec?.variables}
@@ -212,7 +219,7 @@ function InnerWrapper({ children, project, dashboardName }) {
           )}
         </PersesPrometheusDatasourceWrapper>
       </VariableProviderWithQueryParams>
-    </TimeRangeProvider>
+    </TimeRangeProviderWithQueryParams>
   );
 }
 

--- a/web/src/components/dashboards/shared/dashboard-dropdown.tsx
+++ b/web/src/components/dashboards/shared/dashboard-dropdown.tsx
@@ -1,5 +1,13 @@
 import * as _ from 'lodash-es';
-import { Label, SelectOption } from '@patternfly/react-core';
+import {
+  Label,
+  LabelGroup,
+  Level,
+  LevelItem,
+  SelectOption,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -31,18 +39,22 @@ export const DashboardDropdown: React.FC<DashboardDropdownProps> = ({
     });
     return (
       <SelectOption value={value} isSelected={isSelected || false} {...rest}>
-        <div className="monitoring-dashboards__dashboard_dropdown_item">
-          <span>{matchedValue?.title}</span>
-          <div className="monitoring-dashboards__dashboard_dropdown_tags">
-            {matchedValue?.tags?.map((tag, i) => (
-              <Tag
-                color={tagColors[_.indexOf(uniqueTags, tag) % tagColors.length]}
-                key={i}
-                text={tag}
-              />
-            ))}
-          </div>
-        </div>
+        <Level hasGutter>
+          <LevelItem>
+            <span>{matchedValue?.title}</span>
+          </LevelItem>
+          <LevelItem>
+            <LabelGroup>
+              {matchedValue?.tags?.map((tag, i) => (
+                <Tag
+                  color={tagColors[_.indexOf(uniqueTags, tag) % tagColors.length]}
+                  key={i}
+                  text={tag}
+                />
+              ))}
+            </LabelGroup>
+          </LevelItem>
+        </Level>
       </SelectOption>
     );
   };
@@ -53,20 +65,22 @@ export const DashboardDropdown: React.FC<DashboardDropdownProps> = ({
   }));
 
   return (
-    <div className="form-group monitoring-dashboards__dropdown-wrap" data-test="dashboard-dropdown">
-      <label className="monitoring-dashboards__dropdown-title" htmlFor="monitoring-board-dropdown">
-        {t('Dashboard')}
-      </label>
-      <SingleTypeaheadDropdown
-        items={selectItems}
-        onChange={onChange}
-        OptionComponent={OptionComponent}
-        selectedKey={selectedKey}
-        hideClearButton
-        resizeToFit
-        clearOnNewItems
-      />
-    </div>
+    <Stack data-test="dashboard-dropdown">
+      <StackItem>
+        <label htmlFor="monitoring-board-dropdown">{t('Dashboard')}</label>
+      </StackItem>
+      <StackItem isFilled>
+        <SingleTypeaheadDropdown
+          items={selectItems}
+          onChange={onChange}
+          OptionComponent={OptionComponent}
+          selectedKey={selectedKey}
+          hideClearButton
+          resizeToFit
+          clearOnNewItems
+        />
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/web/src/components/dashboards/shared/time-dropdowns.tsx
+++ b/web/src/components/dashboards/shared/time-dropdowns.tsx
@@ -1,173 +1,19 @@
-import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
-import {
-  dashboardsSetEndTime,
-  dashboardsSetPollInterval,
-  dashboardsSetTimespan,
-} from '../../../actions/observe';
-import { useBoolean } from '../../hooks/useBoolean';
-import CustomTimeRangeModal from '../shared/custom-time-range-modal';
-import { getLegacyObserveState, usePerspective } from '../../hooks/usePerspective';
-import { SimpleSelect, SimpleSelectOption } from '../../SimpleSelect';
-import { MonitoringState } from '../../../reducers/observe';
-import {
-  DEFAULT_REFRESH_INTERVAL,
-  DropDownPollInterval,
-} from '../../../components/dropdown-poll-interval';
-import { QueryParams } from '../../query-params';
-import { NumberParam, useQueryParam } from 'use-query-params';
-import { useIsPerses } from './useIsPerses';
-import {
-  formatPrometheusDuration,
-  parsePrometheusDuration,
-} from '../../console/console-shared/src/datetime/prometheus';
-
-const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
-const DEFAULT_TIMERANGE = '30m';
-
-const TimespanDropdown: React.FC = () => {
-  const { t } = useTranslation(process.env.I18N_NAMESPACE);
-
-  const { perspective } = usePerspective();
-  const isPerses = useIsPerses();
-
-  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
-
-  const timespan = useSelector((state: MonitoringState) =>
-    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
-  );
-  const endTime = useSelector((state: MonitoringState) =>
-    getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'endTime']),
-  );
-
-  const [timeRangeFromParams, setTimeRange] = useQueryParam(QueryParams.TimeRange, NumberParam);
-  const [endTimeFromParams, setEndTime] = useQueryParam(QueryParams.EndTime, NumberParam);
-
-  const selectedKey =
-    endTime || endTimeFromParams
-      ? CUSTOM_TIME_RANGE_KEY
-      : formatPrometheusDuration(_.toNumber(timeRangeFromParams) || timespan);
-
-  const dispatch = useDispatch();
-  const onChange = React.useCallback(
-    (v: string) => {
-      if (v === CUSTOM_TIME_RANGE_KEY) {
-        setModalOpen();
-      } else {
-        setTimeRange(parsePrometheusDuration(v));
-        setEndTime(undefined);
-        if (!isPerses) {
-          dispatch(dashboardsSetTimespan(parsePrometheusDuration(v), perspective));
-          dispatch(dashboardsSetEndTime(null, perspective));
-        }
-      }
-    },
-    [setModalOpen, dispatch, perspective, setTimeRange, setEndTime, isPerses],
-  );
-
-  const initialOptions = React.useMemo<SimpleSelectOption[]>(() => {
-    const intervalOptions: SimpleSelectOption[] = [
-      { content: t('Custom time range'), value: CUSTOM_TIME_RANGE_KEY },
-      { content: t('Last {{count}} minute', { count: 5 }), value: '5m' },
-      { content: t('Last {{count}} minute', { count: 15 }), value: '15m' },
-      { content: t('Last {{count}} minute', { count: 30 }), value: '30m' },
-      { content: t('Last {{count}} hour', { count: 1 }), value: '1h' },
-      { content: t('Last {{count}} hour', { count: 2 }), value: '2h' },
-      { content: t('Last {{count}} hour', { count: 6 }), value: '6h' },
-      { content: t('Last {{count}} hour', { count: 12 }), value: '12h' },
-      { content: t('Last {{count}} day', { count: 1 }), value: '1d' },
-      { content: t('Last {{count}} day', { count: 2 }), value: '2d' },
-      { content: t('Last {{count}} week', { count: 1 }), value: '1w' },
-      { content: t('Last {{count}} week', { count: 2 }), value: '2w' },
-    ];
-
-    // If selectedKey is empty, the dashboard has changed. Reset selected to default value.
-    if (selectedKey === '' || (selectedKey === DEFAULT_TIMERANGE && !timeRangeFromParams)) {
-      setTimeRange(parsePrometheusDuration(DEFAULT_TIMERANGE));
-      setEndTime(undefined);
-    }
-    return intervalOptions.map((o) => ({ ...o, selected: o.value === selectedKey }));
-  }, [selectedKey, t, timeRangeFromParams, setTimeRange, setEndTime]);
-
-  const defaultTimerange = (isPerses ? timeRangeFromParams : timespan) ?? undefined;
-  const defaultEndTime = (isPerses ? endTimeFromParams : endTime) ?? undefined;
-
-  return (
-    <>
-      <CustomTimeRangeModal
-        perspective={perspective}
-        isOpen={isModalOpen}
-        setClosed={setModalClosed}
-        timespan={defaultTimerange}
-        endTime={defaultEndTime}
-      />
-      <div className="form-group monitoring-dashboards__dropdown-wrap">
-        <label
-          className="monitoring-dashboards__dropdown-title"
-          htmlFor="monitoring-time-range-dropdown"
-        >
-          {t('Time range')}
-        </label>
-        <SimpleSelect
-          id="monitoring-time-range-dropdown"
-          initialOptions={initialOptions}
-          className="monitoring-dashboards__variable-dropdown"
-          onSelect={(_event, selection) => {
-            if (selection) {
-              onChange(String(selection));
-            }
-          }}
-          toggleWidth="150px"
-          placeholder={t('Last {{count}} minute', { count: 30 })}
-        />
-      </div>
-    </>
-  );
-};
-
-const PollIntervalDropdown: React.FC = () => {
-  const { t } = useTranslation(process.env.I18N_NAMESPACE);
-  const { perspective } = usePerspective();
-  const isPerses = useIsPerses();
-  const [selectedInterval, setSelectedInterval] = React.useState(
-    isPerses ? 0 : DEFAULT_REFRESH_INTERVAL,
-  );
-
-  const dispatch = useDispatch();
-  const [, setRefreshInterval] = useQueryParam(QueryParams.RefreshInterval, NumberParam);
-
-  const setInterval = React.useCallback(
-    (v: number) => {
-      setSelectedInterval(v);
-      setRefreshInterval(v);
-      if (!isPerses) {
-        dispatch(dashboardsSetPollInterval(v, perspective));
-      }
-    },
-    [dispatch, perspective, isPerses, setRefreshInterval],
-  );
-
-  return (
-    <div className="form-group monitoring-dashboards__dropdown-wrap">
-      <label htmlFor="refresh-interval-dropdown" className="monitoring-dashboards__dropdown-title">
-        {t('Refresh interval')}
-      </label>
-      <DropDownPollInterval
-        id="refresh-interval-dropdown"
-        setInterval={setInterval}
-        selectedInterval={selectedInterval}
-      />
-    </div>
-  );
-};
+import { Stack, StackItem } from '@patternfly/react-core';
+import { TimeRangeControls } from '@perses-dev/plugin-system';
 
 export const TimeDropdowns: React.FC = React.memo(() => {
+  const { t } = useTranslation(process.env.I18N_NAMESPACE);
+
   return (
-    <div className="monitoring-dashboards__options">
-      <TimespanDropdown />
-      <PollIntervalDropdown />
-    </div>
+    <Stack aria-label="Perses Time Range Controls">
+      <StackItem>
+        <b> {t('Time Range Controls')} </b>
+      </StackItem>
+      <StackItem>
+        <TimeRangeControls />
+      </StackItem>
+    </Stack>
   );
 });


### PR DESCRIPTION
### Description 
This is a backport of https://github.com/openshift/monitoring-plugin/pull/429 for release-coo-0.4. 

This is needed because 

- the original PR (https://github.com/openshift/monitoring-plugin/pull/429) accommodates PF6 and OCP v4.19+ 
- while this PR accommodates PF5 and OCP v4.15 - v4.18.

### JIRA 
[OU-786](https://issues.redhat.com/browse/OU-786) [Perses] Use Perses variable selectors and skin them with Patternfly guidelines

[OU-775](https://issues.redhat.com/browse/OU-775) [Perses dashboards] Multiple variables don't wrap

### Testing 
1. Start a 4.15 - 4.18 OCP cluster 
2. Install Cluster Observability Operator 
3. Install UIPlugin > monitoring > check 'perses' as a feature to include 
4. In the Cluster Observability Operator > Yaml > ClusterServiceVersion replace `registry.redhat.io/cluster-observability-operator/monitoring-console-plugin-0-4-rhel9@sha256:0f85b8266a061aac5be61f475203d0b59ef2afe0d55e0c7cb1a57437a9a5b9be` with a image that contains this PR:
    - use quay.io/jezhu/monitoring-console-plugin:perses_dropdown_release_coo_0.4 OR 
    - build your own from a copy of this PR
 5. (Optional) Add another Perses Dashboard [example dashboard](https://github.com/zhuje/development-tools/blob/main/perses/perses_dashboard.yaml)
 
### Demo Video 

https://github.com/user-attachments/assets/cee63fc6-147f-464a-9cd0-cff022c18f33

_Figure 1. Shows OCP v4.18 Time Range Controls and Dashboard Variables are the new features added in this PR._ 
 