### PR TITLE
NO-JIRA: test: Fix operator sidebar navigation

### DIFF
--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -498,7 +498,11 @@ Cypress.Commands.add('beforeBlockCOO', (MCP: { namespace: string, operatorName: 
     cy.log(`Observability-operator pod is now running in namespace: ${MCP.namespace}`);
   });
 
-  nav.sidenav.clickNavLink(['Ecosystem', 'Installed Operators']);
+  cy.get('#page-sidebar').then(($sidebar) => {
+    const section = $sidebar.text().includes('Ecosystem') ? 'Ecosystem' : 'Operators';
+    cy.clickNavLink([section, 'Installed Operators']);
+  });
+
   cy.byTestID('name-filter-input').should('be.visible').type('Cluster Observability{enter}');
   cy.get('[data-test="status-text"]', { timeout: installTimeoutMilliseconds }).eq(0).should('contain.text', 'Succeeded', { timeout: installTimeoutMilliseconds });
 


### PR DESCRIPTION
Fixes issue in cypress Commands file, which triggered import errors during running tests that install COO.
In addition the change makes the installation process more robust by supporting 4.20 as well as 4.19 UIs. 

Changes:
- Uses cy.clickNavLink command instead of direct nav interaction
- Supports both 'Ecosystem' (4.20) and 'Operators' (4.19) tab names