### PR TITLE
OU-692: Update montioring-plugin to NodeJS v22

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20:1-59 AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-22:9.6-1755075210 AS web-builder
 
 WORKDIR /opt/app-root
 

--- a/Dockerfile.dev-mcp
+++ b/Dockerfile.dev-mcp
@@ -1,6 +1,6 @@
 # mcp (monitoring-console-plugin)
 
-FROM registry.redhat.io/ubi9/nodejs-20:1-59 AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-22:9.6-1755075210 AS web-builder
 
 USER 0
 

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-18:latest AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-22:9.6-1755075210 AS web-builder
 
 WORKDIR /opt/app-root
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,6 +1,6 @@
 # mcp (monitoring-console-plugin)
 
-FROM registry.redhat.io/ubi9/nodejs-20:1-59 AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-22:9.6-1755075210 AS web-builder
 
 USER 0
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20:1-59 AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-22:9.6-1755075210 AS web-builder
 
 USER 0
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -62,7 +62,7 @@
         "@cypress/webpack-preprocessor": "^6.0.2",
         "@types/classnames": "^2.2.7",
         "@types/lodash-es": "^4.17.12",
-        "@types/node": "^17.0.21",
+        "@types/node": "^22.17.2",
         "@types/react": "17.0.83",
         "@types/react-helmet": "^6.1.11",
         "@types/react-router-dom": "^5.3.2",
@@ -4825,10 +4825,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "license": "MIT"
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.13",
@@ -18135,6 +18138,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -85,7 +85,7 @@
     "@cypress/webpack-preprocessor": "^6.0.2",
     "@types/classnames": "^2.2.7",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^17.0.21",
+    "@types/node": "^22.17.2",
     "@types/react": "17.0.83",
     "@types/react-helmet": "^6.1.11",
     "@types/react-router-dom": "^5.3.2",


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/OU-692

### Description 
1. Update the following Dockerfile to contain NodeJS v22 
- Dockerfile.dev
- Dockerfile.dev-mcp
- Dockerfile.konflux
- Dockerfile.mcp
- Dockerfile.test

### Note 
`Dockefile` uses`registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19` to use nodejs v22 in this [PR](https://github.com/openshift-eng/ocp-build-data/pull/6342). 

`Dockerfile.art` use `registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.20` also contains Node v22 noted [here](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.20/streams.yml#L71).



