### PR TITLE
OU-849: Upgrade jsx pre processor to "react-jsx"

### DIFF
--- a/web/.eslintrc.yml
+++ b/web/.eslintrc.yml
@@ -29,6 +29,8 @@ rules:
   react/display-name: off
   react/prop-types: off
   "@typescript-eslint/no-explicit-any": off
+  # React 17 doesn't reuqire this anymore
+  react/react-in-jsx-scope: off 
 settings:
   react:
     version: detect

--- a/web/cypress/dummy.tsx
+++ b/web/cypress/dummy.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export {
   ActionServiceProvider,
   BlueInfoCircleIcon,

--- a/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 
 import {
   Chart,
@@ -25,8 +25,8 @@ import { VictoryPortal } from 'victory';
 
 const AlertsChart = ({ chartDays, theme }: { chartDays: number; theme: 'light' | 'dark' }) => {
   const dispatch = useDispatch();
-  const [chartContainerHeight, setChartContainerHeight] = React.useState<number>();
-  const [chartHeight, setChartHeight] = React.useState<number>();
+  const [chartContainerHeight, setChartContainerHeight] = useState<number>();
+  const [chartHeight, setChartHeight] = useState<number>();
   const alertsData = useSelector((state: MonitoringState) =>
     state.plugins.mcp.getIn(['incidentsData', 'alertsData']),
   );
@@ -40,34 +40,34 @@ const AlertsChart = ({ chartDays, theme }: { chartDays: number; theme: 'light' |
     state.plugins.mcp.getIn(['incidentsData', 'groupId']),
   );
 
-  const dateValues = React.useMemo(() => generateDateArray(chartDays), [chartDays]);
+  const dateValues = useMemo(() => generateDateArray(chartDays), [chartDays]);
 
-  const chartData = React.useMemo(() => {
+  const chartData = useMemo(() => {
     if (!Array.isArray(alertsData) || alertsData.length === 0) return [];
     return alertsData.map((alert) => createAlertsChartBars(alert, dateValues));
   }, [alertsData, dateValues]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setChartContainerHeight(chartData?.length < 5 ? 300 : chartData?.length * 60);
     setChartHeight(chartData?.length < 5 ? 250 : chartData?.length * 55);
   }, [chartData]);
 
-  const selectedIncidentIsVisible = React.useMemo(() => {
+  const selectedIncidentIsVisible = useMemo(() => {
     return filteredData.some((incident) => incident.group_id === incidentGroupId);
   }, [filteredData, incidentGroupId]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(setAlertsAreLoading({ alertsAreLoading: !selectedIncidentIsVisible }));
   }, [dispatch, selectedIncidentIsVisible]);
 
-  const [width, setWidth] = React.useState(0);
-  const containerRef = React.useRef(null);
-  const handleResize = React.useCallback(() => {
+  const [width, setWidth] = useState(0);
+  const containerRef = useRef(null);
+  const handleResize = useCallback(() => {
     if (containerRef.current && containerRef.current.clientWidth) {
       setWidth(containerRef.current.clientWidth);
     }
   }, []);
-  React.useEffect(() => {
+  useEffect(() => {
     const observer = getResizeObserver(containerRef.current, handleResize);
     handleResize();
     return () => observer();

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 
 import {
   Chart,
@@ -46,34 +46,34 @@ const IncidentsChart = ({
   theme: 'light' | 'dark';
 }) => {
   const dispatch = useDispatch();
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [chartContainerHeight, setChartContainerHeight] = React.useState<number>();
-  const [chartHeight, setChartHeight] = React.useState<number>();
-  const dateValues = React.useMemo(() => generateDateArray(chartDays), [chartDays]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [chartContainerHeight, setChartContainerHeight] = useState<number>();
+  const [chartHeight, setChartHeight] = useState<number>();
+  const dateValues = useMemo(() => generateDateArray(chartDays), [chartDays]);
 
-  const chartData = React.useMemo(() => {
+  const chartData = useMemo(() => {
     if (!Array.isArray(incidentsData) || incidentsData.length === 0) return [];
     return incidentsData.map((incident) => createIncidentsChartBars(incident, dateValues));
   }, [incidentsData, dateValues]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setIsLoading(false);
   }, [incidentsData]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setChartContainerHeight(chartData?.length < 5 ? 300 : chartData?.length * 60);
     setChartHeight(chartData?.length < 5 ? 250 : chartData?.length * 55);
   }, [chartData]);
 
-  const [width, setWidth] = React.useState(0);
-  const containerRef = React.useRef(null);
+  const [width, setWidth] = useState(0);
+  const containerRef = useRef(null);
 
   const handleResize = () => {
     if (containerRef.current && containerRef.current.clientWidth) {
       setWidth(containerRef.current.clientWidth);
     }
   };
-  React.useEffect(() => {
+  useEffect(() => {
     const observer = getResizeObserver(containerRef.current, handleResize);
     handleResize();
     return () => observer();
@@ -86,7 +86,7 @@ const IncidentsChart = ({
     state.plugins.mcp.getIn(['incidentsData', 'incidentsActiveFilters']),
   );
 
-  const isHidden = React.useCallback(
+  const isHidden = useCallback(
     (group_id) => selectedId !== '' && selectedId !== group_id,
     [selectedId],
   );
@@ -109,7 +109,7 @@ const IncidentsChart = ({
     }
   };
 
-  const getOpacity = React.useCallback(
+  const getOpacity = useCallback(
     (datum) => (datum.fillOpacity = isHidden(datum.group_id) ? '0.3' : '1'),
     [isHidden],
   );

--- a/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import {
   GreenCheckCircleIcon,
@@ -28,7 +28,7 @@ import isEqual from 'lodash/isEqual';
 import { MonitoringState } from 'src/reducers/observe';
 
 function useDeepCompareMemoize(value) {
-  const ref = React.useRef();
+  const ref = useRef();
 
   if (!isEqual(value, ref.current)) {
     ref.current = value;
@@ -42,7 +42,7 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
   const [namespace] = useActiveNamespace();
   useAlertsPoller();
   const { perspective, alertsKey } = usePerspective();
-  const [alertsWithMatchedData, setAlertsWithMatchedData] = React.useState([]);
+  const [alertsWithMatchedData, setAlertsWithMatchedData] = useState([]);
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const alertsWithLabels = useSelector((state: MonitoringState) =>
@@ -63,7 +63,7 @@ const IncidentsDetailsRowTable = ({ alerts }) => {
   }
   const memoizedAlerts = useDeepCompareMemoize(alerts);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setAlertsWithMatchedData(findMatchingAlertsWithId(memoizedAlerts, alertsWithLabels));
   }, [memoizedAlerts, alertsWithLabels]);
 

--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import * as React from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useSafeFetch } from '../console/utils/safe-fetch-hook';
 import { createAlertsQuery, fetchDataForIncidentsAndAlerts } from './api';
 import { useTranslation } from 'react-i18next';
@@ -63,24 +63,24 @@ const IncidentsPage = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const dispatch = useDispatch();
   const location = useLocation();
-  const urlParams = React.useMemo(() => parseUrlParams(location.search), [location.search]);
+  const urlParams = useMemo(() => parseUrlParams(location.search), [location.search]);
   const { perspective } = usePerspective();
   const { theme } = usePatternFlyTheme();
   // loading states
-  const [incidentsAreLoading, setIncidentsAreLoading] = React.useState(true);
+  const [incidentsAreLoading, setIncidentsAreLoading] = useState(true);
   // days span is where we store the value for creating time ranges for
   // fetch incidents/alerts based on the length of time ranges
   // when days filter changes we set a new days span -> calculate new time range and fetch new data
-  const [daysSpan, setDaysSpan] = React.useState<number>();
-  const [timeRanges, setTimeRanges] = React.useState([]);
+  const [daysSpan, setDaysSpan] = useState<number>();
+  const [timeRanges, setTimeRanges] = useState([]);
   // data that is used for processing to serve it to the alerts table and chart
-  const [incidentForAlertProcessing, setIncidentForAlertProcessing] = React.useState<
+  const [incidentForAlertProcessing, setIncidentForAlertProcessing] = useState<
     Array<Partial<Incident>>
   >([]);
-  const [hideCharts, setHideCharts] = React.useState(false);
+  const [hideCharts, setHideCharts] = useState(false);
 
-  const [incidentFilterIsExpanded, setIncidentIsExpanded] = React.useState(false);
-  const [daysFilterIsExpanded, setDaysFilterIsExpanded] = React.useState(false);
+  const [incidentFilterIsExpanded, setIncidentIsExpanded] = useState(false);
+  const [daysFilterIsExpanded, setDaysFilterIsExpanded] = useState(false);
 
   const onIncidentFilterToggle = (ev) => {
     ev.stopPropagation();
@@ -115,7 +115,7 @@ const IncidentsPage = () => {
   const filteredData = useSelector((state: MonitoringState) =>
     state.plugins.mcp.getIn(['incidentsData', 'filteredIncidentsData']),
   );
-  React.useEffect(() => {
+  useEffect(() => {
     const hasUrlParams = Object.keys(urlParams).length > 0;
     if (hasUrlParams) {
       // If URL parameters exist, update incidentsActiveFilters based on them
@@ -147,11 +147,11 @@ const IncidentsPage = () => {
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     updateBrowserUrl(incidentsActiveFilters, incidentGroupId);
   }, [incidentsActiveFilters]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(
       setFilteredIncidentsData({
         filteredIncidentsData: filterIncident(incidentsActiveFilters, incidents),
@@ -163,11 +163,11 @@ const IncidentsPage = () => {
   const safeFetch = useSafeFetch();
   const title = t('Incidents');
 
-  React.useEffect(() => {
+  useEffect(() => {
     setTimeRanges(getIncidentsTimeRanges(daysSpan, now));
   }, [daysSpan]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDaysSpan(
       parsePrometheusDuration(
         incidentsActiveFilters.days.length > 0
@@ -177,7 +177,7 @@ const IncidentsPage = () => {
     );
   }, [incidentsActiveFilters.days]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     (async () => {
       Promise.all(
         timeRanges.map(async (range) => {
@@ -206,7 +206,7 @@ const IncidentsPage = () => {
     })();
   }, [incidentForAlertProcessing]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(
       setAlertsTableData({
         alertsTableData: groupAlertsForTable(alertsData),
@@ -214,7 +214,7 @@ const IncidentsPage = () => {
     );
   }, [alertsData]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     (async () => {
       Promise.all(
         timeRanges.map(async (range) => {
@@ -251,7 +251,7 @@ const IncidentsPage = () => {
     })();
   }, [timeRanges]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (incidentGroupId) {
       Promise.all(
         timeRanges.map(async (range) => {

--- a/web/src/components/Incidents/IncidentsTable.tsx
+++ b/web/src/components/Incidents/IncidentsTable.tsx
@@ -3,7 +3,7 @@ import { Bullseye, Card, CardBody, EmptyState, EmptyStateBody } from '@patternfl
 import { SearchIcon } from '@patternfly/react-icons';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import React from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { MonitoringState } from 'src/reducers/observe';
 import { AlertStateIcon, SeverityBadge } from '../alerting/AlertUtils';
@@ -17,7 +17,7 @@ export const IncidentsTable = () => {
     severity: 'Severity',
     state: 'State',
   };
-  const [expandedAlerts, setExpandedAlerts] = React.useState([]);
+  const [expandedAlerts, setExpandedAlerts] = useState([]);
   const setAlertExpanded = (alert: Alert, isExpanding = true) =>
     setExpandedAlerts((prevExpanded) => {
       const otherAlertExpanded = prevExpanded.filter((r) => r !== alert.component);

--- a/web/src/components/MetricsPage.tsx
+++ b/web/src/components/MetricsPage.tsx
@@ -58,7 +58,8 @@ import {
   wrappable,
 } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, Ref } from 'react';
+import { useMemo, useCallback, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -218,7 +219,7 @@ const PreDefinedQueriesDropdown = () => {
 
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
-  const queries: SelectOptionProps[] = React.useMemo(() => {
+  const queries: SelectOptionProps[] = useMemo(() => {
     switch (perspective) {
       case 'dev':
         return devQueries(activeNamespace);
@@ -272,7 +273,7 @@ const PreDefinedQueriesDropdown = () => {
   );
 };
 
-const MetricsActionsMenu: React.FC = () => {
+const MetricsActionsMenu: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
@@ -285,7 +286,7 @@ const MetricsActionsMenu: React.FC = () => {
   );
 
   const dispatch = useDispatch();
-  const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
+  const addQuery = useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
 
   const doDelete = () => {
     dispatch(queryBrowserDeleteAllQueries());
@@ -297,7 +298,7 @@ const MetricsActionsMenu: React.FC = () => {
       isOpen={isOpen}
       onSelect={setClosed}
       onOpenChange={(open: boolean) => (open ? setIsOpen() : setClosed())}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+      toggle={(toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle ref={toggleRef} onClick={setIsOpen} isExpanded={isOpen}>
           Actions
         </MenuToggle>
@@ -324,7 +325,7 @@ const MetricsActionsMenu: React.FC = () => {
   );
 };
 
-export const ToggleGraph: React.FC = () => {
+export const ToggleGraph: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
@@ -333,11 +334,11 @@ export const ToggleGraph: React.FC = () => {
   );
 
   const dispatch = useDispatch();
-  const toggle = React.useCallback(() => dispatch(toggleGraphs()), [dispatch]);
+  const toggle = useCallback(() => dispatch(toggleGraphs()), [dispatch]);
 
   // Use an empty useEffect to get access to the cleanup function so that if graphs are
   // currently hidden then we show the graphs as we unmount
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       dispatch(showGraphs());
     };
@@ -356,7 +357,7 @@ export const ToggleGraph: React.FC = () => {
   );
 };
 
-const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
+const SeriesButton: FC<SeriesButtonProps> = ({ index, labels }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
@@ -384,7 +385,7 @@ const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
   );
 
   const dispatch = useDispatch();
-  const toggleSeries = React.useCallback(
+  const toggleSeries = useCallback(
     () => dispatch(queryBrowserToggleSeries(index, labels)),
     [dispatch, index, labels],
   );
@@ -407,7 +408,7 @@ const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
   );
 };
 
-const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
+const QueryKebab: FC<{ index: number }> = ({ index }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
@@ -445,22 +446,22 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
 
   const dispatch = useDispatch();
 
-  const toggleIsEnabled = React.useCallback(
+  const toggleIsEnabled = useCallback(
     () => dispatch(queryBrowserToggleIsEnabled(index)),
     [dispatch, index],
   );
 
-  const toggleAllSeries = React.useCallback(
+  const toggleAllSeries = useCallback(
     () => dispatch(queryBrowserToggleAllSeries(index)),
     [dispatch, index],
   );
 
-  const doDelete = React.useCallback(() => {
+  const doDelete = useCallback(() => {
     dispatch(queryBrowserDeleteQuery(index));
     focusedQuery = undefined;
   }, [dispatch, index]);
 
-  const doClone = React.useCallback(() => {
+  const doClone = useCallback(() => {
     dispatch(queryBrowserDuplicateQuery(index));
   }, [dispatch, index]);
 
@@ -577,20 +578,15 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
   return <KebabDropdown dropdownItems={dropdownItems} />;
 };
 
-export const QueryTable: React.FC<QueryTableProps> = ({
-  index,
-  namespace,
-  customDatasource,
-  units,
-}) => {
+export const QueryTable: FC<QueryTableProps> = ({ index, namespace, customDatasource, units }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
-  const [data, setData] = React.useState<PrometheusData>();
-  const [error, setError] = React.useState<PrometheusAPIError>();
-  const [page, setPage] = React.useState(1);
-  const [perPage, setPerPage] = React.useState(50);
-  const [sortBy, setSortBy] = React.useState<ISortBy>({});
+  const [data, setData] = useState<PrometheusData>();
+  const [error, setError] = useState<PrometheusAPIError>();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(50);
+  const [sortBy, setSortBy] = useState<ISortBy>({});
   const valueFormat = valueFormatter(units);
 
   const isEnabled = useSelector((state: MonitoringState) =>
@@ -628,7 +624,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({
 
   const dispatch = useDispatch();
 
-  const toggleAllSeries = React.useCallback(
+  const toggleAllSeries = useCallback(
     () => dispatch(queryBrowserToggleAllSeries(index)),
     [dispatch, index],
   );
@@ -645,7 +641,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({
   );
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
 
   // If the namespace is defined getPrometheusURL will use
   // the PROMETHEUS_TENANCY_BASE_PATH for requests in the developer view
@@ -677,7 +673,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({
 
   usePoll(tick, pollInterval, namespace, query, span, lastRequestTime);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setData(undefined);
     setError(undefined);
     setPage(1);
@@ -887,7 +883,7 @@ const PromQLExpressionInput = (props) => (
   />
 );
 
-const Query: React.FC<{
+const Query: FC<{
   index: number;
   customDatasource?: CustomDataSource;
   units: GraphUnits;
@@ -923,19 +919,19 @@ const Query: React.FC<{
 
   const dispatch = useDispatch();
 
-  const toggleIsEnabled = React.useCallback(
+  const toggleIsEnabled = useCallback(
     () => dispatch(queryBrowserToggleIsEnabled(index)),
     [dispatch, index],
   );
 
-  const handleTextChange = React.useCallback(
+  const handleTextChange = useCallback(
     (value: string) => {
       dispatch(queryBrowserPatchQuery(index, { text: value }));
     },
     [dispatch, index],
   );
 
-  const handleExecuteQueries = React.useCallback(() => {
+  const handleExecuteQueries = useCallback(() => {
     dispatch(queryBrowserRunQueries());
   }, [dispatch]);
 
@@ -1024,7 +1020,7 @@ const Query: React.FC<{
   );
 };
 
-const QueryBrowserWrapper: React.FC<{
+const QueryBrowserWrapper: FC<{
   customDataSourceName: string;
   customDataSource: CustomDataSource;
   customDatasourceError: boolean;
@@ -1045,7 +1041,7 @@ const QueryBrowserWrapper: React.FC<{
   const queries = queriesList.toJS();
 
   // Initialize queries from URL parameters
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(queryBrowserDeleteAllQueries());
     const searchParams = getAllQueryArguments();
     for (let i = 0; _.has(searchParams, `query${i}`); i++) {
@@ -1065,18 +1061,15 @@ const QueryBrowserWrapper: React.FC<{
   // Use React.useMemo() to prevent these two arrays being recreated on every render, which would
   // trigger unnecessary re-renders of QueryBrowser, which can be quite slow
   const queriesMemoKey = JSON.stringify(_.map(queries, 'query'));
-  const queryStrings = React.useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
+  const queryStrings = useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
   const disabledSeriesMemoKey = JSON.stringify(
     _.reject(_.map(queries, 'disabledSeries'), _.isEmpty),
   );
-  const disabledSeries = React.useMemo(
-    () => _.map(queries, 'disabledSeries'),
-    [disabledSeriesMemoKey],
-  );
+  const disabledSeries = useMemo(() => _.map(queries, 'disabledSeries'), [disabledSeriesMemoKey]);
   /* eslint-enable react-hooks/exhaustive-deps */
 
   // Update the URL parameters when the queries shown in the graph change
-  React.useEffect(() => {
+  useEffect(() => {
     const newParams: Record<string, string> = {};
     _.each(queryStrings, (q, i) => (newParams[`query${i}`] = q || ''));
     if (customDataSourceName) {
@@ -1148,11 +1141,11 @@ const QueryBrowserWrapper: React.FC<{
   );
 };
 
-const AddQueryButton: React.FC = () => {
+const AddQueryButton: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const dispatch = useDispatch();
-  const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
+  const addQuery = useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
 
   return (
     <Button onClick={addQuery} type="button" variant="secondary">
@@ -1161,11 +1154,11 @@ const AddQueryButton: React.FC = () => {
   );
 };
 
-const RunQueriesButton: React.FC = () => {
+const RunQueriesButton: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const dispatch = useDispatch();
-  const runQueries = React.useCallback(() => dispatch(queryBrowserRunQueries()), [dispatch]);
+  const runQueries = useCallback(() => dispatch(queryBrowserRunQueries()), [dispatch]);
 
   return (
     <Button onClick={runQueries} type="submit" variant="primary">
@@ -1174,7 +1167,7 @@ const RunQueriesButton: React.FC = () => {
   );
 };
 
-const QueriesList: React.FC<{ customDatasource?: CustomDataSource; units: GraphUnits }> = ({
+const QueriesList: FC<{ customDatasource?: CustomDataSource; units: GraphUnits }> = ({
   customDatasource,
   units,
 }) => {
@@ -1204,7 +1197,7 @@ const QueriesList: React.FC<{ customDatasource?: CustomDataSource; units: GraphU
 const IntervalDropdown = () => {
   const { perspective } = usePerspective();
   const dispatch = useDispatch();
-  const setInterval = React.useCallback(
+  const setInterval = useCallback(
     (v: number) => dispatch(queryBrowserSetPollInterval(v)),
     [dispatch],
   );
@@ -1214,11 +1207,11 @@ const IntervalDropdown = () => {
   return <DropDownPollInterval setInterval={setInterval} selectedInterval={pollInterval} />;
 };
 
-const GraphUnitsDropDown: React.FC = () => {
+const GraphUnitsDropDown: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const [selectedUnits, setUnits] = useQueryParam(QueryParams.Units, StringParam);
 
-  const initialOptions = React.useMemo<SimpleSelectOption[]>(() => {
+  const initialOptions = useMemo<SimpleSelectOption[]>(() => {
     const intervalOptions: SimpleSelectOption[] = [
       { content: t('Bytes Binary (KiB, MiB)'), value: 'bytes' },
       { content: t('Bytes Decimal (kb, MB)'), value: 'Bytes' },
@@ -1246,35 +1239,34 @@ const GraphUnitsDropDown: React.FC = () => {
   );
 };
 
-const MetricsPage_: React.FC = () => {
+const MetricsPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const [units, setUnits] = useQueryParam(QueryParams.Units, StringParam);
 
   const dispatch = useDispatch();
   const { perspective } = usePerspective();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isGraphUnit(units)) {
       setUnits('short');
     }
   }, [units, setUnits]);
 
   // Clear queries on unmount
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       dispatch(queryBrowserDeleteAllQueries());
     };
   }, [dispatch]);
-  const [customDataSource, setCustomDataSource] = React.useState<CustomDataSource>(undefined);
-  const [customDataSourceIsResolved, setCustomDataSourceIsResolved] =
-    React.useState<boolean>(false);
+  const [customDataSource, setCustomDataSource] = useState<CustomDataSource>(undefined);
+  const [customDataSourceIsResolved, setCustomDataSourceIsResolved] = useState<boolean>(false);
   const customDataSourceName = getQueryArgument(QueryParams.Datasource);
   const [extensions, extensionsResolved] = useResolvedExtensions<DataSource>(isDataSource);
   const hasExtensions = !_.isEmpty(extensions);
-  const [customDatasourceError, setCustomDataSourceError] = React.useState(false);
+  const [customDatasourceError, setCustomDataSourceError] = useState(false);
 
   // get custom datasources
-  React.useEffect(() => {
+  useEffect(() => {
     const getCustomDataSource = async () => {
       if (!customDataSourceName) {
         setCustomDataSource(null);
@@ -1391,7 +1383,7 @@ const MetricsPage_: React.FC = () => {
 
 const MetricsPage = withFallback(MetricsPage_);
 
-const MetricsPageWrapper_: React.FC = () => (
+const MetricsPageWrapper_: FC = () => (
   <QueryParamProvider adapter={ReactRouter5Adapter}>
     <MetricsPage />
   </QueryParamProvider>

--- a/web/src/components/TypeaheadSelect.tsx
+++ b/web/src/components/TypeaheadSelect.tsx
@@ -11,7 +11,7 @@ import {
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
-import React from 'react';
+import * as React from 'react';
 
 const NO_RESULTS = 'no results';
 

--- a/web/src/components/alerting/AlertDetail/SilencedByTable.tsx
+++ b/web/src/components/alerting/AlertDetail/SilencedByTable.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC, MouseEvent } from 'react';
+import { useState, useMemo } from 'react';
 import {
   ResourceIcon,
   Silence,
@@ -26,15 +27,15 @@ import { Link } from 'react-router-dom-v5-compat';
 import { SeverityCounts, StateTimestamp } from '../AlertUtils';
 import { t_global_spacer_xs } from '@patternfly/react-tokens';
 
-export const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) => {
+export const SilencedByList: FC<{ silences: Silence[] }> = ({ silences }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const [namespace] = useActiveNamespace();
   const navigate = useNavigate();
   const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
-  const [silence, setSilence] = React.useState<Silence | null>(null);
+  const [silence, setSilence] = useState<Silence | null>(null);
 
-  const editSilence = (event: React.MouseEvent, rowIndex: number) => {
+  const editSilence = (event: MouseEvent, rowIndex: number) => {
     navigate(getEditSilenceAlertUrl(perspective, silences.at(rowIndex)?.id, namespace));
   };
 
@@ -54,7 +55,7 @@ export const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) 
       },
       {
         title: t('Expire silence'),
-        onClick: (event: React.MouseEvent, rowIndex: number) => {
+        onClick: (event: MouseEvent, rowIndex: number) => {
           setSilence(silences.at(rowIndex));
           setModalOpen();
         },
@@ -124,7 +125,7 @@ export const SilencedByList: React.FC<{ silences: Silence[] }> = ({ silences }) 
     },
   ]);
 
-  const columns = React.useMemo<Array<DataViewTh>>(
+  const columns = useMemo<Array<DataViewTh>>(
     () => [
       {
         id: 'name',

--- a/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
+++ b/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
@@ -5,7 +5,8 @@ import {
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import React, { useMemo } from 'react';
+import type { FC } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRuleUrl, usePerspective } from '../../../components/hooks/usePerspective';
 import { AggregatedAlert } from '../AlertsAggregates';
@@ -17,7 +18,7 @@ import { SelectedFilters } from '../useSelectedFilters';
 import { filterAlerts } from './hooks/utils';
 import { Badge, Flex, FlexItem } from '@patternfly/react-core';
 
-type AggregateAlertTableRowProps = React.FC<{
+type AggregateAlertTableRowProps = FC<{
   aggregatedAlert: AggregatedAlert;
   rowData: { rowIndex: number; selectedFilters: SelectedFilters };
 }>;
@@ -26,7 +27,7 @@ const AggregateAlertTableRow: AggregateAlertTableRowProps = ({
   aggregatedAlert,
   rowData: { rowIndex, selectedFilters },
 }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const title = aggregatedAlert.name;

--- a/web/src/components/alerting/AlertList/AlertTableRow.tsx
+++ b/web/src/components/alerting/AlertList/AlertTableRow.tsx
@@ -19,7 +19,7 @@ import { AlertSource } from '../../../components/types';
 import { Td, Tr } from '@patternfly/react-table';
 import { DropdownItem, Flex, FlexItem } from '@patternfly/react-core';
 import KebabDropdown from '../../../components/kebab-dropdown';
-import React from 'react';
+import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { AlertResource, alertState } from '../../../components/utils';
@@ -30,7 +30,7 @@ import {
 } from '../../../components/hooks/usePerspective';
 import { Link } from 'react-router-dom-v5-compat';
 
-const AlertTableRow: React.FC<{ alert: Alert }> = ({ alert }) => {
+const AlertTableRow: FC<{ alert: Alert }> = ({ alert }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const navigate = useNavigate();

--- a/web/src/components/alerting/AlertList/DownloadCSVButton.tsx
+++ b/web/src/components/alerting/AlertList/DownloadCSVButton.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePerspective } from '../../hooks/usePerspective';
 import { AggregatedAlert } from '../AlertsAggregates';

--- a/web/src/components/alerting/AlertList/hooks/useAggregateAlertColumns.ts
+++ b/web/src/components/alerting/AlertList/hooks/useAggregateAlertColumns.ts
@@ -1,7 +1,7 @@
 import { AlertSeverity, TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { AggregatedAlert } from '../../AlertsAggregates';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { useMemo } from 'react';
 import { sortable } from '@patternfly/react-table';
 import { ListOrder } from '../../../../components/utils';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +19,7 @@ export const alertSeverityOrder = (aggregatedAlert: AggregatedAlert): ListOrder 
 const useAggregateAlertColumns = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
-  const columns = React.useMemo<TableColumn<AggregatedAlert>[]>(() => {
+  const columns = useMemo<TableColumn<AggregatedAlert>[]>(() => {
     const cols: TableColumn<AggregatedAlert>[] = [
       {
         title: '',

--- a/web/src/components/alerting/AlertRulesDetailsPage.tsx
+++ b/web/src/components/alerting/AlertRulesDetailsPage.tsx
@@ -37,7 +37,7 @@ import {
 } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -88,7 +88,7 @@ type ActiveAlertsProps = {
   ruleID: string;
 };
 
-export const ActiveAlerts: React.FC<ActiveAlertsProps> = ({ alerts, namespace, ruleID }) => {
+export const ActiveAlerts: FC<ActiveAlertsProps> = ({ alerts, namespace, ruleID }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const navigate = useNavigate();
@@ -139,7 +139,7 @@ export const ActiveAlerts: React.FC<ActiveAlertsProps> = ({ alerts, namespace, r
     </Table>
   );
 };
-const AlertRulesDetailsPage_: React.FC = () => {
+const AlertRulesDetailsPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const params = useParams<{ ns?: string; id: string }>();
 

--- a/web/src/components/alerting/AlertRulesPage.tsx
+++ b/web/src/components/alerting/AlertRulesPage.tsx
@@ -13,7 +13,8 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable, Td } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -43,7 +44,7 @@ import { useAlertsPoller } from '../hooks/useAlertsPoller';
 import { getLegacyObserveState, getRuleUrl, usePerspective } from '../hooks/usePerspective';
 import { severityRowFilter } from './AlertUtils';
 
-const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
+const StateCounts: FC<{ alerts: PrometheusAlert[] }> = ({ alerts }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const counts = _.countBy(alerts, 'state');
@@ -83,7 +84,7 @@ const alertStateFilter = (t): RowFilter => ({
   type: 'alerting-rule-has-alert-state',
 });
 
-const RuleTableRow: React.FC<RowProps<Rule>> = ({ obj }) => {
+const RuleTableRow: FC<RowProps<Rule>> = ({ obj }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
@@ -116,7 +117,7 @@ const RuleTableRow: React.FC<RowProps<Rule>> = ({ obj }) => {
   );
 };
 
-const AlertRulesPage_: React.FC = () => {
+const AlertRulesPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { alertsKey, silencesKey, rulesKey, perspective, defaultAlertTenant } = usePerspective();
   const [namespace] = useActiveNamespace();
@@ -134,12 +135,12 @@ const AlertRulesPage_: React.FC = () => {
       getLegacyObserveState(perspective, state)?.get(silencesKey)?.loadError,
   );
 
-  const ruleAdditionalSources = React.useMemo(
+  const ruleAdditionalSources = useMemo(
     () => getAdditionalSources(data, alertingRuleSource),
     [data],
   );
 
-  const namespacedData = React.useMemo(() => {
+  const namespacedData = useMemo(() => {
     if (perspective === 'dev') {
       return data?.filter((rule) => rule.labels?.namespace === namespace);
     }
@@ -175,7 +176,7 @@ const AlertRulesPage_: React.FC = () => {
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(namespacedData, rowFilters);
 
-  const columns = React.useMemo<TableColumn<Rule>[]>(
+  const columns = useMemo<TableColumn<Rule>[]>(
     () => [
       {
         id: 'name',

--- a/web/src/components/alerting/AlertUtils.tsx
+++ b/web/src/components/alerting/AlertUtils.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
+import { memo } from 'react';
 import {
   Action,
   Alert,
@@ -78,9 +79,7 @@ export const alertingRuleSource = (rule: Rule): AlertSource | string => {
 export const alertSource = (alert: Alert): AlertSource | string => alertingRuleSource(alert.rule);
 export const alertCluster = (alert: Alert): string => alert.labels?.cluster ?? '';
 
-export const SilencesNotLoadedWarning: React.FC<{ silencesLoadError: any }> = ({
-  silencesLoadError,
-}) => {
+export const SilencesNotLoadedWarning: FC<{ silencesLoadError: any }> = ({ silencesLoadError }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (
@@ -118,7 +117,7 @@ const getSeverityKey = (severity: string, t) => {
   }
 };
 
-export const SeverityIcon: React.FC<{ severity: string }> = React.memo(({ severity }) => {
+export const SeverityIcon: FC<{ severity: string }> = memo(({ severity }) => {
   switch (severity) {
     case AlertSeverity.Critical:
       return <ExclamationCircleIcon color={t_global_color_status_danger_default.var} />;
@@ -133,7 +132,7 @@ export const SeverityIcon: React.FC<{ severity: string }> = React.memo(({ severi
   }
 });
 
-export const AlertState: React.FC<AlertStateProps> = React.memo(({ state }) => {
+export const AlertState: FC<AlertStateProps> = memo(({ state }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const icon = <AlertStateIcon state={state} />;
@@ -153,7 +152,7 @@ type AlertStateProps = {
   state: AlertStates;
 };
 
-export const AlertStateIcon: React.FC<{ state: string }> = React.memo(({ state }) => {
+export const AlertStateIcon: FC<{ state: string }> = memo(({ state }) => {
   switch (state) {
     case AlertStates.Firing:
       return <BellIcon />;
@@ -179,7 +178,7 @@ export const getAlertStateKey = (state, t) => {
   }
 };
 
-export const AlertStateDescription: React.FC<{ alert: Alert }> = ({ alert }) => {
+export const AlertStateDescription: FC<{ alert: Alert }> = ({ alert }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   if (alert && !_.isEmpty(alert.silencedBy)) {
@@ -198,7 +197,7 @@ export const StateTimestamp = ({ text, timestamp }) => (
   </div>
 );
 
-export const SeverityBadge: React.FC<{ severity: string; count?: number }> = React.memo(
+export const SeverityBadge: FC<{ severity: string; count?: number }> = memo(
   ({ severity, count }) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
@@ -226,7 +225,7 @@ export const SeverityBadge: React.FC<{ severity: string; count?: number }> = Rea
   },
 );
 
-export const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: string }> = ({
+export const PopoverField: FC<{ bodyContent: ReactNode; label: string }> = ({
   bodyContent,
   label,
 }) => (
@@ -235,7 +234,7 @@ export const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: strin
   </Popover>
 );
 
-export const Graph: React.FC<GraphProps> = ({
+export const Graph: FC<GraphProps> = ({
   filterLabels = undefined,
   formatSeriesTitle,
   namespace,
@@ -276,7 +275,7 @@ type GraphProps = {
   showLegend?: boolean;
 };
 
-export const SeverityHelp: React.FC = () => {
+export const SeverityHelp: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (
@@ -329,7 +328,7 @@ export const SeverityHelp: React.FC = () => {
   );
 };
 
-export const SourceHelp: React.FC = () => {
+export const SourceHelp: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (
@@ -369,7 +368,7 @@ export const getSourceKey = (source, t: TFunction) => {
   }
 };
 
-export const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
+export const SeverityCounts: FC<{ alerts: Alert[] }> = ({ alerts }) => {
   if (_.isEmpty(alerts)) {
     return <>-</>;
   }

--- a/web/src/components/alerting/AlertingPage.tsx
+++ b/web/src/components/alerting/AlertingPage.tsx
@@ -1,19 +1,20 @@
 import { PageSection, Title } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC } from 'react';
+import { lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HorizontalNav, useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 
-const AlertsPage = React.lazy(
+const AlertsPage = lazy(
   () => import(/* webpackChunkName: "AlertsPage" */ '../alerting/AlertsPage'),
 );
-const SilencesPage = React.lazy(
+const SilencesPage = lazy(
   () => import(/* webpackChunkName: "SilencesPage" */ '../alerting/SilencesPage'),
 );
-const AlertRulesPage = React.lazy(
+const AlertRulesPage = lazy(
   () => import(/* webpackChunkName: "AlertRulesPage" */ '../alerting/AlertRulesPage'),
 );
 
-const AlertingPage: React.FC = () => {
+const AlertingPage: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const [perspective] = useActivePerspective();

--- a/web/src/components/alerting/AlertsDetailsPage.tsx
+++ b/web/src/components/alerting/AlertsDetailsPage.tsx
@@ -12,7 +12,8 @@ import {
   useResolvedExtensions,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, useNavigate, useParams } from 'react-router-dom-v5-compat';
@@ -88,7 +89,7 @@ import {
   SourceHelp,
 } from './AlertUtils';
 
-const AlertsDetailsPage_: React.FC = () => {
+const AlertsDetailsPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const params = useParams<{ ruleID: string }>();
   const navigate = useNavigate();
@@ -124,7 +125,7 @@ const AlertsDetailsPage_: React.FC = () => {
 
   const labelsMemoKey = JSON.stringify(alert?.labels);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
+  const labels: PrometheusLabels = useMemo(() => alert?.labels, [labelsMemoKey]);
 
   // eslint-disable-next-line camelcase
   const runbookURL = alert?.annotations?.runbook_url;
@@ -396,7 +397,7 @@ const AlertsDetailsPage_: React.FC = () => {
 };
 const AlertsDetailsPage = withFallback(AlertsDetailsPage_);
 
-const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rule }) => {
+const HeaderAlertMessage: FC<{ alert: Alert; rule: Rule }> = ({ alert, rule }) => {
   const annotation = alert.annotations.description ? 'description' : 'message';
   return (
     <AlertMessage
@@ -407,12 +408,12 @@ const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rul
   );
 };
 
-const AlertMessage: React.FC<AlertMessageProps> = ({ alertText, labels, template }) => {
+const AlertMessage: FC<AlertMessageProps> = ({ alertText, labels, template }) => {
   if (_.isEmpty(alertText)) {
     return null;
   }
 
-  let messageParts: React.ReactNode[] = [alertText];
+  let messageParts: ReactNode[] = [alertText];
 
   // Go through each recognized resource type and replace any resource names that exist in alertText
   // with a link to the resource's details page
@@ -474,7 +475,7 @@ const alertMessageResources: {
 const matchCount = (haystack: string, regExpString: string) =>
   _.size(haystack.match(new RegExp(regExpString, 'g')));
 
-const AlertStateHelp: React.FC = () => {
+const AlertStateHelp: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/alerting/AlertsPage.tsx
+++ b/web/src/components/alerting/AlertsPage.tsx
@@ -8,7 +8,8 @@ import {
 import { Flex, PageSection } from '@patternfly/react-core';
 import { Table, TableGridBreakpoint, Th, Thead, Tr } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -34,7 +35,7 @@ import {
 import Error from './Error';
 import useSelectedFilters from './useSelectedFilters';
 
-const AlertsPage_: React.FC = () => {
+const AlertsPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { alertsKey, silencesKey, defaultAlertTenant, perspective } = usePerspective();
 
@@ -52,12 +53,9 @@ const AlertsPage_: React.FC = () => {
       getLegacyObserveState(perspective, state)?.get(silencesKey)?.loadError,
   );
 
-  const alertAdditionalSources = React.useMemo(
-    () => getAdditionalSources(data, alertSource),
-    [data],
-  );
+  const alertAdditionalSources = useMemo(() => getAdditionalSources(data, alertSource), [data]);
 
-  const clusters = React.useMemo(() => {
+  const clusters = useMemo(() => {
     const clusterSet = new Set<string>();
     data?.forEach((alert) => {
       const clusterName = alert.labels?.cluster;

--- a/web/src/components/alerting/Error.tsx
+++ b/web/src/components/alerting/Error.tsx
@@ -6,7 +6,7 @@ import {
   PanelMainBody,
   Title,
 } from '@patternfly/react-core';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type ErrorProps = {

--- a/web/src/components/alerting/SilenceCreatePage.tsx
+++ b/web/src/components/alerting/SilenceCreatePage.tsx
@@ -1,5 +1,4 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { getAllQueryArguments } from '../console/utils/router';
 import { SilenceForm } from './SilenceForm';

--- a/web/src/components/alerting/SilenceEditPage.tsx
+++ b/web/src/components/alerting/SilenceEditPage.tsx
@@ -1,7 +1,6 @@
 import { Silence, SilenceStates } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert } from '@patternfly/react-core';
 import * as _ from 'lodash-es';
-import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom-v5-compat';

--- a/web/src/components/alerting/SilenceForm.tsx
+++ b/web/src/components/alerting/SilenceForm.tsx
@@ -32,7 +32,8 @@ import {
 import { ExclamationCircleIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { t_global_spacer_sm } from '@patternfly/react-tokens';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { ComponentType, FC, FormEventHandler, MouseEvent, ChangeEvent, Ref } from 'react';
+import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -60,7 +61,7 @@ type Matcher = {
 
 type SilenceFormProps = {
   defaults: any;
-  Info?: React.ComponentType;
+  Info?: ComponentType;
   title: string;
 };
 
@@ -124,7 +125,7 @@ const NegativeMatcherHelp = () => {
   );
 };
 
-const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => {
+const SilenceForm_: FC<SilenceFormProps> = ({ defaults, Info, title }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const navigate = useNavigate();
 
@@ -166,23 +167,23 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
 
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
-  const [comment, setComment] = React.useState(defaults.comment ?? '');
-  const [createdBy, setCreatedBy] = React.useState(defaults.createdBy ?? '');
-  const [duration, setDuration] = React.useState(defaultDuration);
-  const [endsAt, setEndsAt] = React.useState(
+  const [comment, setComment] = useState(defaults.comment ?? '');
+  const [createdBy, setCreatedBy] = useState(defaults.createdBy ?? '');
+  const [duration, setDuration] = useState(defaultDuration);
+  const [endsAt, setEndsAt] = useState(
     defaults.endsAt ?? formatDate(new Date(new Date(now).setHours(now.getHours() + 2))),
   );
-  const [error, setError] = React.useState<string>();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [isStartNow, setIsStartNow] = React.useState(defaultIsStartNow);
-  const [matchers, setMatchers] = React.useState<Array<Matcher>>(
+  const [error, setError] = useState<string>();
+  const [inProgress, setInProgress] = useState(false);
+  const [isStartNow, setIsStartNow] = useState(defaultIsStartNow);
+  const [matchers, setMatchers] = useState<Array<Matcher>>(
     defaults.matchers ?? [{ isRegex: false, isEqual: true, name: '', value: '' }],
   );
-  const [startsAt, setStartsAt] = React.useState(defaults.startsAt ?? formatDate(now));
+  const [startsAt, setStartsAt] = useState(defaults.startsAt ?? formatDate(now));
   const user = useSelector(getUser);
   const [namespace] = useActiveNamespace();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!createdBy && user) {
       setCreatedBy(user.metadata?.name || user.username);
     }
@@ -218,7 +219,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
     );
   };
 
-  const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
     // Don't allow comments to only contain whitespace
@@ -289,7 +290,6 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
         </HelperText>
       </PageSection>
       <Divider />
-
       <PageSection hasBodyWrapper={false}>
         <Form onSubmit={onSubmit} maxWidth="950px">
           {Info && <Info />}
@@ -320,11 +320,11 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
                 <Select
                   data-test="silence-for"
                   isOpen={isOpen}
-                  onSelect={(event: React.MouseEvent | React.ChangeEvent, value: string) => {
+                  onSelect={(event: MouseEvent | ChangeEvent, value: string) => {
                     setDuration(value);
                     setClosed();
                   }}
-                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  toggle={(toggleRef: Ref<MenuToggleElement>) => (
                     <MenuToggle
                       ref={toggleRef}
                       onClick={setIsOpen}

--- a/web/src/components/alerting/SilencesDetailsPage.tsx
+++ b/web/src/components/alerting/SilencesDetailsPage.tsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
@@ -50,7 +50,7 @@ import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react
 import { useNavigate, useParams, Link } from 'react-router-dom-v5-compat';
 import { useAlertsPoller } from '../hooks/useAlertsPoller';
 
-const SilencesDetailsPage_: React.FC = () => {
+const SilencesDetailsPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const params = useParams<{ id: string }>();
 
@@ -203,7 +203,7 @@ const SilencesDetailsPage_: React.FC = () => {
 };
 const SilencesDetailsPage = withFallback(SilencesDetailsPage_);
 
-const SilencedAlertsList: React.FC<SilencedAlertsListProps> = ({ alerts }) => {
+const SilencedAlertsList: FC<SilencedAlertsListProps> = ({ alerts }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const navigate = useNavigate();
   const { perspective } = usePerspective();

--- a/web/src/components/alerting/SilencesPage.tsx
+++ b/web/src/components/alerting/SilencesPage.tsx
@@ -21,7 +21,8 @@ import {
 } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useState, useMemo, useContext, useCallback, memo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -41,13 +42,13 @@ import { Silences } from '../types';
 import { fuzzyCaseInsensitive, refreshSilences, silenceCluster, silenceState } from '../utils';
 import { SelectedSilencesContext, SilenceTableRow } from './SilencesUtils';
 
-const SilencesPage_: React.FC = () => {
+const SilencesPage_: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const { silencesKey, perspective } = usePerspective();
 
-  const [selectedSilences, setSelectedSilences] = React.useState(new Set());
-  const [errorMessage, setErrorMessage] = React.useState();
+  const [selectedSilences, setSelectedSilences] = useState(new Set());
+  const [errorMessage, setErrorMessage] = useState();
 
   useAlertsPoller();
 
@@ -59,7 +60,7 @@ const SilencesPage_: React.FC = () => {
     (state: MonitoringState) => getLegacyObserveState(perspective, state)?.get(silencesKey) || {},
   );
 
-  const clusters = React.useMemo(() => {
+  const clusters = useMemo(() => {
     const clusterSet = new Set<string>();
     data?.forEach((silence) => {
       const clusterName = silenceCluster(silence);
@@ -124,7 +125,7 @@ const SilencesPage_: React.FC = () => {
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(data, rowFilters);
 
-  const columns = React.useMemo<Array<TableColumn<Silence>>>(() => {
+  const columns = useMemo<Array<TableColumn<Silence>>>(() => {
     const cols: Array<TableColumn<Silence>> = [
       {
         id: 'checkbox',
@@ -242,14 +243,14 @@ const SilencesPage_: React.FC = () => {
 };
 const SilencesPage = withFallback(SilencesPage_);
 
-const SelectAllCheckbox: React.FC<{ silences: Silence[] }> = ({ silences }) => {
-  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
+const SelectAllCheckbox: FC<{ silences: Silence[] }> = ({ silences }) => {
+  const { selectedSilences, setSelectedSilences } = useContext(SelectedSilencesContext);
 
   const activeSilences = _.filter(silences, (s) => silenceState(s) !== SilenceStates.Expired);
   const isAllSelected =
     activeSilences.length > 0 && _.every(activeSilences, (s) => selectedSilences.has(s.id));
 
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (isChecked: boolean) => {
       const ids = isChecked ? activeSilences.map((s) => s.id) : [];
       setSelectedSilences(new Set(ids));
@@ -290,7 +291,7 @@ const silenceClusterOrder = (clusters: Array<string>) => {
   ];
 };
 
-const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setErrorMessage }) => {
+const ExpireAllSilencesButton: FC<ExpireAllSilencesButtonProps> = ({ setErrorMessage }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const { perspective, silencesKey } = usePerspective();
@@ -299,7 +300,7 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
 
   const dispatch = useDispatch();
 
-  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
+  const { selectedSilences, setSelectedSilences } = useContext(SelectedSilencesContext);
 
   const [namespace] = useActiveNamespace();
 
@@ -337,11 +338,11 @@ const ExpireAllSilencesButton: React.FC<ExpireAllSilencesButtonProps> = ({ setEr
   );
 };
 
-const SilenceTableRowWithCheckbox: React.FC<RowProps<Silence>> = ({ obj }) => (
+const SilenceTableRowWithCheckbox: FC<RowProps<Silence>> = ({ obj }) => (
   <SilenceTableRow showCheckbox={true} obj={obj} />
 );
 
-const CreateSilenceButton: React.FC = React.memo(() => {
+const CreateSilenceButton: FC = memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const [namespace] = useActiveNamespace();

--- a/web/src/components/alerting/SilencesUtils.tsx
+++ b/web/src/components/alerting/SilencesUtils.tsx
@@ -39,7 +39,8 @@ import {
 import { Td } from '@patternfly/react-table';
 import { t_global_spacer_xs } from '@patternfly/react-tokens';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, Ref } from 'react';
+import { useContext, useCallback, createContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
@@ -58,7 +59,7 @@ import {
 } from '../utils';
 import { SeverityCounts, StateTimestamp } from './AlertUtils';
 
-export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
+export const SilenceTableRow: FC<SilenceTableRowProps> = ({ obj, showCheckbox }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const [namespace] = useActiveNamespace();
@@ -67,9 +68,9 @@ export const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, showCheck
   const state = silenceState(obj);
   const cluster = matchers.find((label) => label.name === 'cluster')?.value;
 
-  const { selectedSilences, setSelectedSilences } = React.useContext(SelectedSilencesContext);
+  const { selectedSilences, setSelectedSilences } = useContext(SelectedSilencesContext);
 
-  const onCheckboxChange = React.useCallback(
+  const onCheckboxChange = useCallback(
     (isChecked: boolean) => {
       setSelectedSilences((oldSet) => {
         const newSet = new Set(oldSet);
@@ -154,7 +155,7 @@ type SilenceTableRowProps = {
   showCheckbox?: boolean;
 };
 
-export const SelectedSilencesContext = React.createContext({
+export const SelectedSilencesContext = createContext({
   selectedSilences: new Set(),
   setSelectedSilences: undefined,
 });
@@ -205,7 +206,7 @@ export const SilenceState = ({ silence }) => {
   ) : null;
 };
 
-export const SilenceDropdown: React.FC<SilenceDropdownProps> = ({ silence, toggleText }) => {
+export const SilenceDropdown: FC<SilenceDropdownProps> = ({ silence, toggleText }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
   const [namespace] = useActiveNamespace();
@@ -242,7 +243,7 @@ export const SilenceDropdown: React.FC<SilenceDropdownProps> = ({ silence, toggl
         data-test="silence-actions"
         popperProps={{ position: 'right' }}
         onOpenChange={(isOpen: boolean) => (isOpen ? setIsOpen() : setClosed())}
-        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        toggle={(toggleRef: Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
             aria-label="kebab dropdown toggle"
@@ -261,7 +262,7 @@ export const SilenceDropdown: React.FC<SilenceDropdownProps> = ({ silence, toggl
   );
 };
 
-export const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
+export const ExpireSilenceModal: FC<ExpireSilenceModalProps> = ({
   isOpen,
   setClosed,
   silenceID,
@@ -274,7 +275,7 @@ export const ExpireSilenceModal: React.FC<ExpireSilenceModalProps> = ({
 
   const [isInProgress, , setInProgress, setNotInProgress] = useBoolean(false);
   const [success, , setSuccess] = useBoolean(false);
-  const [errorMessage, setErrorMessage] = React.useState();
+  const [errorMessage, setErrorMessage] = useState();
 
   const expireSilence = () => {
     setInProgress();

--- a/web/src/components/console/console-shared/error/error-boundary.tsx
+++ b/web/src/components/console/console-shared/error/error-boundary.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import type { ComponentType, FC } from 'react';
+import { Component } from 'react';
 import { history } from '../../utils/router';
 
 type ErrorBoundaryProps = {
-  FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackProps>;
+  FallbackComponent?: ComponentType<ErrorBoundaryFallbackProps>;
 };
 
 /** Needed for tests -- should not be imported by application logic */
@@ -12,9 +13,9 @@ export type ErrorBoundaryState = {
   errorInfo: { componentStack: string };
 };
 
-const DefaultFallback: React.FC = () => <div />;
+const DefaultFallback: FC = () => <div />;
 
-class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   // eslint-disable-next-line
   unlisten: () => void = () => {};
 

--- a/web/src/components/console/console-shared/error/fallbacks/withFallback.tsx
+++ b/web/src/components/console/console-shared/error/fallbacks/withFallback.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import type { ComponentType } from 'react';
 import ErrorBoundary from '../error-boundary';
 
 type WithFallback = <P = object>(
-  Component: React.ComponentType<P>,
-  FallbackComponent?: React.ComponentType<any>,
-) => React.ComponentType<P>;
+  Component: ComponentType<P>,
+  FallbackComponent?: ComponentType<any>,
+) => ComponentType<P>;
 
 const withFallback: WithFallback = (WrappedComponent, FallbackComponent) => {
   const Component = (props) => (

--- a/web/src/components/console/console-shared/src/components/empty-state/AccessDenied.tsx
+++ b/web/src/components/console/console-shared/src/components/empty-state/AccessDenied.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Alert, Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ConsoleEmptyState } from './ConsoleEmptyState';
@@ -10,7 +10,7 @@ const RestrictedSignIcon = () => {
   return <img src={restrictedSignImg} alt={t('Restricted access')} />;
 };
 
-export const AccessDenied: React.FC = ({ children }) => {
+export const AccessDenied: FC = ({ children }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/console/console-shared/src/components/empty-state/ConsoleEmptyState.tsx
+++ b/web/src/components/console/console-shared/src/components/empty-state/ConsoleEmptyState.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC, ComponentType, ReactElement } from 'react';
 import {
   EmptyStateActions,
   EmptyStateBody,
@@ -8,7 +8,7 @@ import {
   EmptyStateProps,
 } from '@patternfly/react-core';
 
-export const ConsoleEmptyState: React.FC<ConsoleEmptyStateProps> = ({
+export const ConsoleEmptyState: FC<ConsoleEmptyStateProps> = ({
   children,
   Icon,
   primaryActions,
@@ -47,9 +47,9 @@ ConsoleEmptyState.displayName = 'ConsoleEmptyState';
 type ConsoleEmptyStateProps = Partial<EmptyStateProps> & {
   className?: string;
   'data-test'?: string;
-  Icon?: React.ComponentType;
-  primaryActions?: React.ReactElement[];
-  secondaryActions?: React.ReactElement[];
-  title?: string | React.ReactElement;
+  Icon?: ComponentType;
+  primaryActions?: ReactElement[];
+  secondaryActions?: ReactElement[];
+  title?: string | ReactElement;
   variant?: EmptyStateVariant;
 };

--- a/web/src/components/console/console-shared/src/components/empty-state/EmptyBox.tsx
+++ b/web/src/components/console/console-shared/src/components/empty-state/EmptyBox.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import type { FCC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConsoleEmptyState } from './ConsoleEmptyState';
 
-export const EmptyBox: React.FCC<EmptyBoxProps> = ({ label }) => {
+export const EmptyBox: FCC<EmptyBoxProps> = ({ label }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/console/console-shared/src/components/loading/LoadError.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/LoadError.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ConsoleEmptyState } from '../empty-state/ConsoleEmptyState';
 
-export const LoadError: React.FC<LoadErrorProps> = ({ label, children, canRetry = true }) => {
+export const LoadError: FC<LoadErrorProps> = ({ label, children, canRetry = true }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const actions = canRetry

--- a/web/src/components/console/console-shared/src/components/loading/Loading.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/Loading.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FCC } from 'react';
 
-export const Loading: React.FCC<LoadingProps> = ({ className }) => (
+export const Loading: FCC<LoadingProps> = ({ className }) => (
   <div className={className} data-test="loading-indicator">
     <Spinner size="lg" />
   </div>

--- a/web/src/components/console/console-shared/src/components/loading/LoadingBox.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/LoadingBox.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Loading } from './Loading';
 import { ConsoleEmptyState } from '../empty-state/ConsoleEmptyState';
 
-export const LoadingBox: React.FC = ({ children }) => (
+export const LoadingBox: FC = ({ children }) => (
   <ConsoleEmptyState data-test="loading-box" isFullHeight>
     <Loading />
     {children}

--- a/web/src/components/console/console-shared/src/components/loading/LoadingInline.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/LoadingInline.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import type { FCC } from 'react';
 import { Loading } from './Loading';
 
 // Leave to keep compatibility with console looks
-export const LoadingInline: React.FCC = () => <Loading className="co-m-loader--inline" />;
+export const LoadingInline: FCC = () => <Loading className="co-m-loader--inline" />;
 LoadingInline.displayName = 'LoadingInline';

--- a/web/src/components/console/console-shared/src/components/query-browser/QueryBrowserTooltip.tsx
+++ b/web/src/components/console/console-shared/src/components/query-browser/QueryBrowserTooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import * as _ from 'lodash-es';
 
 import { VictoryPortal } from 'victory';
@@ -36,7 +36,7 @@ export const valueFormatter = (units: string): ((v: number) => string) =>
     : formatValue;
 
 // For performance, use this instead of PatternFly's ChartTooltip or Victory VictoryTooltip
-const QueryBrowserTooltipWrapped: React.FC<TooltipProps> = ({
+const QueryBrowserTooltipWrapped: FC<TooltipProps> = ({
   activePoints,
   center,
   height,

--- a/web/src/components/console/console-shared/src/components/status/StatusBox.tsx
+++ b/web/src/components/console/console-shared/src/components/status/StatusBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC, ComponentType, ReactNode } from 'react';
 import { Alert, Flex, FlexItem, PageSection, Title } from '@patternfly/react-core';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +9,7 @@ import { LoadingBox } from '../loading/LoadingBox';
 import { LoadError } from '../loading/LoadError';
 import { getLastLanguage } from '../../../../utils/getLastLanguage';
 
-const Data: React.FC<DataProps> = ({
+const Data: FC<DataProps> = ({
   NoDataEmptyMsg,
   EmptyMsg,
   label,
@@ -36,7 +36,7 @@ const Data: React.FC<DataProps> = ({
 };
 Data.displayName = 'Data';
 
-export const StatusBox: React.FC<StatusBoxProps> = (props) => {
+export const StatusBox: FC<StatusBoxProps> = (props) => {
   const { loadError, loaded, skeleton, data, ...dataProps } = props;
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
@@ -89,12 +89,12 @@ export const StatusBox: React.FC<StatusBoxProps> = (props) => {
 StatusBox.displayName = 'StatusBox';
 
 type DataProps = {
-  NoDataEmptyMsg?: React.ComponentType;
-  EmptyMsg?: React.ComponentType;
+  NoDataEmptyMsg?: ComponentType;
+  EmptyMsg?: ComponentType;
   label?: string;
   unfilteredData?: any;
   data?: any;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 type StatusBoxProps = {
@@ -103,8 +103,8 @@ type StatusBoxProps = {
   loaded?: boolean;
   data?: any;
   unfilteredData?: any;
-  skeleton?: React.ReactNode;
-  NoDataEmptyMsg?: React.ComponentType;
-  EmptyMsg?: React.ComponentType;
-  children?: React.ReactNode;
+  skeleton?: ReactNode;
+  NoDataEmptyMsg?: ComponentType;
+  EmptyMsg?: ComponentType;
+  children?: ReactNode;
 };

--- a/web/src/components/console/graphs/bar.tsx
+++ b/web/src/components/console/graphs/bar.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC, ComponentType } from 'react';
+import { Fragment } from 'react';
 import {
   ChartBar,
   ChartLabel,
@@ -48,7 +49,7 @@ const barTheme = {
   },
 };
 
-const BarChart: React.FC<BarChartProps> = ({
+const BarChart: FC<BarChartProps> = ({
   barSpacing = 15,
   barWidth = DEFAULT_BAR_WIDTH,
   data = [],
@@ -82,7 +83,7 @@ const BarChart: React.FC<BarChartProps> = ({
       <PrometheusGraphLink query={noLink ? undefined : query}>
         {data.length ? (
           data.map((datum, index) => (
-            <React.Fragment key={index}>
+            <Fragment key={index}>
               <div className="graph-bar__label">
                 {LabelComponent ? (
                   <LabelComponent title={datum.x} metric={datum.metric} />
@@ -105,7 +106,7 @@ const BarChart: React.FC<BarChartProps> = ({
                   padding={padding}
                 />
               </div>
-            </React.Fragment>
+            </Fragment>
           ))
         ) : (
           <GraphEmpty loading={loading} />
@@ -115,7 +116,7 @@ const BarChart: React.FC<BarChartProps> = ({
   );
 };
 
-export const Bar: React.FC<BarProps> = ({
+export const Bar: FC<BarProps> = ({
   barSpacing,
   barWidth,
   delay = undefined,
@@ -162,7 +163,7 @@ type BarChartProps = {
   barSpacing?: number;
   barWidth?: number;
   data?: DataPoint[];
-  LabelComponent?: React.ComponentType<LabelComponentProps>;
+  LabelComponent?: ComponentType<LabelComponentProps>;
   loading?: boolean;
   noLink?: boolean;
   query?: string;
@@ -176,7 +177,7 @@ type BarProps = {
   barWidth?: number;
   delay?: number;
   humanize?: Humanize;
-  LabelComponent?: React.ComponentType<LabelComponentProps>;
+  LabelComponent?: ComponentType<LabelComponentProps>;
   metric?: string;
   namespace?: string;
   noLink?: boolean;

--- a/web/src/components/console/graphs/graph-empty.tsx
+++ b/web/src/components/console/graphs/graph-empty.tsx
@@ -1,8 +1,8 @@
 import { EmptyState, EmptyStateVariant, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const GraphEmpty: React.FC<GraphEmptyProps> = ({ minHeight = 180, loading = false }) => {
+export const GraphEmpty: FC<GraphEmptyProps> = ({ minHeight = 180, loading = false }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/console/graphs/promethues-graph.tsx
+++ b/web/src/components/console/graphs/promethues-graph.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, RefObject, Ref } from 'react';
+import { forwardRef } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 import { Title } from '@patternfly/react-core';
@@ -17,7 +18,7 @@ const mapStateToProps = (state: RootState) => ({
   namespace: getActiveNamespace(state),
 });
 
-const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
+const PrometheusGraphLink_: FC<PrometheusGraphLinkProps> = ({
   children,
   query,
   namespace,
@@ -45,8 +46,8 @@ const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
 };
 export const PrometheusGraphLink = connect(mapStateToProps)(PrometheusGraphLink_);
 
-export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(
-  ({ children, className, title }, ref: React.RefObject<HTMLDivElement>) => (
+export const PrometheusGraph: FC<PrometheusGraphProps> = forwardRef(
+  ({ children, className, title }, ref: RefObject<HTMLDivElement>) => (
     <div ref={ref} className={classNames('graph-wrapper graph-wrapper__horizontal-bar', className)}>
       {title && (
         <Title headingLevel="h5" className="graph-title">
@@ -67,6 +68,6 @@ type PrometheusGraphLinkProps = {
 
 type PrometheusGraphProps = {
   className?: string;
-  ref?: React.Ref<HTMLDivElement>;
+  ref?: Ref<HTMLDivElement>;
   title?: string;
 };

--- a/web/src/components/console/utils/button-bar.jsx
+++ b/web/src/components/console/utils/button-bar.jsx
@@ -1,17 +1,17 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { Children, cloneElement } from 'react';
 import * as PropTypes from 'prop-types';
 import { Alert, AlertGroup, Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { LoadingInline } from '../console-shared/src/components/loading/LoadingInline';
 
 const injectDisabled = (children, disabled) => {
-  return React.Children.map(children, (c) => {
+  return Children.map(children, (c) => {
     if (!_.isObject(c) || c.type !== 'button') {
       return c;
     }
 
-    return React.cloneElement(c, { disabled: c.props.disabled || disabled });
+    return cloneElement(c, { disabled: c.props.disabled || disabled });
   });
 };
 

--- a/web/src/components/console/utils/link.tsx
+++ b/web/src/components/console/utils/link.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
 import Linkify from 'react-linkify';
 import { Button, Icon } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-export const ExternalLink: React.FC<ExternalLinkProps> = ({
+export const ExternalLink: FC<ExternalLinkProps> = ({
   children,
   href,
   text,
@@ -33,14 +33,14 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({
 );
 
 // Open links in a new window and set noopener/noreferrer.
-export const LinkifyExternal: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+export const LinkifyExternal: FC<{ children: ReactNode }> = ({ children }) => (
   <Linkify properties={{ target: '_blank', rel: 'noopener noreferrer' }}>{children}</Linkify>
 );
 LinkifyExternal.displayName = 'LinkifyExternal';
 
 type ExternalLinkProps = {
   href: string;
-  text?: React.ReactNode;
+  text?: ReactNode;
   additionalClassName?: string;
   dataTestID?: string;
   stopPropagation?: boolean;

--- a/web/src/components/dashboards/legacy/bar-chart.tsx
+++ b/web/src/components/dashboards/legacy/bar-chart.tsx
@@ -1,12 +1,12 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { Bar, LabelComponentProps } from '../../console/graphs/bar';
 import { CustomDataSource } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
 
-const Label: React.FC<LabelComponentProps> = ({ metric }) => <>{_.values(metric).join()}</>;
+const Label: FC<LabelComponentProps> = ({ metric }) => <>{_.values(metric).join()}</>;
 
-const BarChart: React.FC<BarChartProps> = ({ customDataSource, pollInterval, query }) => (
+const BarChart: FC<BarChartProps> = ({ customDataSource, pollInterval, query }) => (
   <Bar
     barSpacing={5}
     barWidth={8}

--- a/web/src/components/dashboards/legacy/custom-time-range-modal.tsx
+++ b/web/src/components/dashboards/legacy/custom-time-range-modal.tsx
@@ -13,7 +13,8 @@ import {
   TimePicker,
 } from '@patternfly/react-core';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, MouseEventHandler } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 
@@ -42,7 +43,7 @@ type CustomTimeRangeModalProps = {
   endTime?: number;
 };
 
-const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
+const CustomTimeRangeModal: FC<CustomTimeRangeModalProps> = ({
   perspective,
   isOpen,
   setClosed,
@@ -59,16 +60,12 @@ const CustomTimeRangeModal: React.FC<CustomTimeRangeModalProps> = ({
   // covers all of today
   const now = new Date();
   const defaultFrom = endTime && timespan ? new Date(endTime - timespan) : undefined;
-  const [fromDate, setFromDate] = React.useState(toISODateString(defaultFrom ?? now));
-  const [fromTime, setFromTime] = React.useState(
-    defaultFrom ? toISOTimeString(defaultFrom) : '00:00',
-  );
-  const [toDate, setToDate] = React.useState(toISODateString(endTime ? new Date(endTime) : now));
-  const [toTime, setToTime] = React.useState(
-    endTime ? toISOTimeString(new Date(endTime)) : '23:59',
-  );
+  const [fromDate, setFromDate] = useState(toISODateString(defaultFrom ?? now));
+  const [fromTime, setFromTime] = useState(defaultFrom ? toISOTimeString(defaultFrom) : '00:00');
+  const [toDate, setToDate] = useState(toISODateString(endTime ? new Date(endTime) : now));
+  const [toTime, setToTime] = useState(endTime ? toISOTimeString(new Date(endTime)) : '23:59');
 
-  const submit: React.MouseEventHandler<HTMLButtonElement> = () => {
+  const submit: MouseEventHandler<HTMLButtonElement> = () => {
     const from = Date.parse(`${fromDate} ${fromTime}`);
     const to = Date.parse(`${toDate} ${toTime}`);
     if (_.isInteger(from) && _.isInteger(to)) {

--- a/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
+++ b/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import { memo, useCallback } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
@@ -18,7 +19,7 @@ import { DashboardDropdown } from '../shared/dashboard-dropdown';
 import { PollIntervalDropdown, TimespanDropdown } from './time-dropdowns';
 import { LegacyDashboardsAllVariableDropdowns } from './legacy-variable-dropdowns';
 
-const HeaderTop: React.FC = React.memo(() => {
+const HeaderTop: FC = memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (
@@ -40,19 +41,19 @@ const HeaderTop: React.FC = React.memo(() => {
   );
 });
 
-type MonitoringDashboardsLegacyPageProps = React.PropsWithChildren<{
+type MonitoringDashboardsLegacyPageProps = PropsWithChildren<{
   boardItems: CombinedDashboardMetadata[];
   changeBoard: (dashboardName: string) => void;
   dashboardName: string;
 }>;
 
-export const DashboardSkeletonLegacy: React.FC<MonitoringDashboardsLegacyPageProps> = React.memo(
+export const DashboardSkeletonLegacy: FC<MonitoringDashboardsLegacyPageProps> = memo(
   ({ children, boardItems, changeBoard, dashboardName }) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
     const { perspective } = usePerspective();
 
-    const onChangeBoard = React.useCallback(
+    const onChangeBoard = useCallback(
       (selectedDashboard: string) => {
         changeBoard(selectedDashboard);
       },

--- a/web/src/components/dashboards/legacy/error.tsx
+++ b/web/src/components/dashboards/legacy/error.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Alert, Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
 
-const ErrorAlert: React.FC<{ error: Error }> = ({ error }) => {
+const ErrorAlert: FC<{ error: Error }> = ({ error }) => {
   return (
     <Alert isInline title={error.name} variant="danger">
       <Panel isScrollable>

--- a/web/src/components/dashboards/legacy/graph.tsx
+++ b/web/src/components/dashboards/legacy/graph.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { dashboardsSetEndTime, dashboardsSetTimespan, Perspective } from '../../../actions/observe';
@@ -22,7 +23,7 @@ type Props = {
   onDataChange?: (data: any) => void;
 };
 
-const Graph: React.FC<Props> = ({
+const Graph: FC<Props> = ({
   customDataSource,
   formatSeriesTitle,
   isStack,
@@ -42,7 +43,7 @@ const Graph: React.FC<Props> = ({
     getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'timespan']),
   );
 
-  const onZoom = React.useCallback(
+  const onZoom = useCallback(
     (from, to) => {
       dispatch(dashboardsSetEndTime(to, perspective));
       dispatch(dashboardsSetTimespan(to - from, perspective));

--- a/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
@@ -1,5 +1,5 @@
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
-import * as React from 'react';
+import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import { QueryParamProvider } from 'use-query-params';
@@ -17,7 +17,7 @@ type LegacyDashboardsPageProps = {
   namespace?: string;
 };
 
-const LegacyDashboardsPage_: React.FC<LegacyDashboardsPageProps> = ({
+const LegacyDashboardsPage_: FC<LegacyDashboardsPageProps> = ({
   urlBoard,
   namespace, // only used in developer perspective
 }) => {
@@ -53,7 +53,7 @@ const LegacyDashboardsPage_: React.FC<LegacyDashboardsPageProps> = ({
   );
 };
 
-const LegacyDashboardsPage: React.FC = () => {
+const LegacyDashboardsPage: FC = () => {
   const params = useParams<{ ns?: string; dashboardName: string }>();
 
   return (

--- a/web/src/components/dashboards/legacy/legacy-dashboard.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard.tsx
@@ -17,7 +17,8 @@ import {
   FlexItem,
   ExpandableSectionToggle,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC } from 'react';
+import { memo, useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
@@ -93,7 +94,7 @@ const getPanelSpan = (panel: Panel): gridSpans => {
   return 12;
 };
 
-const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
+const Card: FC<CardProps> = memo(({ panel, perspective }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const [namespace] = useActiveNamespace();
@@ -107,17 +108,17 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
     getLegacyObserveState(perspective, state)?.getIn(['dashboards', perspective, 'variables']),
   );
 
-  const ref = React.useRef();
+  const ref = useRef();
   const [, wasEverVisible] = useIsVisible(ref);
 
-  const [isError, setIsError] = React.useState<boolean>(false);
-  const [dataSourceInfoLoading, setDataSourceInfoLoading] = React.useState<boolean>(true);
-  const [customDataSource, setCustomDataSource] = React.useState<CustomDataSource>(undefined);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [dataSourceInfoLoading, setDataSourceInfoLoading] = useState<boolean>(true);
+  const [customDataSource, setCustomDataSource] = useState<CustomDataSource>(undefined);
   const customDataSourceName = panel.datasource?.name;
   const [extensions, extensionsResolved] = useResolvedExtensions<DataSource>(isDataSource);
   const hasExtensions = !_.isEmpty(extensions);
 
-  const formatSeriesTitle = React.useCallback(
+  const formatSeriesTitle = useCallback(
     (labels, i) => {
       const title = panel.targets?.[i]?.legendFormat;
       if (_.isNil(title)) {
@@ -133,7 +134,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
     },
     [panel],
   );
-  const [csvData, setCsvData] = React.useState([]);
+  const [csvData, setCsvData] = useState([]);
 
   const csvExportHandler = () => {
     let csvString = '';
@@ -204,7 +205,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
     </DropdownItem>,
   ];
 
-  React.useEffect(() => {
+  useEffect(() => {
     const getCustomDataSource = async () => {
       if (!customDataSourceName) {
         setDataSourceInfoLoading(false);
@@ -237,14 +238,14 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
     });
   }, [extensions, extensionsResolved, customDataSourceName, hasExtensions]);
 
-  const handleZoom = React.useCallback((timeRange: number, endTime: number) => {
+  const handleZoom = useCallback((timeRange: number, endTime: number) => {
     setQueryArguments({
       [QueryParams.EndTime]: endTime.toString(),
       [QueryParams.TimeRange]: timeRange.toString(),
     });
   }, []);
 
-  const panelBreakpoints = React.useMemo(() => {
+  const panelBreakpoints = useMemo(() => {
     const panelSpan = getPanelSpan(panel);
     return {
       sm: 12 as gridSpans,
@@ -368,7 +369,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel, perspective }) => {
   );
 });
 
-const PanelsRow: React.FC<PanelsRowProps> = ({ row, perspective }) => {
+const PanelsRow: FC<PanelsRowProps> = ({ row, perspective }) => {
   const showButton = row.showTitle && !_.isEmpty(row.title);
 
   const [isExpanded, toggleIsExpanded] = useBoolean(showButton ? !row.collapse : true);
@@ -395,7 +396,7 @@ const PanelsRow: React.FC<PanelsRowProps> = ({ row, perspective }) => {
   );
 };
 
-export const LegacyDashboard: React.FC<BoardProps> = ({ rows, perspective }) => (
+export const LegacyDashboard: FC<BoardProps> = ({ rows, perspective }) => (
   <Flex direction={{ default: 'column' }}>
     {_.map(rows, (row) => (
       <FlexItem>

--- a/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
@@ -17,7 +17,8 @@ import {
   SplitItem,
   Split,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC, Ref } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
@@ -105,7 +106,7 @@ const LegacyDashboardsVariableOption = ({ value, isSelected, ...rest }) =>
     </SelectOption>
   );
 
-const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
+const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({
   id,
   name,
   namespace,
@@ -126,15 +127,15 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
   const dispatch = useDispatch();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
 
-  const [isError, setIsError] = React.useState(false);
+  const [isError, setIsError] = useState(false);
 
   const customDataSourceName = variable?.datasource?.name;
   const [extensions, extensionsResolved] = useResolvedExtensions<DataSource>(isDataSource);
   const hasExtensions = !_.isEmpty(extensions);
 
-  const getURL = React.useCallback(
+  const getURL = useCallback(
     async (prometheusProps) => {
       try {
         if (!customDataSourceName) {
@@ -161,7 +162,7 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
     [customDataSourceName, extensions, extensionsResolved, hasExtensions, perspective],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!query) {
       return;
     }
@@ -236,7 +237,7 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
     variable.options,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (variable.value && variable.value !== getQueryArgument(name)) {
       if (perspective === 'dev' && name !== 'namespace') {
         setQueryArgument(name, variable.value);
@@ -246,7 +247,7 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
     }
   }, [perspective, name, variable.value]);
 
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (v: string) => {
       if (v !== variable.value) {
         if (perspective === 'dev' && name !== 'namespace') {
@@ -286,7 +287,7 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
         <StackItem>
           {isError ? (
             <Select
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              toggle={(toggleRef: Ref<MenuToggleElement>) => (
                 <MenuToggle ref={toggleRef} isDisabled={true} onClick={(e) => e.preventDefault()}>
                   <RedExclamationCircleIcon /> {t('Error loading options')}
                 </MenuToggle>
@@ -310,7 +311,7 @@ const LegacyDashboardsVariableDropdown: React.FC<VariableDropdownProps> = ({
 };
 
 // Expects to be inside of a Patternfly Split Component
-export const LegacyDashboardsAllVariableDropdowns: React.FC = () => {
+export const LegacyDashboardsAllVariableDropdowns: FC = () => {
   const [namespace] = useActiveNamespace();
   const { perspective } = usePerspective();
   const variables = useSelector((state: MonitoringState) =>

--- a/web/src/components/dashboards/legacy/single-stat.tsx
+++ b/web/src/components/dashboards/legacy/single-stat.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { ReactNode, FC } from 'react';
+import { useState, useCallback } from 'react';
 import { PrometheusEndpoint, PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, Title } from '@patternfly/react-core';
 
@@ -89,17 +90,11 @@ const colorMap: Record<string, PatternflyToken> = {
 const getColorCSS = (colorName: string): string =>
   colorMap[colorName] ? colorMap[colorName].var : undefined;
 
-const Body: React.FC<{ children: React.ReactNode; color?: string }> = ({ children, color }) => (
+const Body: FC<{ children: ReactNode; color?: string }> = ({ children, color }) => (
   <Bullseye style={{ color }}>{children}</Bullseye>
 );
 
-const SingleStat: React.FC<Props> = ({
-  customDataSource,
-  namespace,
-  panel,
-  pollInterval,
-  query,
-}) => {
+const SingleStat: FC<Props> = ({ customDataSource, namespace, panel, pollInterval, query }) => {
   const {
     decimals,
     format,
@@ -113,13 +108,13 @@ const SingleStat: React.FC<Props> = ({
   } = panel;
 
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
-  const [error, setError] = React.useState<string>();
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [value, setValue] = React.useState<string>();
+  const [error, setError] = useState<string>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [value, setValue] = useState<string>();
   const { perspective } = usePerspective();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
 
   const url = getPrometheusURL(
     {

--- a/web/src/components/dashboards/legacy/table.tsx
+++ b/web/src/components/dashboards/legacy/table.tsx
@@ -13,7 +13,8 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ErrorAlert from './error';
@@ -64,20 +65,20 @@ const perPageOptions: PerPageOptions[] = [5, 10, 20, 50, 100].map((n) => ({
   value: n,
 }));
 
-const Table: React.FC<Props> = ({ customDataSource, panel, pollInterval, queries, namespace }) => {
+const Table: FC<Props> = ({ customDataSource, panel, pollInterval, queries, namespace }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
 
-  const [error, setError] = React.useState();
-  const [isLoading, setLoading] = React.useState(true);
-  const [data, setData] = React.useState();
-  const [page, setPage] = React.useState(1);
-  const [perPage, setPerPage] = React.useState(5);
-  const [sortBy, setSortBy] = React.useState<ISortBy>({ index: 0, direction: 'asc' });
+  const [error, setError] = useState();
+  const [isLoading, setLoading] = useState(true);
+  const [data, setData] = useState();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(5);
+  const [sortBy, setSortBy] = useState<ISortBy>({ index: 0, direction: 'asc' });
   const onSort = (e, index: ISortBy['index'], direction: ISortBy['direction']) =>
     setSortBy({ index, direction });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
 
   const tick = () => {
     const allPromises = _.map(queries, (query) =>

--- a/web/src/components/dashboards/legacy/time-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/time-dropdowns.tsx
@@ -1,7 +1,8 @@
 import { Stack, StackItem } from '@patternfly/react-core';
 import { SimpleSelect, SimpleSelectOption } from '@patternfly/react-templates';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { NumberParam, useQueryParam } from 'use-query-params';
@@ -24,7 +25,7 @@ import CustomTimeRangeModal from './custom-time-range-modal';
 const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 const DEFAULT_TIMERANGE = '30m';
 
-export const TimespanDropdown: React.FC = () => {
+export const TimespanDropdown: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const { perspective } = usePerspective();
@@ -47,7 +48,7 @@ export const TimespanDropdown: React.FC = () => {
       : formatPrometheusDuration(_.toNumber(timeRangeFromParams) || timespan);
 
   const dispatch = useDispatch();
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (v: string) => {
       if (v === CUSTOM_TIME_RANGE_KEY) {
         setModalOpen();
@@ -61,7 +62,7 @@ export const TimespanDropdown: React.FC = () => {
     [setModalOpen, dispatch, perspective, setTimeRange, setEndTime],
   );
 
-  const initialOptions = React.useMemo<SimpleSelectOption[]>(() => {
+  const initialOptions = useMemo<SimpleSelectOption[]>(() => {
     const intervalOptions: SimpleSelectOption[] = [
       { content: t('Custom time range'), value: CUSTOM_TIME_RANGE_KEY },
       { content: t('Last {{count}} minute', { count: 5 }), value: '5m' },
@@ -118,15 +119,15 @@ export const TimespanDropdown: React.FC = () => {
   );
 };
 
-export const PollIntervalDropdown: React.FC = () => {
+export const PollIntervalDropdown: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();
-  const [selectedInterval, setSelectedInterval] = React.useState(DEFAULT_REFRESH_INTERVAL);
+  const [selectedInterval, setSelectedInterval] = useState(DEFAULT_REFRESH_INTERVAL);
 
   const dispatch = useDispatch();
   const [, setRefreshInterval] = useQueryParam(QueryParams.RefreshInterval, NumberParam);
 
-  const setInterval = React.useCallback(
+  const setInterval = useCallback(
     (v: number) => {
       setSelectedInterval(v);
       setRefreshInterval(v);

--- a/web/src/components/dashboards/legacy/useLegacyDashboards.ts
+++ b/web/src/components/dashboards/legacy/useLegacyDashboards.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useState, useMemo, useEffect } from 'react';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -32,23 +32,23 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
   const { perspective } = usePerspective();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
-  const [legacyDashboards, setLegacyDashboards] = React.useState<Board[]>([]);
-  const [legacyDashboardsError, setLegacyDashboardsError] = React.useState<string>();
+  const safeFetch = useCallback(useSafeFetch(), []);
+  const [legacyDashboards, setLegacyDashboards] = useState<Board[]>([]);
+  const [legacyDashboardsError, setLegacyDashboardsError] = useState<string>();
   const [dashboardParam] = useQueryParam(QueryParams.Dashboard, StringParam);
   const [refreshInterval] = useQueryParam(QueryParams.RefreshInterval, NumberParam);
   const [legacyDashboardsLoading, , , setLegacyDashboardsLoaded] = useBoolean(true);
   const [initialLoad, , , setInitialLoaded] = useBoolean(true);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const legacyDashboard = React.useMemo(() => {
+  const legacyDashboard = useMemo(() => {
     if (perspective === 'dev') {
       return dashboardParam;
     }
     return urlBoard;
   }, [perspective, dashboardParam, urlBoard]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     safeFetch<any>('/api/console/monitoring-dashboard-config')
       .then((response) => {
         setLegacyDashboardsLoaded();
@@ -86,7 +86,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
       });
   }, [namespace, safeFetch, setLegacyDashboardsLoaded, t]);
 
-  const legacyRows = React.useMemo(() => {
+  const legacyRows = useMemo(() => {
     const data = _.find(legacyDashboards, { name: legacyDashboard })?.data;
 
     return data?.rows?.length
@@ -107,7 +107,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
         }, []);
   }, [legacyDashboard, legacyDashboards]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Dashboard query argument is only set in dev perspective, so skip for admin
     if (perspective !== 'dev') {
       return;
@@ -119,7 +119,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
 
   // Homogenize data needed for dashboards dropdown between legacy and perses dashboards
   // to enable both to use the same component
-  const legacyDashboardsMetadata = React.useMemo<CombinedDashboardMetadata[]>(() => {
+  const legacyDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
     if (legacyDashboardsLoading) {
       return [];
     }
@@ -132,7 +132,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
     });
   }, [legacyDashboards, legacyDashboardsLoading]);
 
-  const changeLegacyDashboard = React.useCallback(
+  const changeLegacyDashboard = useCallback(
     (newBoard: string) => {
       if (!newBoard) {
         // If the board is being cleared then don't do anything
@@ -182,7 +182,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
     ],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       (!legacyDashboard ||
         !legacyDashboards.some((legacyBoard) => legacyBoard.name === legacyDashboard) ||
@@ -195,7 +195,7 @@ export const useLegacyDashboards = (namespace: string, urlBoard: string) => {
   }, [legacyDashboards, changeLegacyDashboard, initialLoad, setInitialLoaded, legacyDashboard]);
 
   // Clear variables on unmount
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       dispatch(DashboardsClearVariables(perspective));
     };

--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
+import * as React from 'react';
 import {
   ChartsProvider,
   generateChartsTheme,

--- a/web/src/components/dashboards/perses/dashboard-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-page.tsx
@@ -1,6 +1,6 @@
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import * as React from 'react';
+import type { FC } from 'react';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
 import { LoadingInline } from '../../console/console-shared/src/components/loading/LoadingInline';
@@ -21,7 +21,7 @@ const queryClient = new QueryClient({
   },
 });
 
-const MonitoringDashboardsPage_: React.FC = () => {
+const MonitoringDashboardsPage_: FC = () => {
   const {
     changeBoard,
     activeProjectDashboardsMetadata,
@@ -63,7 +63,7 @@ const MonitoringDashboardsPage_: React.FC = () => {
   );
 };
 
-const MonitoringDashboardsPageWrapper: React.FC = () => {
+const MonitoringDashboardsPageWrapper: FC = () => {
   return (
     <QueryParamProvider adapter={ReactRouter5Adapter}>
       <QueryClientProvider client={queryClient}>

--- a/web/src/components/dashboards/perses/dashboard-skeleton.tsx
+++ b/web/src/components/dashboards/perses/dashboard-skeleton.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
@@ -22,7 +23,7 @@ import { usePerspective } from '../../hooks/usePerspective';
 import { DashboardDropdown } from '../shared/dashboard-dropdown';
 import { CombinedDashboardMetadata } from './hooks/useDashboardsData';
 
-const HeaderTop: React.FC = React.memo(() => {
+const HeaderTop: FC = memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (
@@ -41,21 +42,21 @@ const HeaderTop: React.FC = React.memo(() => {
   );
 });
 
-type MonitoringDashboardsPageProps = React.PropsWithChildren<{
+type MonitoringDashboardsPageProps = PropsWithChildren<{
   boardItems: CombinedDashboardMetadata[];
   changeBoard: (dashboardName: string) => void;
   dashboardName: string;
   activeProject?: string;
 }>;
 
-export const DashboardSkeleton: React.FC<MonitoringDashboardsPageProps> = React.memo(
+export const DashboardSkeleton: FC<MonitoringDashboardsPageProps> = memo(
   ({ children, boardItems, changeBoard, dashboardName, activeProject }) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
     const { perspective } = usePerspective();
     const { setDashboard } = useDashboardActions();
     const variables = useVariableDefinitions();
 
-    const onChangeBoard = React.useCallback(
+    const onChangeBoard = useCallback(
       (selectedDashboard: string) => {
         changeBoard(selectedDashboard);
 
@@ -72,7 +73,7 @@ export const DashboardSkeleton: React.FC<MonitoringDashboardsPageProps> = React.
       [changeBoard, boardItems, activeProject, setDashboard],
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
       onChangeBoard(dashboardName);
     }, [dashboardName, onChangeBoard]);
 

--- a/web/src/components/dashboards/perses/emptystates/DashboardEmptyState.tsx
+++ b/web/src/components/dashboards/perses/emptystates/DashboardEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Title, EmptyState, EmptyStateBody, Bullseye } from '@patternfly/react-core';
 import { ListIcon } from '@patternfly/react-icons';
 

--- a/web/src/components/dashboards/perses/emptystates/ProjectEmptyState.tsx
+++ b/web/src/components/dashboards/perses/emptystates/ProjectEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Title, EmptyState, EmptyStateBody, Bullseye } from '@patternfly/react-core';
 import { ListIcon } from '@patternfly/react-icons';
 

--- a/web/src/components/dashboards/perses/hooks/useDashboardsData.ts
+++ b/web/src/components/dashboards/perses/hooks/useDashboardsData.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useCallback, useEffect } from 'react';
 
 import { DashboardResource } from '@perses-dev/core';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -28,7 +28,7 @@ export const useDashboardsData = () => {
   const [dashboardName] = useQueryParam(QueryParams.Dashboard, StringParam);
 
   // Determine when to stop having the full page loader be used
-  const combinedInitialLoad = React.useMemo(() => {
+  const combinedInitialLoad = useMemo(() => {
     if (!initialPageLoad) {
       return false;
     }
@@ -41,7 +41,7 @@ export const useDashboardsData = () => {
 
   // Homogenize data needed for dashboards dropdown between legacy and perses dashboards
   // to enable both to use the same component
-  const combinedDashboardsMetadata = React.useMemo<CombinedDashboardMetadata[]>(() => {
+  const combinedDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
     if (combinedInitialLoad) {
       return [];
     }
@@ -60,13 +60,13 @@ export const useDashboardsData = () => {
   }, [persesDashboards, combinedInitialLoad]);
 
   // Retrieve dashboard metadata for the currently selected project
-  const activeProjectDashboardsMetadata = React.useMemo<CombinedDashboardMetadata[]>(() => {
+  const activeProjectDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
     return combinedDashboardsMetadata.filter((combinedDashboardMetadata) => {
       return combinedDashboardMetadata.project === activeProject;
     });
   }, [combinedDashboardsMetadata, activeProject]);
 
-  const changeBoard = React.useCallback(
+  const changeBoard = useCallback(
     (newBoard: string) => {
       if (!newBoard) {
         // If the board is being cleared then don't do anything
@@ -91,7 +91,7 @@ export const useDashboardsData = () => {
   // If a dashboard hasn't been selected yet, or if the current project doesn't have a
   // matching board name then display the board present in the URL parameters or the first
   // board in the dropdown list
-  React.useEffect(() => {
+  useEffect(() => {
     const metadataMatch = activeProjectDashboardsMetadata.find((activeProjectDashboardMetadata) => {
       return (
         activeProjectDashboardMetadata.project === activeProject &&

--- a/web/src/components/dashboards/perses/perses-dashboards.tsx
+++ b/web/src/components/dashboards/perses/perses-dashboards.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Dashboard } from '@perses-dev/dashboards';
 import { useTranslation } from 'react-i18next';
 

--- a/web/src/components/dashboards/perses/project/ProjectBar.tsx
+++ b/web/src/components/dashboards/perses/project/ProjectBar.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import type { SetStateAction, Dispatch, FC } from 'react';
 import { KEYBOARD_SHORTCUTS } from './utils';
 import ProjectDropdown from './ProjectDropdown';
 
 export type ProjectBarProps = {
-  setActiveProject: React.Dispatch<React.SetStateAction<string>>;
+  setActiveProject: Dispatch<SetStateAction<string>>;
   activeProject: string;
 };
 
-export const ProjectBar: React.FC<ProjectBarProps> = ({ setActiveProject, activeProject }) => {
+export const ProjectBar: FC<ProjectBarProps> = ({ setActiveProject, activeProject }) => {
   return (
     <div className="co-namespace-bar">
       <div className="co-namespace-bar__items">

--- a/web/src/components/dashboards/perses/project/ProjectMenuToggle.tsx
+++ b/web/src/components/dashboards/perses/project/ProjectMenuToggle.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
+import type { ReactElement, RefObject } from 'react';
+import { useRef, useEffect } from 'react';
 import { MenuToggle, Popper } from '@patternfly/react-core';
 import classNames from 'classnames';
 
 const ProjectMenuToggle = (props: {
   disabled: boolean;
-  menu: React.ReactElement;
-  menuRef: React.RefObject<HTMLElement>;
+  menu: ReactElement;
+  menuRef: RefObject<HTMLElement>;
   isOpen: boolean;
   shortCut?: string;
   title: string;
@@ -14,8 +15,8 @@ const ProjectMenuToggle = (props: {
 }) => {
   const { menu, isOpen, shortCut, title, onToggle, disabled, menuRef, className } = props;
 
-  const toggleRef = React.useRef(null);
-  const containerRef = React.useRef(null);
+  const toggleRef = useRef(null);
+  const containerRef = useRef(null);
 
   const handleMenuKeys = (event) => {
     if (
@@ -56,7 +57,7 @@ const ProjectMenuToggle = (props: {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('keyup', handleMenuKeys);
     window.addEventListener('click', handleMenuClick);
     return () => {

--- a/web/src/components/dashboards/perses/project/useActiveProject.tsx
+++ b/web/src/components/dashboards/perses/project/useActiveProject.tsx
@@ -3,7 +3,7 @@ import {
   useActiveNamespace,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { ProjectModel } from '../../../console/models';
 import { usePerspective } from '../../../hooks/usePerspective';
 import { usePerses } from '../hooks/usePerses';
@@ -11,7 +11,7 @@ import { QueryParams } from '../../../query-params';
 import { StringParam, useQueryParam } from 'use-query-params';
 
 export const useActiveProject = () => {
-  const [activeProject, setActiveProject] = React.useState('');
+  const [activeProject, setActiveProject] = useState('');
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
   const { perspective } = usePerspective();
   const { persesProjects, persesProjectsLoading } = usePerses();
@@ -23,7 +23,7 @@ export const useActiveProject = () => {
   });
 
   // Sync the state and the URL param
-  React.useEffect(() => {
+  useEffect(() => {
     // If data and url hasn't been set yet, default to legacy dashboard (for now)
     if (!activeProject && projectFromUrl) {
       setActiveProject(projectFromUrl);
@@ -54,7 +54,7 @@ export const useActiveProject = () => {
   ]);
 
   // Sync the activeProject and activeNamespace changes
-  React.useEffect(() => {
+  useEffect(() => {
     if (!activeProject || !namespacesLoaded || activeProject === activeNamespace) {
       return;
     }

--- a/web/src/components/dashboards/shared/dashboard-dropdown.tsx
+++ b/web/src/components/dashboards/shared/dashboard-dropdown.tsx
@@ -8,7 +8,8 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { SingleTypeaheadDropdown } from '../../console/utils/single-typeahead-dropdown';
@@ -17,17 +18,13 @@ import { CombinedDashboardMetadata } from '../perses/hooks/useDashboardsData';
 type TagColor = 'red' | 'purple' | 'blue' | 'green' | 'teal' | 'orange';
 const tagColors: TagColor[] = ['red', 'purple', 'blue', 'green', 'teal', 'orange'];
 
-const Tag: React.FC<{ color: TagColor; text: string }> = React.memo(({ color, text }) => (
+const Tag: FC<{ color: TagColor; text: string }> = memo(({ color, text }) => (
   <Label isCompact color={color}>
     {text}
   </Label>
 ));
 
-export const DashboardDropdown: React.FC<DashboardDropdownProps> = ({
-  items,
-  onChange,
-  selectedKey,
-}) => {
+export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange, selectedKey }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const allTags = _.flatMap(items, 'tags');

--- a/web/src/components/dropdown-poll-interval.tsx
+++ b/web/src/components/dropdown-poll-interval.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   formatPrometheusDuration,
@@ -15,7 +16,7 @@ type DropDownPollIntervalProps = {
 export const DEFAULT_REFRESH_INTERVAL = parsePrometheusDuration('30s');
 const OFF_KEY = 'OFF_KEY';
 
-export const DropDownPollInterval: React.FunctionComponent<DropDownPollIntervalProps> = ({
+export const DropDownPollInterval: FunctionComponent<DropDownPollIntervalProps> = ({
   id,
   setInterval,
   selectedInterval,
@@ -24,7 +25,7 @@ export const DropDownPollInterval: React.FunctionComponent<DropDownPollIntervalP
 
   const selectedKey = selectedInterval ? formatPrometheusDuration(selectedInterval) : OFF_KEY;
 
-  const initialOptions = React.useMemo<SimpleSelectOption[]>(() => {
+  const initialOptions = useMemo<SimpleSelectOption[]>(() => {
     const intervalOptions: SimpleSelectOption[] = [
       { content: t('Refresh off'), value: OFF_KEY },
       { content: t('{{count}} second', { count: 15 }), value: '15s' },

--- a/web/src/components/hooks/useAlertsPoller.ts
+++ b/web/src/components/hooks/useAlertsPoller.ts
@@ -4,7 +4,7 @@ import {
   useActiveNamespace,
   useResolvedExtensions,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as React from 'react';
+import { useMemo } from 'react';
 import { usePerspective } from './usePerspective';
 import { useRulesAlertsPoller } from './useRulesAlertsPoller';
 import { useSilencesPoller } from './useSilencesPoller';
@@ -17,7 +17,7 @@ export const useAlertsPoller = () => {
   const [customExtensions] =
     useResolvedExtensions<AlertingRulesSourceExtension>(isAlertingRulesSource);
 
-  const alertsSource = React.useMemo(
+  const alertsSource = useMemo(
     () =>
       customExtensions
         .filter((extension) => extension.properties.contextId === alertingContextId)

--- a/web/src/components/hooks/useBoolean.ts
+++ b/web/src/components/hooks/useBoolean.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 
 export const useBoolean = (
   initialValue: boolean,
 ): [boolean, () => void, () => void, () => void] => {
-  const [value, setValue] = React.useState(initialValue);
-  const toggle = React.useCallback(() => setValue((v) => !v), []);
-  const setTrue = React.useCallback(() => setValue(true), []);
-  const setFalse = React.useCallback(() => setValue(false), []);
+  const [value, setValue] = useState(initialValue);
+  const toggle = useCallback(() => setValue((v) => !v), []);
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
   return [value, toggle, setTrue, setFalse];
 };

--- a/web/src/components/hooks/useFeatures.ts
+++ b/web/src/components/hooks/useFeatures.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { proxiedFetch } from '../proxied-fetch';
 
 type features = {
@@ -24,9 +24,9 @@ const MCP_PROXY_PATH = '/api/proxy/plugin/monitoring-console-plugin/backend';
 const featuresEndpoint = `${MCP_PROXY_PATH}/features`;
 
 export const useFeatures = () => {
-  const [features, setFeatures] = React.useState<features>(noFeatures);
-  const dashboardsAbort = React.useRef<() => void | undefined>();
-  const getFeatures = React.useCallback(async () => {
+  const [features, setFeatures] = useState<features>(noFeatures);
+  const dashboardsAbort = useRef<() => void | undefined>();
+  const getFeatures = useCallback(async () => {
     try {
       if (dashboardsAbort.current) {
         dashboardsAbort.current();
@@ -40,7 +40,7 @@ export const useFeatures = () => {
   }, []);
 
   // Use useEffect to call getFeatures only once after the component mounts
-  React.useEffect(() => {
+  useEffect(() => {
     getFeatures();
   }, [getFeatures]);
 

--- a/web/src/components/hooks/useIsVisible.ts
+++ b/web/src/components/hooks/useIsVisible.ts
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 
 export const useIsVisible = (ref) => {
-  const [isVisible, setIsVisible] = React.useState(false);
-  const [wasEverVisible, setWasEverVisible] = React.useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [wasEverVisible, setWasEverVisible] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const callback = ([entry]) => {
       setIsVisible(entry.isIntersecting);
       if (entry.isIntersecting) {

--- a/web/src/components/hooks/useRulesAlertsPoller.ts
+++ b/web/src/components/hooks/useRulesAlertsPoller.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { PrometheusEndpoint, PrometheusRulesResponse } from '@openshift-console/dynamic-plugin-sdk';
 import { getPrometheusURL } from '../console/graphs/helpers';
@@ -26,7 +26,7 @@ export const useRulesAlertsPoller = (
   const { perspective, rulesKey, alertsKey } = usePerspective();
   const dispatch = useDispatch();
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(alertingLoading(alertsKey, perspective));
     const url = getPrometheusURL(
       {

--- a/web/src/components/hooks/useSilencesPoller.ts
+++ b/web/src/components/hooks/useSilencesPoller.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { alertingErrored, alertingLoaded, alertingLoading } from '../../actions/observe';
 import { useURLPoll } from './useURLPoll';
 import { Silence } from '@openshift-console/dynamic-plugin-sdk';
@@ -18,7 +18,7 @@ export const useSilencesPoller = ({ namespace }) => {
     namespace,
   );
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     if (loadError) {
       dispatch(alertingErrored(silencesKey, loadError, perspective));
     } else if (loading) {

--- a/web/src/components/kebab-dropdown.tsx
+++ b/web/src/components/kebab-dropdown.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import type { FC, Ref } from 'react';
 import { Dropdown, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 import { useBoolean } from './hooks/useBoolean';
 
-const KebabDropdown: React.FC<{ dropdownItems: any[] }> = ({ dropdownItems }) => {
+const KebabDropdown: FC<{ dropdownItems: any[] }> = ({ dropdownItems }) => {
   const [isOpen, setIsOpen, setOpen, setClosed] = useBoolean(false);
 
   return (
@@ -13,7 +13,7 @@ const KebabDropdown: React.FC<{ dropdownItems: any[] }> = ({ dropdownItems }) =>
       onSelect={setClosed}
       onOpenChange={(open: boolean) => (open ? setOpen() : setClosed())}
       popperProps={{ position: 'right' }}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+      toggle={(toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
           aria-label="toggle menu"

--- a/web/src/components/labels.tsx
+++ b/web/src/components/labels.tsx
@@ -1,5 +1,4 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Label as PfLabel, LabelGroup as PfLabelGroup } from '@patternfly/react-core';
 

--- a/web/src/components/metrics/promql-expression-input.tsx
+++ b/web/src/components/metrics/promql-expression-input.tsx
@@ -45,7 +45,8 @@ import {
 } from '@patternfly/react-core';
 import { CloseIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { PromQLExtension } from '@prometheus-io/codemirror-promql';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSafeFetch } from '../console/utils/safe-fetch-hook';
@@ -319,7 +320,7 @@ export const promqlHighlighter = HighlightStyle.define([
   { tag: tags.comment, color: t_global_text_color_disabled.var, fontStyle: 'italic' },
 ]);
 
-export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
+export const PromQLExpressionInput: FC<PromQLExpressionInputProps> = ({
   value,
   onExecuteQuery,
   onValueChange,
@@ -328,17 +329,17 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { theme: pfTheme } = usePatternFlyTheme();
 
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
-  const viewRef = React.useRef<EditorView | null>(null);
-  const [metricNames, setMetricNames] = React.useState<Array<string>>([]);
-  const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const [metricNames, setMetricNames] = useState<Array<string>>([]);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
   const placeholder = t('Expression (press Shift+Enter for newlines)');
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     safeFetch<LabelNamesResponse>(
       `${PROMETHEUS_BASE_PATH}/${PrometheusEndpoint.LABEL}/__name__/values`,
     )
@@ -365,7 +366,7 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
     onValueChange('');
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (viewRef.current !== null) {
       const currentExpression = viewRef.current.state.doc.toString();
       if (currentExpression !== value) {
@@ -376,7 +377,7 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
     }
   }, [value]);
 
-  const target = React.useMemo(
+  const target = useMemo(
     () => ({
       focus: () => viewRef.current.focus(),
       setSelectionRange: (from: number, to: number) => {
@@ -388,7 +389,7 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
     [],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     promqlExtension.setComplete({
       remote: {
         url: PROMETHEUS_BASE_PATH,

--- a/web/src/components/prometheus-redirect-page.tsx
+++ b/web/src/components/prometheus-redirect-page.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Navigate } from 'react-router-dom-v5-compat';
 import { getAllQueryArguments } from './console/utils/router';
 import { usePerspective } from './hooks/usePerspective';
@@ -6,7 +6,7 @@ import { usePerspective } from './hooks/usePerspective';
 // Handles links that have the Prometheus UI's URL format (expected for links in alerts sent by
 // Alertmanager). The Prometheus UI specifies the PromQL query with the GET param `g0.expr`, so we
 // use that if it exists. Otherwise, just go to the query browser page with no query.
-const PrometheusRouterRedirect: React.FC = () => {
+const PrometheusRouterRedirect: FC = () => {
   const { urlRoot } = usePerspective();
 
   const params = getAllQueryArguments();

--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -44,7 +44,8 @@ import {
 import { ChartLineIcon } from '@patternfly/react-icons';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import type { FC, Ref, ReactNode, KeyboardEvent, MouseEvent, ComponentType } from 'react';
+import { memo, useState, useEffect, useCallback, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -94,7 +95,7 @@ import { GraphUnits } from './metrics/units';
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 export const colors = queryBrowserTheme.line.colorScale;
 
-export const Error: React.FC<ErrorProps> = ({ error, title = 'An error occurred' }) => (
+export const Error: FC<ErrorProps> = ({ error, title = 'An error occurred' }) => (
   <Alert isInline title={title} variant="danger">
     {_.get(error, 'json.error', error.message)}
   </Alert>
@@ -104,7 +105,7 @@ const BOTTOM_SERIES_HEIGHT = 34;
 const LEGEND_HEIGHT = 90;
 const CHART_HEIGHT = 200;
 
-const GraphEmptyState: React.FC<GraphEmptyStateProps> = ({ children, title }) => (
+const GraphEmptyState: FC<GraphEmptyStateProps> = ({ children, title }) => (
   <div>
     <EmptyState
       titleText={
@@ -120,21 +121,21 @@ const GraphEmptyState: React.FC<GraphEmptyStateProps> = ({ children, title }) =>
   </div>
 );
 
-const SpanControls: React.FC<SpanControlsProps> = React.memo(
+const SpanControls: FC<SpanControlsProps> = memo(
   ({ defaultSpanText, onChange, span, hasReducedResolution }) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
-    const [isValid, setIsValid] = React.useState(true);
-    const [text, setText] = React.useState(formatPrometheusDuration(span));
+    const [isValid, setIsValid] = useState(true);
+    const [text, setText] = useState(formatPrometheusDuration(span));
 
     const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
-    React.useEffect(() => {
+    useEffect(() => {
       setText(formatPrometheusDuration(span));
     }, [span]);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const debouncedOnChange = React.useCallback(_.debounce(onChange, 400), [onChange]);
+    const debouncedOnChange = useCallback(_.debounce(onChange, 400), [onChange]);
 
     const setSpan = (newText: string, isDebounced = false) => {
       const newSpan = parsePrometheusDuration(newText);
@@ -170,7 +171,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(
               <Dropdown
                 isOpen={isOpen}
                 onSelect={setClosed}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                toggle={(toggleRef: Ref<MenuToggleElement>) => (
                   <MenuToggle
                     ref={toggleRef}
                     onClick={setIsOpen}
@@ -206,7 +207,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(
   },
 );
 
-const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
+const LegendContainer = ({ children }: { children?: ReactNode }) => {
   // The first child should be a <rect> with a `width` prop giving the legend's content width
   const width = children?.[0]?.props?.width ?? '100%';
 
@@ -228,7 +229,7 @@ const getXDomain = (endTime: number, span: number): AxisDomain => [endTime - spa
 
 const ONE_MINUTE = 60 * 1000;
 
-const Graph: React.FC<GraphProps> = React.memo(
+const Graph: FC<GraphProps> = memo(
   ({
     allSeries,
     disabledSeries,
@@ -247,10 +248,10 @@ const Graph: React.FC<GraphProps> = React.memo(
     const tooltipSeriesLabels: PrometheusLabels[] = [];
     const legendData: { name: string }[] = [];
 
-    const [xDomain, setXDomain] = React.useState(fixedXDomain || getXDomain(Date.now(), span));
+    const [xDomain, setXDomain] = useState(fixedXDomain || getXDomain(Date.now(), span));
 
     // Only update X-axis if the time range (fixedXDomain or span) or graph data (allSeries) change
-    React.useEffect(() => {
+    useEffect(() => {
       setXDomain(fixedXDomain || getXDomain(Date.now(), span));
     }, [allSeries, span, fixedXDomain]);
 
@@ -474,7 +475,7 @@ const minSpan = 30 * 1000;
 // Don't poll more often than this number of milliseconds
 const minPollInterval = 10 * 1000;
 
-const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
+const ZoomableGraph: FC<ZoomableGraphProps> = ({
   allSeries,
   disabledSeries,
   fixedXDomain,
@@ -486,29 +487,29 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
   units,
   width,
 }) => {
-  const [isZooming, setIsZooming] = React.useState(false);
-  const [x1, setX1] = React.useState(0);
-  const [x2, setX2] = React.useState(0);
+  const [isZooming, setIsZooming] = useState(false);
+  const [x1, setX1] = useState(0);
+  const [x2, setX2] = useState(0);
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
+  const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
       setIsZooming(false);
     }
   };
 
-  const onMouseDown = (e: React.MouseEvent) => {
+  const onMouseDown = (e: MouseEvent) => {
     setIsZooming(true);
     const x = e.clientX - e.currentTarget.getBoundingClientRect().left;
     setX1(x);
     setX2(x);
   };
 
-  const onMouseMove = (e: React.MouseEvent) => {
+  const onMouseMove = (e: MouseEvent) => {
     setX2(e.clientX - e.currentTarget.getBoundingClientRect().left);
   };
 
-  const onMouseUp = (e: React.MouseEvent) => {
+  const onMouseUp = (e: MouseEvent) => {
     setIsZooming(false);
 
     const xMin = Math.min(x1, x2);
@@ -572,7 +573,7 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
 const getMaxSamplesForSpan = (span: number) =>
   _.clamp(Math.round(span / minStep), minSamples, maxSamples);
 
-const QueryBrowser_: React.FC<QueryBrowserProps> = ({
+const QueryBrowser_: FC<QueryBrowserProps> = ({
   customDataSource,
   defaultSamples,
   defaultTimespan = parsePrometheusDuration('30m'),
@@ -616,17 +617,17 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // as defaultTimespan
   const defaultSpanText = spans.find((s) => parsePrometheusDuration(s) >= defaultTimespan);
   // If we have both `timespan` and `defaultTimespan`, `timespan` takes precedence
-  const [span, setSpan] = React.useState(timespan || parsePrometheusDuration(defaultSpanText));
+  const [span, setSpan] = useState(timespan || parsePrometheusDuration(defaultSpanText));
 
   // Limit the number of samples so that the step size doesn't fall below minStep
   const maxSamplesForSpan = defaultSamples || getMaxSamplesForSpan(span);
 
-  const [xDomain, setXDomain] = React.useState<AxisDomain>();
-  const [error, setError] = React.useState<PrometheusAPIError>();
-  const [isDatasetTooBig, setIsDatasetTooBig] = React.useState(false);
-  const [graphData, setGraphData] = React.useState<Series[][]>(null);
-  const [samples, setSamples] = React.useState(maxSamplesForSpan);
-  const [updating, setUpdating] = React.useState(true);
+  const [xDomain, setXDomain] = useState<AxisDomain>();
+  const [error, setError] = useState<PrometheusAPIError>();
+  const [isDatasetTooBig, setIsDatasetTooBig] = useState(false);
+  const [graphData, setGraphData] = useState<Series[][]>(null);
+  const [samples, setSamples] = useState(maxSamplesForSpan);
+  const [updating, setUpdating] = useState(true);
 
   const [containerRef, width] = useRefWidth();
 
@@ -634,37 +635,37 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
 
   const safeFetch = useSafeFetch();
 
-  const [isStacked, setIsStacked] = React.useState(isStack);
-  const [showDisconnectedValues, setIsShowDisconnectedValues] = React.useState(false);
-  const [isDisconnectedEnabled, setIsDisconnectedEnabled] = React.useState(true);
+  const [isStacked, setIsStacked] = useState(isStack);
+  const [showDisconnectedValues, setIsShowDisconnectedValues] = useState(false);
+  const [isDisconnectedEnabled, setIsDisconnectedEnabled] = useState(true);
 
   const canStack = _.sumBy(graphData, 'length') <= maxStacks;
 
   const [activeNamespace] = useActiveNamespace();
 
   // If provided, `timespan` overrides any existing span setting
-  React.useEffect(() => {
+  useEffect(() => {
     if (timespan) {
       setSpan(timespan);
       setSamples(defaultSamples || getMaxSamplesForSpan(timespan));
     }
   }, [defaultSamples, timespan]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setGraphData(null);
     if (fixedEndTime) {
       setXDomain(getXDomain(fixedEndTime, span));
     }
   }, [fixedEndTime, span]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!fixedEndTime) {
       setXDomain(undefined);
     }
   }, [fixedEndTime]);
 
   // Clear any existing series data when the namespace is changed
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(queryBrowserDeleteAllSeries());
   }, [dispatch, activeNamespace]);
 
@@ -843,12 +844,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     showDisconnectedValues,
   );
 
-  React.useLayoutEffect(
-    () => setUpdating(true),
-    [endTime, activeNamespace, queriesKey, samples, span],
-  );
+  useLayoutEffect(() => setUpdating(true), [endTime, activeNamespace, queriesKey, samples, span]);
 
-  const onSpanChange = React.useCallback(
+  const onSpanChange = useCallback(
     (newSpan: number) => {
       setGraphData(null);
       setXDomain(undefined);
@@ -1051,7 +1049,7 @@ type ErrorProps = {
 };
 
 type GraphEmptyStateProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   title: string;
 };
 
@@ -1080,7 +1078,7 @@ export type QueryBrowserProps = {
   filterLabels?: PrometheusLabels;
   fixedEndTime?: number;
   formatSeriesTitle?: FormatSeriesTitle;
-  GraphLink?: React.ComponentType;
+  GraphLink?: ComponentType;
   hideControls?: boolean;
   isStack?: boolean;
   onZoom?: GraphOnZoom;

--- a/web/src/components/table-pagination.tsx
+++ b/web/src/components/table-pagination.tsx
@@ -1,5 +1,5 @@
 import { Pagination, PaginationVariant, PerPageOptions } from '@patternfly/react-core';
-import * as React from 'react';
+import type { FC } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
 const defaultPerPageOptions: PerPageOptions[] = [10, 20, 50, 100, 200, 500].map((n) => ({
@@ -7,7 +7,7 @@ const defaultPerPageOptions: PerPageOptions[] = [10, 20, 50, 100, 200, 500].map(
   value: n,
 }));
 
-const LocalizedToggleTemplate: React.FC<LocalizedToggleTemplateProps> = ({
+const LocalizedToggleTemplate: FC<LocalizedToggleTemplateProps> = ({
   firstIndex,
   itemCount,
   itemsTitle,
@@ -25,7 +25,7 @@ const LocalizedToggleTemplate: React.FC<LocalizedToggleTemplateProps> = ({
   );
 };
 
-const TablePagination: React.FC<TablePaginationProps> = ({
+const TablePagination: FC<TablePaginationProps> = ({
   itemCount,
   page,
   perPage,

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -1,5 +1,4 @@
 import '@patternfly/patternfly/patternfly.css';
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Link, Route, Routes } from 'react-router-dom-v5-compat';

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "target": "es2020",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "strict": false,
     "noUnusedLocals": true,


### PR DESCRIPTION
### JIRA
[OU-849](https://issues.redhat.com/browse/OU-849) Upgrade jsx pre processor to "jsx": "react-jsx"

### Description 
With the new JSX runtime (React 17+), the React library handles JSX behind the scenes without needing the React variable explicitly in each file.

1. Update `.eslintrc.yml` to ignore the need to have React variable explicitly in each file.
```
  # React 17 doesn't require this anymore
  react/react-in-jsx-scope: off 
```

2. Run [codemod](https://github.com/reactjs/react-codemod?tab=readme-ov-file#update-react-imports) to remove React variable explicitly in each file
```
$ npx codemod react/update-react-imports --target <path>
```