### PR TITLE
RHINENG-20424: Incident ID filter for the Incidents Page

### DIFF
--- a/web/src/actions/observe.ts
+++ b/web/src/actions/observe.ts
@@ -32,7 +32,6 @@ export enum ActionType {
   ShowGraphs = 'showGraphs',
   SetIncidents = 'setIncidents',
   SetIncidentsActiveFilters = 'setIncidentsActiveFilters',
-  SetChooseIncident = 'setChooseIncident',
   SetAlertsData = 'setAlertsData',
   SetAlertsTableData = 'setAlertsTableData',
   SetAlertsAreLoading = 'setAlertsAreLoading',
@@ -145,8 +144,6 @@ export const setIncidents = (incidents) => action(ActionType.SetIncidents, incid
 export const setIncidentsActiveFilters = (incidentsActiveFilters) =>
   action(ActionType.SetIncidentsActiveFilters, incidentsActiveFilters);
 
-export const setChooseIncident = (groupId) => action(ActionType.SetChooseIncident, groupId);
-
 export const setAlertsData = (alertsData) => action(ActionType.SetAlertsData, alertsData);
 
 export const setAlertsTableData = (alertsTableData) =>
@@ -196,7 +193,6 @@ type Actions = {
   showGraphs: typeof showGraphs;
   setIncidents: typeof setIncidents;
   setIncidentsActiveFilters: typeof setIncidentsActiveFilters;
-  setChooseIncident: typeof setChooseIncident;
   setAlertsData: typeof setAlertsData;
   setAlertsTableData: typeof setAlertsTableData;
   setAlertsAreLoading: typeof setAlertsAreLoading;

--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -459,37 +459,30 @@ const IncidentsPage = () => {
                   </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarItem align={{ default: 'alignEnd' }}>
-                  <Stack>
-                    <StackItem>
-                      <span>Time range</span>
-                    </StackItem>
-                    <StackItem>
-                      <Select
-                        id="time-range-select"
-                        isOpen={daysFilterIsExpanded}
-                        selected={incidentsActiveFilters.days[0]}
-                        onSelect={onSelect}
-                        onOpenChange={(isOpen) => setDaysFilterIsExpanded(isOpen)}
-                        toggle={(toggleRef) => (
-                          <MenuToggle
-                            ref={toggleRef}
-                            onClick={onToggleClick}
-                            isExpanded={daysFilterIsExpanded}
-                          >
-                            {`Last ${incidentsActiveFilters.days[0]}`}
-                          </MenuToggle>
-                        )}
-                        shouldFocusToggleOnSelect
+                  <Select
+                    id="time-range-select"
+                    isOpen={daysFilterIsExpanded}
+                    selected={incidentsActiveFilters.days[0]}
+                    onSelect={onSelect}
+                    onOpenChange={(isOpen) => setDaysFilterIsExpanded(isOpen)}
+                    toggle={(toggleRef) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={onToggleClick}
+                        isExpanded={daysFilterIsExpanded}
                       >
-                        <SelectList>
-                          <SelectOption value="1 day">{t('Last 1 day')}</SelectOption>
-                          <SelectOption value="3 days">{t('Last 3 days')}</SelectOption>
-                          <SelectOption value="7 days">{t('Last 7 days')}</SelectOption>
-                          <SelectOption value="15 days">{t('Last 15 days')}</SelectOption>
-                        </SelectList>
-                      </Select>
-                    </StackItem>
-                  </Stack>
+                        {`Last ${incidentsActiveFilters.days[0]}`}
+                      </MenuToggle>
+                    )}
+                    shouldFocusToggleOnSelect
+                  >
+                    <SelectList>
+                      <SelectOption value="1 day">{t('Last 1 day')}</SelectOption>
+                      <SelectOption value="3 days">{t('Last 3 days')}</SelectOption>
+                      <SelectOption value="7 days">{t('Last 7 days')}</SelectOption>
+                      <SelectOption value="15 days">{t('Last 15 days')}</SelectOption>
+                    </SelectList>
+                  </Select>
                 </ToolbarItem>
               </ToolbarContent>
             </Toolbar>

--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -44,7 +44,6 @@ import {
   setAlertsAreLoading,
   setAlertsData,
   setAlertsTableData,
-  setChooseIncident,
   setFilteredIncidentsData,
   setIncidentPageFilterType,
   setIncidents,
@@ -157,13 +156,6 @@ const IncidentsPage = () => {
           },
         }),
       );
-      if (urlParams?.groupId?.length > 0) {
-        dispatch(
-          setChooseIncident({
-            groupId: urlParams?.groupId?.at(0),
-          }),
-        );
-      }
     } else {
       // If no URL parameters exist, set the URL based on incidentsInitialState
       updateBrowserUrl(incidentsInitialState);
@@ -187,7 +179,11 @@ const IncidentsPage = () => {
         filteredIncidentsData: filterIncident(incidentsActiveFilters, incidents),
       }),
     );
