### PR TITLE
OCPBUGS-55455: feat: add alerting rules tab to dev console

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -171,6 +171,17 @@
     }
   },
   {
+    "type": "console.tab",
+    "properties": {
+      "contextId": "dev-console-observe",
+      "name": "%plugin__monitoring-plugin~Alerting Rules%",
+      "href": "alertrules",
+      "component": {
+        "$codeRef": "AlertRulesPage"
+      }
+    }
+  },
+  {
     "type": "console.redux-reducer",
     "properties": {
       "scope": "mp",
@@ -261,9 +272,7 @@
     "type": "console.page/route",
     "properties": {
       "exact": false,
-      "path": [
-        "/virt-monitoring"
-      ],
+      "path": ["/virt-monitoring"],
       "component": { "$codeRef": "AlertingPage" }
     }
   },

--- a/web/src/components/alerting/AlertRulesDetailsPage.tsx
+++ b/web/src/components/alerting/AlertRulesDetailsPage.tsx
@@ -58,7 +58,6 @@ import { formatPrometheusDuration } from '../console/console-shared/src/datetime
 import { ExternalLink } from '../console/utils/link';
 import {
   getAlertRulesUrl,
-  getAlertsUrl,
   getAlertUrl,
   getLegacyObserveState,
   getNewSilenceAlertUrl,
@@ -187,16 +186,9 @@ const AlertRulesDetailsPage_: React.FC = () => {
         <PageGroup>
           <PageBreadcrumb hasBodyWrapper={false}>
             <Breadcrumb>
-              {perspective === 'dev' && (
-                <BreadcrumbItem>
-                  <Link to={getAlertsUrl(perspective, namespace)}>{t('Alerts')}</Link>
-                </BreadcrumbItem>
-              )}
-              {perspective !== 'dev' && (
-                <BreadcrumbItem>
-                  <Link to={getAlertRulesUrl(perspective)}>{t('Alerting rules')}</Link>
-                </BreadcrumbItem>
-              )}
+              <BreadcrumbItem>
+                <Link to={getAlertRulesUrl(perspective, namespace)}>{t('Alerting rules')}</Link>
+              </BreadcrumbItem>
               <BreadcrumbItem isActive>{t('Alerting rule details')}</BreadcrumbItem>
             </Breadcrumb>
           </PageBreadcrumb>

--- a/web/src/components/hooks/usePerspective.tsx
+++ b/web/src/components/hooks/usePerspective.tsx
@@ -125,12 +125,14 @@ export const getAlertsUrl = (perspective: Perspective, namespace?: string) => {
 };
 
 // There is no equivalent rules list page in the developer perspective
-export const getAlertRulesUrl = (perspective: Perspective) => {
+export const getAlertRulesUrl = (perspective: Perspective, namespace?: string) => {
   switch (perspective) {
     case 'acm':
       return `/multicloud${RuleResource.plural}`;
     case 'virtualization-perspective':
       return `/virt-monitoring/alertrules`;
+    case 'dev':
+      return `/dev-monitoring/ns/${namespace}/alertrules`;
     case 'admin':
     default:
       return RuleResource.plural;


### PR DESCRIPTION
This PR adds the alerting rule tab to the dev console, to allow filtering of "Not Firing" alerts, which in principle are alerting rules.