### PR TITLE
NO-JIRA: automation - fix monitoring-plugin injection

### DIFF
--- a/web/cypress/fixtures/cmo/update-monitoring-plugin-image.sh
+++ b/web/cypress/fixtures/cmo/update-monitoring-plugin-image.sh
@@ -1,38 +1,31 @@
 #!/bin/bash
 
 # Generate a random filename
-RANDOM_FILE="/tmp/cmo_monitoring_csv_$(date +%s%N).yaml"
+MONITORING_FILE="/tmp/monitoring_csv_$(date +%s%N).yaml"
 
-CMO_CSV_NAME=$(oc get deployment --kubeconfig "${KUBECONFIG}" --namespace="${MP_NAMESPACE}" | grep "cluster-monitoring-operator" | awk '{print $1}')
+MONITORING_CSV_NAME=$(oc get deployment --kubeconfig "${KUBECONFIG}" --namespace="${MP_NAMESPACE}" | grep "monitoring-plugin" | awk '{print $1}')
 
 oc project --namespace="${MP_NAMESPACE}"
 
-oc get deployment "${CMO_CSV_NAME}" -n "${MP_NAMESPACE}" -o yaml > "${RANDOM_FILE}" --kubeconfig "${KUBECONFIG}"
+oc get deployment "${MONITORING_CSV_NAME}" -n "${MP_NAMESPACE}" -o yaml > "${MONITORING_FILE}" --kubeconfig "${KUBECONFIG}"
 
 # Patch the deployment file related images
-sed -i "s#value: .*monitoring-plugin.*#value: ${MP_IMAGE}#g" "${RANDOM_FILE}"
-sed -i "s#^\([[:space:]]*- -images=monitoring-plugin=\).*#\1${MP_IMAGE}#g" "${RANDOM_FILE}"
+sed -i "s#^\([[:space:]]*image: \).*#\1${MP_IMAGE}#g" "${MONITORING_FILE}"
 
-oc replace -f "${RANDOM_FILE}" --kubeconfig "${KUBECONFIG}"
+oc replace -f "${MONITORING_FILE}" --kubeconfig "${KUBECONFIG}"
 
-# Scale down
+# Scale down the cluster-monitoring-operator as "manager" pod is responsible for the monitoring-plugin
 oc patch clusterversion version --type json -p "$(cat disable-monitoring.yaml)"
 
 oc scale --replicas=0 -n "${MP_NAMESPACE}" deployment/cluster-monitoring-operator
 
-oc scale --replicas=0 -n "${MP_NAMESPACE}" deployment/monitoring-plugin
-
 # Apply the patched deployment resource file
-oc replace -f "${RANDOM_FILE}" --kubeconfig "${KUBECONFIG}"
+oc replace -f "${MONITORING_FILE}" --kubeconfig "${KUBECONFIG}"
 
-# Scale up the Monitoring-plugin
-oc scale --replicas=1 -n "${MP_NAMESPACE}" deployment/cluster-monitoring-operator
-
+# Scale up the monitoring-plugin with new image, leaving the cluster-monitoring-operator at 0 replicas to not revert the change
 oc scale --replicas=1 -n "${MP_NAMESPACE}" deployment/monitoring-plugin
 
 # Wait for the operator to reconcile the change and make sure all the pods are running.
 sleep 30
 OUTPUT=`oc wait --for=condition=Ready pods --selector=app.kubernetes.io/part-of=monitoring-plugin -n "${MP_NAMESPACE}" --timeout=60s`
-echo "${OUTPUT}"
-OUTPUT=`oc wait --for=condition=ready pods -l app.kubernetes.io/name=cluster-monitoring-operator -n "${MP_NAMESPACE}" --timeout=60s --kubeconfig "${KUBECONFIG}"`
 echo "${OUTPUT}"


### PR DESCRIPTION
Original script was not working locally when running full test suite was run. 
It was not noticed before due to only few scripts created at the time it was tested and how fast it run. It was noticed that, now that we have more scripts running, during the execution the Cluster Monitoring Operator's CSV was reconciled/reverted to the original content, making some scripts failing in the middle of the execution, not finding some data-test IDs created and not yet merged to main. 
Other point is that, when running in prowJob, the cluster is provisioned with monitoring-plugin image already included. So, even if this script was run during the automation execution, it didn't make any difference, once the original monitoring-plugin image was already the image built with the latest changes.

With this fix:
- cmo deployment is scaled down
- monitoring-plugin image is injected into monitoring-plugin deployment yaml file
- monitoring-plugin deployment is scale up

The re-enablement continues the same and it was tested that monitoring-plugin deployment got reverted successfully with the original image.