### PR TITLE
OU-772: remove troubleshooting panel links from non-admin

### DIFF
--- a/web/src/components/alerting/AlertsDetailsPage.tsx
+++ b/web/src/components/alerting/AlertsDetailsPage.tsx
@@ -139,6 +139,14 @@ const AlertsDetailsPage_: React.FC = () => {
 
   const AlertsChart = alertsChart?.[0];
 
+  // Keep the default name for the admin perspective while providing specific
+  // entrypoints for all other perspectives as wel
+  const alertActionContextName = `alert-detail-toolbar-actions${
+    perspective === 'admin' ? '' : '-' + perspective
+  }`;
+  const alertActionContext = {};
+  alertActionContext[alertActionContextName] = { alert };
+
   return (
     <>
       <Helmet>
@@ -199,7 +207,7 @@ const AlertsDetailsPage_: React.FC = () => {
                   <Title headingLevel="h2">{t('Alert details')}</Title>
                 </ToolbarItem>
                 <ToolbarGroup align={{ default: 'alignEnd' }}>
-                  <ActionServiceProvider context={{ 'alert-detail-toolbar-actions': { alert } }}>
+                  <ActionServiceProvider context={alertActionContext}>
                     {({ actions, loaded }) =>
                       loaded
                         ? actions.map((action) => {
@@ -218,7 +226,6 @@ const AlertsDetailsPage_: React.FC = () => {
                                 </ToolbarItem>
                               );
                             }
-
                             return null;
                           })
                         : null


### PR DESCRIPTION
This PR looks to prevent the troubleshooting panel links from appearing on the alert detail page for the non-admin perspective

![image](https://github.com/user-attachments/assets/7f9e2778-8d1b-4e71-9989-3e1d5113a7ea)


![image](https://github.com/user-attachments/assets/099417c2-6b51-46d3-81a8-a6075f2efb3d)
