### PR TITLE
OBSINTA-776: Incident detection tests

### DIFF
--- a/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
+++ b/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
@@ -1,0 +1,59 @@
+/*
+The test verifies the whole lifecycle of the Incident feature, without any external dependencies.
+*/
+import { commonPages } from '../../views/common';
+import { incidentsPage } from '../../views/incidents-page';
+
+// Set constants for the operators that need to be installed for tests.
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+describe('Incidents', () => {
+  before(() => {
+    cy.afterBlockCOO(MCP, MP); // Following cypher best practices, the cleanup is done before the test block
+    cy.beforeBlockCOO(MCP, MP);
+    cy.createKubePodCrashLoopingAlert();
+  });
+
+  after(() => {
+    cy.afterBlockCOO(MCP, MP); // For compatibility with other tests
+  });
+
+  it('Admin Perspective - Incidents tab renders and responds to interactions', () => {
+    cy.log('1.1 Navigate to Alerting → Incidents');
+    incidentsPage.goTo();
+    commonPages.titleShouldHaveText('Incidents');
+  });
+
+  it('Incident with KubePodCrashLooping alert is present in the alerts table', () => {
+    incidentsPage.goTo();
+    commonPages.titleShouldHaveText('Incidents');
+    incidentsPage.clearAllFilters();
+    
+    const intervalMs = 60_000;
+    const maxMinutes = 20; 
+
+    cy.waitUntil(() => incidentsPage.findIncidentWithAlert('KubePodCrashLooping'), { 
+      interval: intervalMs, 
+      timeout: maxMinutes * intervalMs 
+    });
+
+    incidentsPage
+      .elements
+      .alertsTable()
+      .contains('KubePodCrashLooping')
+      .should('exist');
+  });
+});

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -1,8 +1,16 @@
+/*
+The test verifies the basic functionality of the Incidents page and serves
+as a verification that the Incidents View is working as expected.
+
+Currently, it depends on an alert being present in the cluster.
+In the future, mocking requests / injecting alerts should be considered.
+Natural creation of the alert is done in the 00.coo_incidents_e2e.cy.ts test, 
+but takes significant time.
+*/
 
 import { commonPages } from '../../views/common';
 import { incidentsPage } from '../../views/incidents-page';
 
