### PR TITLE
OU-671: Add Patternfly Theming to Perses

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,25 @@ $ ./scripts/api_backend_dev.sh
 
 # Lastly navigate to http://localhost:8080/ to see Perses app running 
 ```
+
+##### Install COO && Perses Datasource && Perses Sample Dashboard 
+1. Install COO through the OpenShift UI > OperatorHub > Cluster Observability Operator 
+2. Install UIPlugin > monitoring 
+3. oc apply -f <PERSES_DATASOURCE_YAML>
+   - See sample yaml [here](https://github.com/observability-ui/development-tools/blob/main/monitoring-plugin/monitoring-console-plugin/perses/thanos-querier-datasource.yaml) 
+4. oc apply -f <PERSES_DASHBOARD_YAML>
+   - See sample yaml  [here](https://github.com/observability-ui/development-tools/blob/main/monitoring-plugin/monitoring-console-plugin/perses/perses-dashboard.yaml)
+
+##### Port forward Perses Datasource 
+To use the PERSES_DATASOURCE you deployed above, you'll need to forward it to your local machine then proxy it using the local Perses Instance. 
+
+```
+# Forward cluster Prometheus Instance to localhost:9090
+oc port-forward -n openshift-monitoring service/prometheus-operated 9090:9090
+
+# Test is port-forward returns Prometheus data from query 'up'
+curl "http://localhost:9090/api/v1/query?query=up"
+```
+
+Adjust Perses local instance http://localhost:8080/ to use the a proxy to http://localhost:9090/ instead of http://demo.prometheus.io. 
+

--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -37,9 +37,13 @@ import { usePatternFlyTheme } from '../../hooks/usePatternflyTheme';
 import { OcpDatasourceApi } from './datasource-api';
 import { PERSES_PROXY_BASE_PATH, useFetchPersesDashboard } from './perses-client';
 import { CachedDatasourceAPI } from './perses/datasource-api';
-
-import { t_color_gray_95, t_color_white } from '@patternfly/react-tokens';
-
+import {
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  t_color_gray_95,
+  t_color_white,
+} from '@patternfly/react-tokens';
 import { QueryParams } from '../../query-params';
 import { StringParam, useQueryParam } from 'use-query-params';
 import { useTranslation } from 'react-i18next';
@@ -82,41 +86,137 @@ interface PersesWrapperProps {
 }
 
 const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
+  const isDark = theme === 'dark';
+  const primaryTextColor = isDark ? t_color_white.value : t_color_gray_95.value;
+  const primaryBackgroundColor = 'var(--pf-t--global--background--color--primary--default)';
+
   return {
     typography: {
-      fontFamily: 'var(--pf-t--global--font--family--body)',
       ...typography,
+      fontFamily: 'var(--pf-t--global--font--family--body)',
+      subtitle1: {
+        // Card Heading
+        fontFamily: 'var(--pf-t--global--font--family--heading)',
+        fontWeight: 'var(--pf-t--global--font--weight--heading--default)',
+        lineHeight: 'var(--pf-v6-c-card__title-text--LineHeight)',
+        fontSize: 'var(--pf-t--global--font--size--heading--sm)',
+      },
+      h2: {
+        // Panel Group Heading
+        color: 'var(--pf-t--global--text--color--brand--default)',
+        fontWeight: 'var(--pf-t--global--font--weight--body--default)',
+        fontSize: 'var(--pf-t--global--font--size--600)',
+      },
+    },
+    palette: {
+      primary: {
+        light: chart_color_blue_100.value,
+        main: chart_color_blue_200.value,
+        dark: chart_color_blue_300.value,
+        contrastText: primaryTextColor,
+      },
+      secondary: {
+        main: primaryTextColor,
+        light: primaryTextColor,
+        dark: primaryTextColor,
+      },
+      background: {
+        default: primaryBackgroundColor,
+        paper: primaryBackgroundColor,
+        navigation: primaryBackgroundColor,
+        code: primaryBackgroundColor,
+        tooltip: primaryBackgroundColor,
+        lighter: primaryBackgroundColor,
+        border: primaryBackgroundColor,
+      },
+      text: {
+        primary: primaryTextColor,
+        secondary: primaryTextColor,
+        disabled: primaryTextColor,
+        navigation: primaryTextColor,
+        accent: primaryTextColor,
+        link: primaryTextColor,
+        linkHover: primaryTextColor,
+      },
     },
     components: {
-      MuiIconButton: {
+      MuiTypography: {
+        styleOverrides: {
+          root: {
+            // Custom Time Range Selector
+            '&.MuiClock-meridiemText': {
+              color: primaryTextColor,
+            },
+          },
+        },
+      },
+      MuiSvgIcon: {
         styleOverrides: {
           root: {
             color: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
           },
         },
       },
-    },
-    palette: {
-      primary: {
-        main: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            borderRadius: 'var(--pf-t--global--border--radius--medium)',
+            borderColor: 'var(--pf-t--global--border--color--default)',
+          },
+        },
       },
-      background: {
-        navigation: 'var(--pf-t--global--background--color--primary--default)',
-        default: 'var(--pf-t--global--background--color--primary--default)',
-        paper: 'var(--pf-t--global--background--color--primary--default)',
-        code: 'var(--pf-t--global--background--color--primary--default)',
-        tooltip: 'var(--pf-t--global--background--color--primary--default)',
-        lighter: 'var(--pf-t--global--background--color--primary--default)',
-        border: 'var(--pf-t--global--background--color--primary--default)',
+      MuiCardHeader: {
+        styleOverrides: {
+          root: {
+            '&.MuiCardHeader-root': {
+              borderBottom: 'none',
+              paddingBlockEnd: 'var(--pf-t--global--spacer--md)',
+              paddingBlockStart: 'var(--pf-t--global--spacer--lg)',
+              paddingLeft: 'var(--pf-t--global--spacer--lg)',
+              paddingRight: 'var(--pf-t--global--spacer--lg)',
+            },
+          },
+        },
       },
-      text: {
-        navigation: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        accent: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        primary: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        secondary: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        disabled: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        link: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
-        linkHover: theme === 'dark' ? t_color_white.value : t_color_gray_95.value,
+      MuiCardContent: {
+        styleOverrides: {
+          root: {
+            '&.MuiCardContent-root': {
+              borderTop: 'none',
+              '&:last-child': {
+                paddingBottom: 'var(--pf-t--global--spacer--lg)',
+                paddingLeft: 'var(--pf-t--global--spacer--lg)',
+                paddingRight: 'var(--pf-t--global--spacer--lg)',
+              },
+            },
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          notchedOutline: {
+            borderColor: 'var(--pf-t--global--border--color--default)',
+          },
+          root: {
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--pf-t--global--border--color--default)',
+            },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--pf-t--global--border--color--default)',
+            },
+          },
+          input: {
+            // Dashboard Variables >> Text Variable
+            padding: '8.5px 14px',
+          },
+        },
+      },
+      MuiSelect: {
+        styleOverrides: {
+          icon: {
+            color: primaryTextColor,
+          },
+        },
       },
     },
   };
@@ -125,7 +225,6 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
 export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
   const [dashboardName] = useQueryParam(QueryParams.Dashboard, StringParam);
-
   const muiTheme = getTheme(theme, {
     shape: {
       borderRadius: 6,


### PR DESCRIPTION
### JIRA 
 [OU-671](https://issues.redhat.com/browse/OU-671) : Add Patternfly Theming to Perses


This does not include stabilizing series colors so that, upon reload, the colors remain the same (based on the series name). This also does not include Dark & Light mode PF theming for the chart tool tips. These tasks will be in a separate JIRA, [OU-992](https://issues.redhat.com/browse/OU-992): Monitoring-Console-Plugin Perses Dashboards Chart Color Series Stabilization and PatternFly Palette Theming.

Continuation of https://github.com/openshift/monitoring-plugin/pull/433

### Screenshots 

#### Before - Light Mode
<img width="1201" height="1083" alt="Screenshot 2025-09-04 at 12 56 15 PM" src="https://github.com/user-attachments/assets/abf7c01d-7254-4579-beed-d540fbbcffa6" />

#### After - Light Mode
<img width="1221" height="981" alt="Screenshot 2025-09-04 at 12 56 20 PM" src="https://github.com/user-attachments/assets/9def396a-cd1a-4b8d-b4a8-bee0f6ed1b48" />

#### Before - Dark Mode
<img width="1201" height="1080" alt="Screenshot 2025-09-04 at 12 49 24 PM" src="https://github.com/user-attachments/assets/201ba7e1-02a6-4d5f-8bab-b8638de8c348" />

#### After Dark Mode 
<img width="1222" height="994" alt="Screenshot 2025-09-04 at 12 49 20 PM" src="https://github.com/user-attachments/assets/4a3a0128-4258-4e15-a449-e7bbe0e78305" />


### Testing 
Image: `quay.io/jezhu/monitoring-console-plugin:ou671-pf-theme-pr-sept8`
Perses Dashboard Yaml: [perses-dashboard.yaml](https://github.com/observability-ui/development-tools/blob/main/monitoring-plugin/monitoring-console-plugin/perses/perses-dashboard.yaml)
