### PR TITLE
NO-JIRA: Cypress Testsuite – Enhance Session Management

### DIFF
--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -67,6 +67,11 @@ Set the following var to specify the cluster timezone for incident timeline calc
 export CYPRESS_TIMEZONE=<timezone>
 ```
 
+Set the following var to enable Cypress session management for faster test execution.
+```bash
+export CYPRESS_SESSION=true
+```
+
 ### Environment Configuration Script
 
 The `configure-env.sh` script provides an interactive way to set up all the required environment variables. This script eliminates the need to manually export each variable and helps find the correct kubeconfig file.

--- a/web/cypress/configure-env.sh
+++ b/web/cypress/configure-env.sh
@@ -173,6 +173,7 @@ print_current_config() {
   print_var "CYPRESS_CUSTOM_COO_BUNDLE_IMAGE" "${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}"
   print_var "CYPRESS_MCP_CONSOLE_IMAGE" "${CYPRESS_MCP_CONSOLE_IMAGE-}"
   print_var "CYPRESS_TIMEZONE" "${CYPRESS_TIMEZONE-}"
+  print_var "CYPRESS_SESSION" "${CYPRESS_SESSION-}"
 }
 
 main() {
@@ -214,6 +215,7 @@ main() {
   local def_custom_coo_bundle=${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}
   local def_mcp_console_image=${CYPRESS_MCP_CONSOLE_IMAGE-}
   local def_timezone=${CYPRESS_TIMEZONE-}
+  local def_session=${CYPRESS_SESSION-}
 
   # Required basics
   local base_url
@@ -405,6 +407,11 @@ main() {
   local timezone
   timezone=$(ask "Cluster timezone (CYPRESS_TIMEZONE)" "${def_timezone:-UTC}")
 
+  local session_ans
+  session_ans=$(ask_yes_no "Enable Cypress session management for faster test execution? (sets CYPRESS_SESSION)" "$(bool_to_default_yn "$def_session")")
+  local session="false"
+  [[ "$session_ans" == "y" ]] && session="true"
+
   # Build export lines with safe quoting
   local -a export_lines
   export_lines+=("export CYPRESS_BASE_URL='$(printf %s "$base_url" | escape_for_single_quotes)'" )
@@ -428,6 +435,7 @@ main() {
   if [[ -n "$timezone" ]]; then
     export_lines+=("export CYPRESS_TIMEZONE='$(printf %s "$timezone" | escape_for_single_quotes)'" )
   fi
+  export_lines+=("export CYPRESS_SESSION='$(printf %s "$session" | escape_for_single_quotes)'" )
 
   echo ""
   if is_sourced; then
@@ -458,6 +466,7 @@ main() {
   [[ -n "${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}$custom_coo_bundle" ]] && echo "  CYPRESS_CUSTOM_COO_BUNDLE_IMAGE=${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE:-$custom_coo_bundle}"
   [[ -n "${CYPRESS_MCP_CONSOLE_IMAGE-}$mcp_console_image" ]] && echo "  CYPRESS_MCP_CONSOLE_IMAGE=${CYPRESS_MCP_CONSOLE_IMAGE:-$mcp_console_image}"
   [[ -n "${CYPRESS_TIMEZONE-}$timezone" ]] && echo "  CYPRESS_TIMEZONE=${CYPRESS_TIMEZONE:-$timezone}"
+  echo "  CYPRESS_SESSION=${CYPRESS_SESSION:-$session}"
 }
 
 main "$@"

--- a/web/cypress/e2e/coo/01.coo_bvt.cy.ts
+++ b/web/cypress/e2e/coo/01.coo_bvt.cy.ts
@@ -21,14 +21,8 @@ const MP = {
 describe('BVT: COO', () => {
 
   before(() => {
-    cy.afterBlockCOO(MCP, MP); // Following best practices, the cleanup is done before the test block
     cy.beforeBlockCOO(MCP, MP);
 
-  });
-
-
-  after(() => {
-    cy.afterBlockCOO(MCP, MP);
   });
 
   it('1. Admin perspective - Observe Menu', () => {

--- a/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
+++ b/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
@@ -25,7 +25,6 @@ describe('BVT: Incidents - e2e', () => {
   let currentAlertName: string;
 
   before(() => {
-    cy.afterBlockCOO(MCP, MP); // Following cypher best practices, the cleanup is done before the test block
     cy.beforeBlockCOO(MCP, MP);
     
     cy.cleanupIncidentPrometheusRules(); 
@@ -35,10 +34,6 @@ describe('BVT: Incidents - e2e', () => {
       currentAlertName = alertName;
       cy.log(`Test will look for alert: ${currentAlertName}`);
     });
-  });
-
-  after(() => {
-    cy.afterBlockCOO(MCP, MP); // For compatibility with other tests
   });
 
   it('1. Admin perspective - Incidents page - Incident with custom alert lifecycle', () => {

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -33,12 +33,7 @@ const ALERT_DESC = 'This is an alert meant to ensure that the entire alerting pi
 const ALERT_SUMMARY = 'An alert that should always be firing to certify that Alertmanager is working properly.'
 describe('BVT: Incidents - UI', () => {
   before(() => {
-    cy.afterBlockCOO(MCP, MP); // Following cypher best practices, the cleanup is done before the test block
     cy.beforeBlockCOO(MCP, MP);
-  });
-
-  after(() => {
-    cy.afterBlockCOO(MCP, MP); // For compatibility with other tests
   });
 
 

--- a/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
+++ b/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
@@ -29,7 +29,6 @@ const MP = {
 describe('Incidents - Mocking Examples', () => {
 
   before(() => {
-    cy.afterBlockCOO(MCP, MP);
     cy.beforeBlockCOO(MCP, MP);
   });
 

--- a/web/cypress/e2e/monitoring/01.bvt_monitoring.cy.ts
+++ b/web/cypress/e2e/monitoring/01.bvt_monitoring.cy.ts
@@ -19,12 +19,7 @@ const MP = {
 describe('BVT: Monitoring', () => {
 
   before(() => {
-    cy.afterBlock(MP);
     cy.beforeBlock(MP);
-  });
-
-  after(() => {
-    cy.afterBlock(MP);
   });
 
   it('1. Admin perspective - Observe Menu', () => {

--- a/web/cypress/e2e/monitoring/regression/01.reg_alerts.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/01.reg_alerts.cy.ts
@@ -21,12 +21,7 @@ const MP = {
 describe('Regression: Monitoring - Alerts', () => {
 
   before(() => {
-    cy.afterBlock(MP);
     cy.beforeBlock(MP);
-  });
-
-  after(() => {
-    cy.afterBlock(MP);
   });
 
   it('1. Admin perspective - Alerting > Alerts page - Filtering', () => {

--- a/web/cypress/e2e/monitoring/regression/02.reg_metrics.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/02.reg_metrics.cy.ts
@@ -12,12 +12,7 @@ const MP = {
 describe('Regression: Monitoring - Metrics', () => {
 
   before(() => {
-    cy.afterBlock(MP);
     cy.beforeBlock(MP);
-  });
-
-  after(() => {
-    cy.afterBlock(MP);
   });
 
   it('1. Admin perspective - Metrics', () => {

--- a/web/cypress/e2e/monitoring/regression/03.reg_legacy_dashboards.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/03.reg_legacy_dashboards.cy.ts
@@ -16,12 +16,7 @@ const MP = {
 describe('Regression: Monitoring - Dashboards (Legacy)', () => {
 
   before(() => {
-    cy.afterBlock(MP);
     cy.beforeBlock(MP);
-  });
-
-  after(() => {
-    cy.afterBlock(MP);
   });
 
   it('1. Admin perspective - Dashboards (legacy)', () => {

--- a/web/cypress/fixtures/export.sh
+++ b/web/cypress/fixtures/export.sh
@@ -35,3 +35,6 @@ export CYPRESS_MCP_CONSOLE_IMAGE=<Monitoring Console Plugin image>
 
 # Set the following var to specify the cluster timezone for incident timeline calculations. Defaults to UTC if not specified.
 export CYPRESS_TIMEZONE=<timezone>
+
+# Set the following var to enable Cypress session management for faster test execution.
+export CYPRESS_SESSION=true


### PR DESCRIPTION
Previously, sessions encompassed only the auth to the cluster.

This PR introduces an option to include all COO / MP setup inside the session, configurable by `CYPRESS_SESSION` env var. This reduces runtime of the testsuite by 2 minutes per spec with shared before block.

More importantly, it reduces the initial loading of a test under development (npx cypress open). Cypress automatically reloads the tests on new changes in the code and this significant shortening of the feedback loop enhances the developer experience.

The updated beforeBlock code also unifies the cleanup logic, performing cleanup **before** the spec is run and leaving the dangling state present in the cluster, adhering to cypress best practices.

### Comparison of test runs
With Sessions:
<img width="1588" height="1345" alt="image" src="https://github.com/user-attachments/assets/db7651cd-fe59-4e07-aca8-05b953495b0a" />
Without Sessions:
<img width="1479" height="1764" alt="image" src="https://github.com/user-attachments/assets/6af4053c-133d-46c8-8445-f99b4fd70a9f" />