-  }, [incidentsActiveFilters.state, incidentsActiveFilters.severity]);
+  }, [
+    incidentsActiveFilters.state,
+    incidentsActiveFilters.severity,
+    incidentsActiveFilters.groupId,
+  ]);
 
   const now = Date.now();
   const safeFetch = useSafeFetch();
@@ -334,7 +330,7 @@ const IncidentsPage = () => {
             <Spinner aria-label="incidents-chart-spinner" />
           </Bullseye>
         ) : (
-          <PageSection hasBodyWrapper={false}>
+          <PageSection hasBodyWrapper={false} className="incidents-page-main-section">
             <Toolbar
               id="toolbar-with-filter"
               collapseListedFiltersBreakpoint="xl"
@@ -342,9 +338,10 @@ const IncidentsPage = () => {
                 dispatch(
                   setIncidentsActiveFilters({
                     incidentsActiveFilters: {
+                      ...incidentsActiveFilters,
                       severity: [],
-                      days: ['7 days'],
                       state: [],
+                      groupId: [],
                     },
                   }),
                 )

--- a/web/src/components/Incidents/ToolbarItemFilter.tsx
+++ b/web/src/components/Incidents/ToolbarItemFilter.tsx
@@ -8,8 +8,7 @@ import {
   MenuToggle,
   Badge,
 } from '@patternfly/react-core';
-import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
-import { getFilterKey } from './utils'; // Assuming this utility function exists
+import { getFilterKey } from './utils';
 
 interface IncidentFilterToolbarItemProps {
   categoryName: string;
@@ -97,9 +96,9 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
               ref={toggleRef}
               onClick={onIncidentFilterToggle}
               isExpanded={incidentFilterIsExpanded}
-              icon={<FilterIcon />}
               badge={
-                Object.entries(incidentsActiveFilters[getFilterKey(categoryName)]).length > 0 ? (
+                Object.entries(incidentsActiveFilters?.[getFilterKey(categoryName)] || {}).length >
+                0 ? (
                   <Badge isRead>
                     {Object.entries(incidentsActiveFilters[getFilterKey(categoryName)]).length}
                   </Badge>

--- a/web/src/components/Incidents/ToolbarItemFilter.tsx
+++ b/web/src/components/Incidents/ToolbarItemFilter.tsx
@@ -119,7 +119,7 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
                   option.value,
                 )}
                 description={option?.description}
-                hasCheckbox
+                hasCheckbox={categoryName === 'Incident ID' ? false : true}
               >
                 {option.value}
               </SelectOption>

--- a/web/src/components/Incidents/ToolbarItemFilter.tsx
+++ b/web/src/components/Incidents/ToolbarItemFilter.tsx
@@ -9,18 +9,20 @@ import {
   Badge,
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
-import { isIncidentFilter } from './utils'; // Assuming this utility function exists
+import { getFilterKey } from './utils'; // Assuming this utility function exists
 
 interface IncidentFilterToolbarItemProps {
   categoryName: string;
   toggleLabel: string;
   options: {
     value: string;
-    description: string;
+    description?: string;
   }[];
   incidentsActiveFilters: {
     severity: string[];
     state: string[];
+    days: string[];
+    groupId: string[];
   };
   onDeleteIncidentFilterChip: (
     category: string,
@@ -61,9 +63,9 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
     <ToolbarItem>
       <ToolbarFilter
         showToolbarItem={showToolbarItem}
-        labels={incidentsActiveFilters[categoryName.toLowerCase()]}
+        labels={incidentsActiveFilters[getFilterKey(categoryName)]}
         deleteLabel={(category, chip) => {
-          if (isIncidentFilter(chip) && typeof category === 'string') {
+          if (typeof category === 'string' && typeof chip === 'string') {
             onDeleteIncidentFilterChip(category, chip, incidentsActiveFilters, dispatch);
           }
         }}
@@ -77,9 +79,9 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
           role="menu"
           aria-label="Filters"
           isOpen={incidentFilterIsExpanded}
-          selected={incidentsActiveFilters[categoryName.toLowerCase()]}
+          selected={incidentsActiveFilters[getFilterKey(categoryName)]}
           onSelect={(event, selection) => {
-            if (isIncidentFilter(selection)) {
+            if (typeof selection === 'string') {
               onIncidentFiltersSelect(
                 event,
                 selection,
@@ -97,9 +99,9 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
               isExpanded={incidentFilterIsExpanded}
               icon={<FilterIcon />}
               badge={
-                Object.entries(incidentsActiveFilters[categoryName.toLowerCase()]).length > 0 ? (
+                Object.entries(incidentsActiveFilters[getFilterKey(categoryName)]).length > 0 ? (
                   <Badge isRead>
-                    {Object.entries(incidentsActiveFilters[categoryName.toLowerCase()]).length}
+                    {Object.entries(incidentsActiveFilters[getFilterKey(categoryName)]).length}
                   </Badge>
                 ) : undefined
               }
@@ -114,10 +116,10 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
               <SelectOption
                 key={option.value}
                 value={option.value}
-                isSelected={incidentsActiveFilters[categoryName.toLowerCase()].includes(
+                isSelected={(incidentsActiveFilters[getFilterKey(categoryName)] ?? []).includes(
                   option.value,
                 )}
-                description={option.description}
+                description={option?.description}
                 hasCheckbox
               >
                 {option.value}

--- a/web/src/components/Incidents/incidents-styles.css
+++ b/web/src/components/Incidents/incidents-styles.css
@@ -29,3 +29,7 @@
 .incidents-page-main-section.pf-v6-c-page__main-section {
   gap: 0;
 }
+
+.pf-m-hidden {
+  display: none;
+}

--- a/web/src/components/Incidents/incidents-styles.css
+++ b/web/src/components/Incidents/incidents-styles.css
@@ -25,3 +25,7 @@
   margin-top: -1px;
   width: 0;
 }
+
+.incidents-page-main-section.pf-v6-c-page__main-section {
+  gap: 0;
+}

--- a/web/src/components/Incidents/model.ts
+++ b/web/src/components/Incidents/model.ts
@@ -62,3 +62,9 @@ export type IncidentFiltersCombined = {
   severity?: Array<string>;
   state?: Array<string>;
 };
+
+export type IncidentsPageFiltersExpandedState = {
+  severity: boolean;
+  state: boolean;
+  groupId: boolean;
+};

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -352,7 +352,7 @@ export function filterIncident(filters: IncidentFiltersCombined, incidents: Arra
 
 export const onDeleteIncidentFilterChip = (
   type: string,
-  id: IncidentFilters | undefined,
+  id: IncidentFilters | string,
   filters: IncidentFiltersCombined,
   setFilters,
 ) => {
@@ -363,6 +363,7 @@ export const onDeleteIncidentFilterChip = (
           severity: filters.severity,
           days: filters.days,
           state: filters.state.filter((fil) => fil !== id),
+          groupId: filters.groupId,
         },
       }),
     );
@@ -374,6 +375,19 @@ export const onDeleteIncidentFilterChip = (
           severity: filters.severity.filter((fil) => fil !== id),
           days: filters.days,
           state: filters.state,
+          groupId: filters.groupId,
+        },
+      }),
+    );
+  }
+  if (type === 'Incident ID') {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: filters.severity,
+          days: filters.days,
+          state: filters.state,
+          groupId: filters.groupId.filter((fil) => fil !== id),
         },
       }),
     );
@@ -392,6 +406,7 @@ export const onDeleteGroupIncidentFilterChip = (
           severity: filters.severity,
           days: filters.days,
           state: [],
+          groupId: filters.groupId,
         },
       }),
     );
@@ -402,6 +417,18 @@ export const onDeleteGroupIncidentFilterChip = (
           severity: [],
           days: filters.days,
           state: filters.state,
+          groupId: filters.groupId,
+        },
+      }),
+    );
+  } else if (category === 'Incident ID') {
+    setFilters(
+      setIncidentsActiveFilters({
+        incidentsActiveFilters: {
+          severity: filters.severity,
+          days: filters.days,
+          state: filters.state,
+          groupId: [],
         },
       }),
     );
@@ -412,6 +439,7 @@ export const onDeleteGroupIncidentFilterChip = (
           severity: [],
           days: filters.days,
           state: [],
+          groupId: [],
         },
       }),
     );