-// Set constants for the operators that need to be installed for tests.
 const MCP = {
   namespace: 'openshift-cluster-observability-operator',
   packageName: 'cluster-observability-operator',
@@ -25,13 +33,14 @@ const ALERT_DESC = 'This is an alert meant to ensure that the entire alerting pi
 const ALERT_SUMMARY = 'An alert that should always be firing to certify that Alertmanager is working properly.'
 describe('Incidents', () => {
   before(() => {
+    cy.afterBlockCOO(MCP, MP); // Following cypher best practices, the cleanup is done before the test block
     cy.beforeBlockCOO(MCP, MP);
-    // TODO: Inject alerts into the database so the behavior is deterministic
   });
 
   after(() => {
-    cy.afterBlockCOO(MCP, MP);
+    cy.afterBlockCOO(MCP, MP); // For compatibility with other tests
   });
+
 
   beforeEach(() => {
 
@@ -65,19 +74,13 @@ describe('Incidents', () => {
 
   it('selecting an incident via chart shows alerts and adds groupId to URL', () => {
     incidentsPage.clearAllFilters();
-    cy.pause();
     incidentsPage.selectIncidentByBarIndex(0);
-    cy.pause();
     cy.url().should('match', /[?&]groupId=/);
-    cy.pause();
     incidentsPage.elements.alertsChartSvg().find('path').should('exist');
-    cy.pause();
   });
 
   it('shows alerts table and allows expanding a row', () => {
-    cy.pause();
     incidentsPage.elements.alertsTable().should('exist');
     incidentsPage.expandRow(0);
-    cy.pause();
   });
 });

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -31,7 +31,7 @@ const NAMESPACE = 'openshift-monitoring';
 const SEVERITY = 'Critical';
 const ALERT_DESC = 'This is an alert meant to ensure that the entire alerting pipeline is functional. This alert is always firing, therefore it should always be firing in Alertmanager and always fire against a receiver. There are integrations with various notification mechanisms that send a notification when this alert is not firing. For example the "DeadMansSnitch" integration in PagerDuty.'
 const ALERT_SUMMARY = 'An alert that should always be firing to certify that Alertmanager is working properly.'
-describe('Incidents', () => {
+describe('BVT: Incidents - UI', () => {
   before(() => {
     cy.afterBlockCOO(MCP, MP); // Following cypher best practices, the cleanup is done before the test block
     cy.beforeBlockCOO(MCP, MP);
@@ -49,37 +49,53 @@ describe('Incidents', () => {
     commonPages.titleShouldHaveText('Incidents');
   });
 
-  it('renders toolbar and toggle charts button', () => {
+  it('1. Admin perspective - Incidents page - Toolbar and charts toggle functionality', () => {
+    cy.log('1.1 Verify toolbar and toggle charts button');
     incidentsPage.elements.toolbar().should('be.visible');
     incidentsPage.elements.toggleChartsButton().should('be.visible');
+    incidentsPage.elements.toggleChartsButton().click();
+    
+    cy.log('1.2 Verify charts are hidden after toggle');
+    incidentsPage.elements.incidentsChartTitle().should('not.exist');
+    incidentsPage.elements.alertsChartTitle().should('not.exist');
+    incidentsPage.elements.toggleChartsButton().click();
   });
 
-  it('sets days filter to 3 days and updates the URL', () => {
+  it('2. Admin perspective - Incidents page - Days filter functionality', () => {
+    cy.log('2.1 Set days filter to 3 days');
     incidentsPage.setDays('3 days');
+    
+    cy.log('2.2 Verify filter and URL update');
     incidentsPage.elements.daysSelect().should('contain.text', '3 days');
     cy.url().should('match', /[?&]days=3\+days/);
   });
 
-  it('toggles Critical filter and updates the URL', () => {
+  it('3. Admin perspective - Incidents page - Critical filter functionality', () => {
+    cy.log('3.1 Clear filters and toggle Critical filter');
     incidentsPage.clearAllFilters();
     incidentsPage.toggleFilter('Critical');
+    
+    cy.log('3.2 Verify URL is updated with incident filters');
     cy.url().should('match', /incidentFilters=.*Critical/);
   });
 
-  it('shows charts and alerts empty state initially', () => {
+  it('4. Admin perspective - Incidents page - Charts and alerts empty state', () => {
+    cy.log('4.1 Verify chart titles are visible');
     incidentsPage.elements.incidentsChartTitle().should('be.visible');
     incidentsPage.elements.alertsChartTitle().should('be.visible');
+    
+    cy.log('4.2 Verify alerts chart shows empty state');
     incidentsPage.elements.alertsChartEmptyState().should('exist');
   });
 
-  it('selecting an incident via chart shows alerts and adds groupId to URL', () => {
+  it('5. Admin perspective - Incidents page - Incident selection and alert details', () => {
+    cy.log('5.1 Select incident and verify alert details');
     incidentsPage.clearAllFilters();
     incidentsPage.selectIncidentByBarIndex(0);
     cy.url().should('match', /[?&]groupId=/);
     incidentsPage.elements.alertsChartSvg().find('path').should('exist');
-  });
 
-  it('shows alerts table and allows expanding a row', () => {
+    cy.log('5.2 Verify alerts table and expand first row');
     incidentsPage.elements.alertsTable().should('exist');
     incidentsPage.expandRow(0);
   });

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -1,0 +1,83 @@
+
+import { commonPages } from '../../views/common';
+import { incidentsPage } from '../../views/incidents-page';
+
+// Set constants for the operators that need to be installed for tests.
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+const ALERTNAME = 'Watchdog';
+const NAMESPACE = 'openshift-monitoring';
+const SEVERITY = 'Critical';
+const ALERT_DESC = 'This is an alert meant to ensure that the entire alerting pipeline is functional. This alert is always firing, therefore it should always be firing in Alertmanager and always fire against a receiver. There are integrations with various notification mechanisms that send a notification when this alert is not firing. For example the "DeadMansSnitch" integration in PagerDuty.'
+const ALERT_SUMMARY = 'An alert that should always be firing to certify that Alertmanager is working properly.'
+describe('Incidents', () => {
+  before(() => {
+    cy.beforeBlockCOO(MCP, MP);
+    // TODO: Inject alerts into the database so the behavior is deterministic
+  });
+
+  after(() => {
+    cy.afterBlockCOO(MCP, MP);
+  });
+
+  beforeEach(() => {
+
+    cy.log('Navigate to Observe → Incidents');
+    incidentsPage.goTo();
+    commonPages.titleShouldHaveText('Incidents');
+  });
+
+  it('renders toolbar and toggle charts button', () => {
+    incidentsPage.elements.toolbar().should('be.visible');
+    incidentsPage.elements.toggleChartsButton().should('be.visible');
+  });
+
+  it('sets days filter to 3 days and updates the URL', () => {
+    incidentsPage.setDays('3 days');
+    incidentsPage.elements.daysSelect().should('contain.text', '3 days');
+    cy.url().should('match', /[?&]days=3\+days/);
+  });
+
+  it('toggles Critical filter and updates the URL', () => {
+    incidentsPage.clearAllFilters();
+    incidentsPage.toggleFilter('Critical');
+    cy.url().should('match', /incidentFilters=.*Critical/);
+  });
+
+  it('shows charts and alerts empty state initially', () => {
+    incidentsPage.elements.incidentsChartTitle().should('be.visible');
+    incidentsPage.elements.alertsChartTitle().should('be.visible');
+    incidentsPage.elements.alertsChartEmptyState().should('exist');
+  });
+
+  it('selecting an incident via chart shows alerts and adds groupId to URL', () => {
+    incidentsPage.clearAllFilters();
+    cy.pause();
+    incidentsPage.selectIncidentByBarIndex(0);
+    cy.pause();
+    cy.url().should('match', /[?&]groupId=/);
+    cy.pause();
+    incidentsPage.elements.alertsChartSvg().find('path').should('exist');
+    cy.pause();
+  });
+
+  it('shows alerts table and allows expanding a row', () => {
+    cy.pause();
+    incidentsPage.elements.alertsTable().should('exist');
+    incidentsPage.expandRow(0);
+    cy.pause();
+  });
+});

--- a/web/cypress/fixtures/incidents/pod_crash_loop.yaml
+++ b/web/cypress/fixtures/incidents/pod_crash_loop.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: crash-loop
+ namespace: openshift-monitoring
+spec:
+ replicas: 1
+ selector:
+   matchLabels:
+     app: crash-loop
+ template:
+   metadata:
+     labels:
+       app: crash-loop
+   spec:
+     containers:
+     - name: crash-loop
+       image: busybox
+       command: ["sh", "-c", "exit 1"]  # Exit immediately with a failure

--- a/web/cypress/fixtures/incidents/prometheus_rule_pod_crash_loop.yaml
+++ b/web/cypress/fixtures/incidents/prometheus_rule_pod_crash_loop.yaml
@@ -12,7 +12,7 @@ spec:
  groups:
  - name: kubernetes-apps
    rules:
-   - alert: KubePodCrashLooping
+   - alert: {{ALERT_NAME}}
      annotations:
        description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
          }}) is in waiting state (reason: "CrashLoopBackOff").'

--- a/web/cypress/fixtures/incidents/prometheus_rule_pod_crash_loop.yaml
+++ b/web/cypress/fixtures/incidents/prometheus_rule_pod_crash_loop.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+ labels:
+   app.kubernetes.io/name: kube-prometheus
+   app.kubernetes.io/part-of: openshift-monitoring
+   prometheus: k8s
+   role: alert-rules
+ name: kubernetes-monitoring-podcrash-rules
+ namespace: openshift-monitoring
+spec:
+ groups:
+ - name: kubernetes-apps
+   rules:
+   - alert: KubePodCrashLooping
+     annotations:
+       description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+         }}) is in waiting state (reason: "CrashLoopBackOff").'
+       summary: Pod is crash looping.
+     expr: |
+       max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m]) >= 1
+     for: 5m
+     labels:
+       severity: warning

--- a/web/cypress/support/index.ts
+++ b/web/cypress/support/index.ts
@@ -1,6 +1,8 @@
 import './nav';
 import './selectors';
 import './commands';
+import './alert-injection';
+import './prometheus-query-mocks';
 
 export const checkErrors = () =>
   cy.window().then((win) => {

--- a/web/cypress/support/index.ts
+++ b/web/cypress/support/index.ts
@@ -1,8 +1,6 @@
 import './nav';
 import './selectors';
 import './commands';
-import './alert-injection';
-import './prometheus-query-mocks';
 
 export const checkErrors = () =>
   cy.window().then((win) => {

--- a/web/cypress/support/index.ts
+++ b/web/cypress/support/index.ts
@@ -7,10 +7,17 @@ export const checkErrors = () =>
     assert.isTrue(!win.windowError, win.windowError);
   });
 
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from failing the test
-    // on a JavaScript exception
-    if (err.message.includes('ResizeObserver loop completed with undelivered notifications')) {
-      return false
-    }
-  });
+
+  // Ignore benign ResizeObserver errors globally so they don't fail tests
+// See: https://docs.cypress.io/api/cypress-api/catalog-of-events#Uncaught-Exceptions
+Cypress.on('uncaught:exception', (err) => {
+  const message = err?.message || String(err || '');
+  if (
+    message.includes('ResizeObserver loop limit exceeded') ||
+    message.includes('ResizeObserver loop completed with undelivered notifications') ||
+    message.includes('ResizeObserver')
+  ) {
+    return false;
+  }
+  // allow other errors to fail the test
+});

--- a/web/cypress/tsconfig.json
+++ b/web/cypress/tsconfig.json
@@ -4,5 +4,8 @@
     "lib": ["es5", "dom"],
     "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts"]
+
+  "include": [
+    "**/*.ts"
+  ]
 }

--- a/web/cypress/views/incidents-page.ts
+++ b/web/cypress/views/incidents-page.ts
@@ -1,0 +1,78 @@
+import { nav } from './nav';
+
+export const incidentsPage = {
+  goTo: () => {
+    cy.log('incidentsPage.goTo');
+    nav.sidenav.clickNavLink(['Observe', 'Incidents']);
+  },
+
+  setDays: (value: '1 day' | '3 days' | '7 days' | '15 days') => {
+    cy.log('incidentsPage.setDays');
+    incidentsPage.elements.daysSelect().click();
+    cy.contains(value).should('be.visible').click();
+  },
+
+  toggleFilter: (name: 'Critical' | 'Warning' | 'Informative' | 'Firing' | 'Resolved') => {
+    cy.log('incidentsPage.toggleFilter');
+    incidentsPage.elements.filtersSelect().click();
+    cy.contains('label', name)
+      .find('input[type="checkbox"]')
+      .click({ force: true });  
+    incidentsPage.elements.filtersSelect().click();
+  },
+
+  clearAllFilters: () => {
+    cy.log('incidentsPage.clearAllFilters');
+    incidentsPage.elements.clearAllFiltersButton().click({ force: true });
+  },
+
+  toggleCharts: () => {
+    cy.log('incidentsPage.toggleCharts');
+    incidentsPage.elements.toggleChartsButton().click();
+  },
+
+  selectIncidentByBarIndex: (index = 0) => {
+    cy.log('incidentsPage.selectIncidentByBarIndex');
+    incidentsPage.elements.incidentsChartCard()
+      .find('path[role="presentation"]')
+      .eq(index)
+      .click({ force: true });
+  },
+
+  expandRow: (rowIndex = 0) => {
+    cy.log('incidentsPage.expandRow');
+    incidentsPage.elements.alertsTable()
+      .find('tbody')
+      .eq(rowIndex)
+      .within(() => {
+        cy.get('[aria-label="Details"], button[aria-expanded], button.pf-m-plain')
+          .first()
+          .click({ force: true });
+      });
+  },
+
+  // Centralized element selectors - all selectors defined in one place
+  elements: {
+    // Page structure
+    toolbar: () => cy.get('#toolbar-with-filter'),
+
+    // Controls and filters
+    daysSelect: () => cy.get('button[data-ouia-component-id="OUIA-Generated-MenuToggle-4"]'),
+    filtersSelect: () => cy.get('button[data-ouia-component-id="OUIA-Generated-MenuToggle-5"]'),
+    clearAllFiltersButton: () => cy.contains('button', 'Clear all filters'),
+    toggleChartsButton: () => cy.contains('button', /Hide graph|Show graph/),
+
+    // Charts and visualizations  
+    incidentsChartTitle: () => cy.contains('Incidents Timeline'),
+    incidentsChartCard: () => cy.contains('Incidents Timeline').closest('.pf-v6-c-card'),
+    incidentsChartSvg: () => incidentsPage.elements.incidentsChartCard().find('svg'),
+    
+    alertsChartTitle: () => cy.contains('Alerts Timeline'),
+    alertsChartCard: () => cy.contains('Alerts Timeline').closest('.pf-v6-c-card'),
+    alertsChartSvg: () => incidentsPage.elements.alertsChartCard().find('svg'),
+    alertsChartEmptyState: () => cy.contains('Select an incident in the chart above to see alerts.').closest('.pf-v6-c-card'),
+
+    // Tables and data
+    alertsTable: () => cy.get('[aria-label="alerts-table"]'),
+  },
+};

--- a/web/cypress/views/incidents-page.ts
+++ b/web/cypress/views/incidents-page.ts
@@ -61,19 +61,25 @@ export const incidentsPage = {
 
 
   findIncidentWithAlert: (alertName: string): Cypress.Chainable<boolean> => {
+    cy.reload();
     cy.log(`incidentsPage.findIncidentWithAlert: ${alertName}`);
+    // Bars are sometimes not loaded immidiately, this refreshes
+    // the charts and ensures the bars are loaded if present
+    incidentsPage.setDays('1 day');
+    
     return incidentsPage.elements.incidentsChartCard()
       .find('path[role="presentation"]')
       .then(($bars) => {
         const totalBars = $bars.length;
         if (totalBars <= 3) { // 3 paths are always present in the legend,
         // their parent is g without presentation label opposed ot the proper bars
-          cy.task('log', 'No bars found in incidents chart');
+          cy.log('No bars found in incidents chart');
           return cy.wrap(false);
         }
 
         const tryIndex = (index: number): Cypress.Chainable<boolean> => {
           if (index >= totalBars - 3) {
+            cy.log("Index out of bounds for bars in incidents chart");
             return cy.wrap(false);
           }
 
@@ -89,6 +95,7 @@ export const incidentsPage = {
                 return cy.wrap(true);
               }
               // Expand a row if present to surface nested details
+              // Currently expects only one row to be present
               incidentsPage.expandRow(0);
               return incidentsPage.elements.alertsTable().invoke('text').then((text2) => {
                 if (String(text2).includes(alertName)) {


### PR DESCRIPTION
**Draft PR: Incident Detection E2E Tests Refactor and Expansion**

This Pull Request introduces initial UI tests for the incident detection feature. Its primary purpose is to serve as a proof of concept, a basic smoke test, and to demonstrate the capabilities for incident page interaction within the testing framework.

### Key Changes:

* **Initial Incident Detection E2E Tests**

    * `views/incidents-page.ts` includes **Cypher selectors**, which facilitate operations on the incident page elements.

    * `e2e/incidents/01.incidents.cy.ts` incorporates tests designed to verify the setup of the incidents plugin and to interact with the various elements present on the page. This test is dependent on existing alerts to be present in the system at the moment.

    * `e2e/incidents/00.incidents.cy.ts` is truly e2e test withou external dependencies, it deploys a pod configured to fail upon startup, thereby generating a `KubePodCrashLoop` alert. The test subsequently verifies that this alert appears within the system.

    * **Error handling has been implemented in `index.ts`** to catch the 'ResizeObserver loop limit' exception, which is otherwise triggered by the incident page.

    * `support/commands.ts`  includes a command for **deploying failing pods**, along with the necessary label additions to ensure proper incident detection functionality during setup.

    * `fixtures/incidents/` contains the **YAML files required for the failing pod deployment**, including a custom alert rule.

This commit lays a foundational groundwork for further automated testing of the incident detection system. It is marked as a draft, I would like to hear feedback on it to know that this is the right direction to take.