### PR TITLE
feat(RHINENG-20424): improved filters for severity and state

### DIFF
--- a/web/src/actions/observe.ts
+++ b/web/src/actions/observe.ts
@@ -38,6 +38,7 @@ export enum ActionType {
   SetAlertsAreLoading = 'setAlertsAreLoading',
   SetIncidentsChartSelection = 'setIncidentsChartSelection',
   SetFilteredIncidentsData = 'setFilteredIncidentsData',
+  SetIncidentPageFilterType = 'setIncidentPageFilterType',
 }
 
 export type Perspective = 'admin' | 'dev' | 'acm' | 'virtualization-perspective';
@@ -160,6 +161,9 @@ export const setIncidentsChartSelection = (incidentsChartSelectedId) =>
 export const setFilteredIncidentsData = (filteredIncidentsData) =>
   action(ActionType.SetFilteredIncidentsData, filteredIncidentsData);
 
+export const setIncidentPageFilterType = (filterTypeSelected) =>
+  action(ActionType.SetIncidentPageFilterType, filterTypeSelected);
+
 type Actions = {
   alertingErrored: typeof alertingErrored;
   alertingLoaded: typeof alertingLoaded;
@@ -198,6 +202,7 @@ type Actions = {
   setAlertsAreLoading: typeof setAlertsAreLoading;
   setIncidentsChartSelection: typeof setIncidentsChartSelection;
   setFilteredIncidentsData: typeof setFilteredIncidentsData;
+  setIncidentPageFilterType: typeof setIncidentPageFilterType;
 };
 
 export type ObserveAction = Action<Actions>;

--- a/web/src/components/Incidents/ToolbarItemFilter.tsx
+++ b/web/src/components/Incidents/ToolbarItemFilter.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import {
+  ToolbarItem,
+  ToolbarFilter,
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  Badge,
+} from '@patternfly/react-core';
+import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
+import { isIncidentFilter } from './utils'; // Assuming this utility function exists
+
+interface IncidentFilterToolbarItemProps {
+  categoryName: string;
+  toggleLabel: string;
+  options: {
+    value: string;
+    description: string;
+  }[];
+  incidentsActiveFilters: {
+    severity: string[];
+    state: string[];
+  };
+  onDeleteIncidentFilterChip: (
+    category: string,
+    chip: string,
+    activeFilters: any,
+    dispatch: any,
+  ) => void;
+  onDeleteGroupIncidentFilterChip: (activeFilters: any, dispatch: any, category: any) => void;
+  incidentFilterIsExpanded: boolean;
+  onIncidentFiltersSelect: (
+    event: React.MouseEvent | React.ChangeEvent,
+    selection: string | undefined,
+    dispatch: any,
+    activeFilters: any,
+    categoryFilterType: string,
+  ) => void;
+  setIncidentIsExpanded: (isOpen: boolean) => void;
+  onIncidentFilterToggle: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>;
+  dispatch: any;
+  showToolbarItem?: boolean;
+}
+
+const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
+  categoryName,
+  toggleLabel,
+  options,
+  incidentsActiveFilters,
+  onDeleteIncidentFilterChip,
+  onDeleteGroupIncidentFilterChip,
+  incidentFilterIsExpanded,
+  onIncidentFiltersSelect,
+  setIncidentIsExpanded,
+  onIncidentFilterToggle,
+  dispatch,
+  showToolbarItem,
+}) => {
+  return (
+    <ToolbarItem>
+      <ToolbarFilter
+        showToolbarItem={showToolbarItem}
+        labels={incidentsActiveFilters[categoryName.toLowerCase()]}
+        deleteLabel={(category, chip) => {
+          if (isIncidentFilter(chip) && typeof category === 'string') {
+            onDeleteIncidentFilterChip(category, chip, incidentsActiveFilters, dispatch);
+          }
+        }}
+        deleteLabelGroup={(category) =>
+          onDeleteGroupIncidentFilterChip(incidentsActiveFilters, dispatch, category)
+        }
+        categoryName={categoryName}
+      >
+        <Select
+          id={`${categoryName}-select`.toLowerCase()}
+          role="menu"
+          aria-label="Filters"
+          isOpen={incidentFilterIsExpanded}
+          selected={incidentsActiveFilters[categoryName.toLowerCase()]}
+          onSelect={(event, selection) => {
+            if (isIncidentFilter(selection)) {
+              onIncidentFiltersSelect(
+                event,
+                selection,
+                dispatch,
+                incidentsActiveFilters,
+                categoryName.toLowerCase(),
+              );
+            }
+          }}
+          onOpenChange={(isOpen) => setIncidentIsExpanded(isOpen)}
+          toggle={(toggleRef) => (
+            <MenuToggle
+              ref={toggleRef}
+              onClick={onIncidentFilterToggle}
+              isExpanded={incidentFilterIsExpanded}
+              icon={<FilterIcon />}
+              badge={
+                Object.entries(incidentsActiveFilters[categoryName.toLowerCase()]).length > 0 ? (
+                  <Badge isRead>
+                    {Object.entries(incidentsActiveFilters[categoryName.toLowerCase()]).length}
+                  </Badge>
+                ) : undefined
+              }
+            >
+              {toggleLabel}
+            </MenuToggle>
+          )}
+          shouldFocusToggleOnSelect
+        >
+          <SelectList>
+            {options.map((option) => (
+              <SelectOption
+                key={option.value}
+                value={option.value}
+                isSelected={incidentsActiveFilters[categoryName.toLowerCase()].includes(
+                  option.value,
+                )}
+                description={option.description}
+                hasCheckbox
+              >
+                {option.value}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </ToolbarFilter>
+    </ToolbarItem>
+  );
+};
+
+export default IncidentFilterToolbarItem;
+
+export const severityOptions = [
+  { value: 'Critical', description: 'The incident is critical.' },
+  { value: 'Warning', description: 'The incident might lead to critical.' },
+  { value: 'Informative', description: 'The incident is not critical.' },
+];
+
+export const stateOptions = [
+  { value: 'Firing', description: 'The incident is currently firing.' },
+  { value: 'Resolved', description: 'The incident is not currently firing.' },
+];

--- a/web/src/components/Incidents/model.ts
+++ b/web/src/components/Incidents/model.ts
@@ -58,6 +58,7 @@ export type Severity = 'critical' | 'warning' | 'info';
 
 export type IncidentFiltersCombined = {
   days: Array<DaysFilters>;
-  incidentFilters: Array<IncidentFilters>;
   groupId?: Array<string>;
+  severity?: Array<string>;
+  state?: Array<string>;
 };

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -317,7 +317,7 @@ export function generateDateArray(days: number): Array<number> {
  *
  * Example usage:
  * ```javascript
- * const filters = { incidentFilters: ["Critical", "Firing"] };
+ * const filters = { severity: ["Critical"], state: ["Firing"] };
  * const filteredIncidents = filterIncident(filters, incidents);
  * ```
  */
@@ -331,34 +331,22 @@ export function filterIncident(filters: IncidentFiltersCombined, incidents: Arra
   };
 
   return incidents.filter((incident) => {
-    // If no filters are applied, return all incidents
-    if (!filters.incidentFilters.length) {
-      return incident;
+    if (!filters.severity.length && !filters.state.length) {
+      return true;
     }
 
-    // Normalize user-provided filters to match keys in conditions
-    const normalizedFilters = filters.incidentFilters.map((filter) => filter.trim());
-
-    // Separate filters into categories
-    const severityFilters = ['Critical', 'Warning', 'Informative'].filter((key) =>
-      normalizedFilters.includes(key),
-    );
-    const statusFilters = ['Firing', 'Resolved'].filter((key) => normalizedFilters.includes(key));
-
-    // Match severity filters (OR behavior within the category)
     const isSeverityMatch =
-      severityFilters.length > 0
-        ? severityFilters.some((filter) => incident[conditions[filter]] === true)
+      filters.severity.length > 0
+        ? filters.severity.some((filter) => incident[conditions[filter]] === true)
         : true; // True if no severity filters
 
-    // Match status filters (OR behavior within the category)
-    const isStatusMatch =
-      statusFilters.length > 0
-        ? statusFilters.some((filter) => incident[conditions[filter]] === true)
-        : true; // True if no status filters
+    const isStateMatch =
+      filters.state.length > 0
+        ? filters.state.some((filter) => incident[conditions[filter]] === true)
+        : true; // True if no state filters
 
     // Combine conditions with AND behavior between categories
-    return isSeverityMatch && isStatusMatch;
+    return isSeverityMatch && isStateMatch;
   });
 }
 
@@ -368,12 +356,24 @@ export const onDeleteIncidentFilterChip = (
   filters: IncidentFiltersCombined,
   setFilters,
 ) => {
-  if (type === 'Filters') {
+  if (type === 'State') {
     setFilters(
       setIncidentsActiveFilters({
         incidentsActiveFilters: {
-          incidentFilters: filters.incidentFilters.filter((fil) => fil !== id),
+          severity: filters.severity,
           days: filters.days,
+          state: filters.state.filter((fil) => fil !== id),
+        },
+      }),
+    );
+  }
+  if (type === 'Severity') {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: filters.severity.filter((fil) => fil !== id),
+          days: filters.days,
+          state: filters.state,
         },
       }),
     );
@@ -381,23 +381,51 @@ export const onDeleteIncidentFilterChip = (
     setFilters(
       setIncidentsActiveFilters({
         incidentsActiveFilters: {
-          incidentFilters: [],
+          severity: [],
           days: ['7 days'],
+          state: [],
         },
       }),
     );
   }
 };
 
-export const onDeleteGroupIncidentFilterChip = (filters: IncidentFiltersCombined, setFilters) => {
-  setFilters(
-    setIncidentsActiveFilters({
-      incidentsActiveFilters: {
-        incidentFilters: [],
-        days: filters.days,
-      },
-    }),
-  );
+export const onDeleteGroupIncidentFilterChip = (
+  filters: IncidentFiltersCombined,
+  setFilters,
+  category,
+) => {
+  if (category === 'State') {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: filters.severity,
+          days: filters.days,
+          state: [],
+        },
+      }),
+    );
+  } else if (category === 'Severity') {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: [],
+          days: filters.days,
+          state: filters.state,
+        },
+      }),
+    );
+  } else {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: [],
+          days: filters.days,
+          state: [],
+        },
+      }),
+    );
+  }
 };
 
 export const makeIncidentUrlParams = (
@@ -437,7 +465,7 @@ export const changeDaysFilter = (
 ) => {
   dispatch(
     setIncidentsActiveFilters({
-      incidentsActiveFilters: { days: [days], incidentFilters: filters.incidentFilters },
+      incidentsActiveFilters: { days: [days], severity: filters.severity, state: filters.state },
     }),
   );
 };
@@ -447,31 +475,29 @@ export const onIncidentFiltersSelect = (
   selection: IncidentFilters,
   dispatch,
   incidentsActiveFilters: IncidentFiltersCombined,
+  filterCategoryType: string,
 ) => {
-  onSelect(event, selection, dispatch, incidentsActiveFilters);
+  onSelect(event, selection, dispatch, incidentsActiveFilters, filterCategoryType);
 };
 
-const onSelect = (
-  event,
-  selection: IncidentFilters,
-  dispatch,
-  incidentsActiveFilters: IncidentFiltersCombined,
-) => {
+const onSelect = (event, selection, dispatch, incidentsActiveFilters, filterCategoryType) => {
   const checked = event.target.checked;
 
-  dispatch((dispatch) => {
-    const prevSelections = incidentsActiveFilters.incidentFilters || [];
+  dispatch(() => {
+    const targetArray = incidentsActiveFilters[filterCategoryType] || [];
+    const newFilters = { ...incidentsActiveFilters };
 
-    const updatedSelections = checked
-      ? [...prevSelections, selection]
-      : prevSelections.filter((value) => value !== selection);
+    if (checked) {
+      if (!targetArray.includes(selection)) {
+        newFilters[filterCategoryType] = [...targetArray, selection];
+      }
+    } else {
+      newFilters[filterCategoryType] = targetArray.filter((value) => value !== selection);
+    }
 
     dispatch(
       setIncidentsActiveFilters({
-        incidentsActiveFilters: {
-          ...incidentsActiveFilters,
-          incidentFilters: updatedSelections,
-        },
+        incidentsActiveFilters: newFilters,
       }),
     );
   });
@@ -480,7 +506,7 @@ const onSelect = (
 export const parseUrlParams = (search) => {
   const params = new URLSearchParams(search);
   const result: { [key: string]: any } = {};
-  const arrayKeys = ['days', 'incidentFilters', 'groupId'];
+  const arrayKeys = ['days', 'groupId', 'severity', 'state'];
 
   params.forEach((value, key) => {
     if (arrayKeys.includes(key)) {

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -92,12 +92,15 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         incidentsChartSelectedId: '',
         incidentsInitialState: {
           days: ['7 days'],
-          incidentFilters: ['Critical', 'Warning', 'Firing'],
+          severity: ['Critical', 'Warning'],
+          state: ['Firing'],
         },
         incidentsActiveFilters: {
           days: [],
-          incidentFilters: [],
+          severity: [],
+          state: [],
         },
+        incidentPageFilterType: 'Severity',
         groupId: '',
       }),
     });
@@ -349,6 +352,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       return state.setIn(
         ['incidentsData', 'filteredIncidentsData'],
         action.payload.filteredIncidentsData,
+      );
+    }
+
+    case ActionType.SetIncidentPageFilterType: {
+      return state.setIn(
+        ['incidentsData', 'incidentPageFilterType'],
+        action.payload.incidentPageFilterType,
       );
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-20424

Mocks
https://www.figma.com/proto/b8DEWJHPd3hrn1F0Hxl80t/Incidents---Alert-grouping?page-id=0%3A1&node-id=1275-2757&viewport=834%2C-2626%2C0.49&t=OOTxxjQc9ZXntUwg-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1170%3A4992&fuid=1352985364760770809

This is the start of the implementation of new filters for the Incidents page:
1) I added a filter Type "filter/switch" that allows us to switch between different filters
2) I separated the Severity and State filters into 2 different filters. Now, when you select them, they create their own filter chip groups with "Severity" and "State" names.
3) I updated the filtering logic according to the new changes.
4) I updated the state logic according to the new changes.
5) I updated the filter chip deletion logic according to the new changes.