@@ -472,17 +500,22 @@ export const onIncidentFiltersSelect = (
 
 const onSelect = (event, selection, dispatch, incidentsActiveFilters, filterCategoryType) => {
   const checked = event.target.checked;
+  let effectiveFilterType = filterCategoryType;
+
+  if (effectiveFilterType === 'incident id') {
+    effectiveFilterType = 'groupId';
+  }
 
   dispatch(() => {
-    const targetArray = incidentsActiveFilters[filterCategoryType] || [];
+    const targetArray = incidentsActiveFilters[effectiveFilterType] || [];
     const newFilters = { ...incidentsActiveFilters };
 
     if (checked) {
       if (!targetArray.includes(selection)) {
-        newFilters[filterCategoryType] = [...targetArray, selection];
+        newFilters[effectiveFilterType] = [...targetArray, selection];
       }
     } else {
-      newFilters[filterCategoryType] = targetArray.filter((value) => value !== selection);
+      newFilters[effectiveFilterType] = targetArray.filter((value) => value !== selection);
     }
 
     dispatch(
@@ -507,4 +540,23 @@ export const parseUrlParams = (search) => {
   });
 
   return result;
+};
+
+export const getIncidentIdOptions = (incidents: Array<Incident>) => {
+  const uniqueIds = new Set<string>();
+  incidents.forEach((incident) => {
+    if (incident.group_id) {
+      uniqueIds.add(incident.group_id);
+    }
+  });
+  return Array.from(uniqueIds).map((id) => ({
+    value: id,
+  }));
+};
+
+export const getFilterKey = (categoryName: string): string => {
+  if (categoryName === 'Incident ID') {
+    return 'groupId';
+  }
+  return categoryName.toLowerCase();
 };

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -479,7 +479,12 @@ export const changeDaysFilter = (
 ) => {
   dispatch(
     setIncidentsActiveFilters({
-      incidentsActiveFilters: { days: [days], severity: filters.severity, state: filters.state },
+      incidentsActiveFilters: {
+        days: [days],
+        severity: filters.severity,
+        state: filters.state,
+        groupId: filters.groupId,
+      },
     }),
   );
 };
@@ -523,7 +528,6 @@ export const onIncidentFiltersSelect = (
  * @returns {void}
  */
 const onSelect = (event, selection, dispatch, incidentsActiveFilters, filterCategoryType) => {
-  const checked = event.target.checked;
   let effectiveFilterType = filterCategoryType;
 
   if (effectiveFilterType === 'incident id') {
@@ -534,19 +538,19 @@ const onSelect = (event, selection, dispatch, incidentsActiveFilters, filterCate
     const targetArray = incidentsActiveFilters[effectiveFilterType] || [];
     const newFilters = { ...incidentsActiveFilters };
 
+    // Determine if the item is already selected by checking the current state.
+    // This replaces the need for event.target.checked.
+    const isSelected = targetArray.includes(selection);
+
     if (effectiveFilterType === 'groupId') {
-      if (checked) {
-        newFilters[effectiveFilterType] = [selection];
-      } else {
-        newFilters[effectiveFilterType] = [];
-      }
+      // Single-select logic: If already selected, unselect it. Otherwise, select it.
+      newFilters[effectiveFilterType] = isSelected ? [] : [selection];
     } else {
-      if (checked) {
-        if (!targetArray.includes(selection)) {
-          newFilters[effectiveFilterType] = [...targetArray, selection];
-        }
-      } else {
+      // Multi-select logic: If already selected, remove it. Otherwise, add it.
+      if (isSelected) {
         newFilters[effectiveFilterType] = targetArray.filter((value) => value !== selection);
+      } else {
+        newFilters[effectiveFilterType] = [...targetArray, selection];
       }
     }
 
@@ -593,6 +597,7 @@ export const getIncidentIdOptions = (incidents: Array<Incident>) => {
   });
   return Array.from(uniqueIds).map((id) => ({
     value: id,
+    description: `Incident ID: ${id}`,
   }));
 };
 

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -103,7 +103,6 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
           groupId: [],
         },
         incidentPageFilterType: 'Severity',
-        groupId: '',
       }),
     });
   }
