### PR TITLE
OBSINTA-463: Rename the cluster health metrics

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -252,7 +252,7 @@ const IncidentsPage = () => {
           const response = await fetchDataForIncidentsAndAlerts(
             safeFetch,
             range,
-            'cluster:health:components:map',
+            'cluster_health_components_map',
           );
           return response.data.result;
         }),
@@ -288,7 +288,7 @@ const IncidentsPage = () => {
           const response = await fetchDataForIncidentsAndAlerts(
             safeFetch,
             range,
-            `cluster:health:components:map{group_id='${selectedGroupId}'}`,
+            `cluster_health_components_map{group_id='${selectedGroupId}'}`,
           );
           return response.data.result;
         }),


### PR DESCRIPTION
This updates/fixes the incident metric name. This PR depends on https://github.com/openshift/cluster-health-analyzer/pull/50 and should be merged after. 