@@ -325,10 +324,6 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         ['incidentsData', 'incidentsActiveFilters'],
         action.payload.incidentsActiveFilters,
       );
-    }
-
-    case ActionType.SetChooseIncident: {
-      return state.setIn(['incidentsData', 'groupId'], action.payload.groupId);
     }
 
     case ActionType.SetAlertsData: {

--- a/web/src/reducers/observe.ts
+++ b/web/src/reducers/observe.ts
@@ -94,11 +94,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
           days: ['7 days'],
           severity: ['Critical', 'Warning'],
           state: ['Firing'],
+          groupId: [],
         },
         incidentsActiveFilters: {
           days: [],
           severity: [],
           state: [],
+          groupId: [],
         },
         incidentPageFilterType: 'Severity',
         groupId: '',


### PR DESCRIPTION
Mocks:
https://issues.redhat.com/browse/RHINENG-20424
Incident ID is a filter for the group_id parameter of the Incidents

1) Added groupId to the incidentActiveFilters in state management, now it works the same way as state/severity filters
2) Added a filter for incident ID, which is populated with Incident IDs
3) Updated the IncidentsChart component to make it work with the new incidentsActiveFilters.groupId, removed state management parts for the old groupId
4) I removed the logic for the opacity change in the Incidents chart; now, we hide other bars when we filter by Incident.
5) Added a function onFilterToggle for toggling the expansion of filters 
6) Added necessary logic for updating the URL params, clearing the filters by single deletion or group deletion
7) Clear all filters now, do not clear the "days" selection, previously it was always refreshing it back to 7 days.

Small UX improvements:
1) Removed "Time range" above the days selector because it is pushing the entire container down and making it look bad. This change was agreed upon with Alberto
2) Removed "gap" for PageSection component so it wouldn't create an empty space between filter chips and "hide/show" chart button
3) Remove the filterIcon component for the IncidentFilterToolbarItem
4) Fixed the "gap" between filter type filter and the filters by using "is hidden" css