### PR TITLE
NO-JIRA: fix: immer dependency anr patternfly icons import

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -45,7 +45,7 @@
         "fuzzysearch": "1.0.x",
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
-        "immer": "^10.1.1",
+        "immer": "^9.0.21",
         "immutable": "3.x",
         "js-yaml": "^4.1.0",
         "lodash-es": "^4.17.21",
@@ -3486,16 +3486,6 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
-    "node_modules/@perses-dev/dashboards/node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@perses-dev/panels-plugin": {
       "version": "0.50.3",
       "resolved": "https://registry.npmjs.org/@perses-dev/panels-plugin/-/panels-plugin-0.50.3.tgz",
@@ -3528,16 +3518,6 @@
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.5.0"
-      }
-    },
-    "node_modules/@perses-dev/panels-plugin/node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@perses-dev/panels-plugin/node_modules/tslib": {
@@ -3575,16 +3555,6 @@
         "@tanstack/react-query": "^4.7.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@perses-dev/prometheus-plugin": {
@@ -3638,16 +3608,6 @@
       "peerDependencies": {
         "@lezer/highlight": "^1.1.2",
         "@lezer/lr": "^1.2.3"
-      }
-    },
-    "node_modules/@perses-dev/prometheus-plugin/node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@perses-dev/prometheus-plugin/node_modules/lru-cache": {
@@ -10826,9 +10786,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
-      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -68,7 +68,7 @@
     "fuzzysearch": "1.0.x",
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
-    "immer": "^10.1.1",
+    "immer": "^9.0.21",
     "immutable": "3.x",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",

--- a/web/src/components/console/utils/single-typeahead-dropdown.tsx
+++ b/web/src/components/console/utils/single-typeahead-dropdown.tsx
@@ -18,7 +18,7 @@ import {
 } from '@patternfly/react-core';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { TimesIcon } from '@patternfly/react-icons';
 import { t_global_spacer_control_horizontal_default } from '@patternfly/react-tokens';
 import { useEffect, useMemo, useRef, useState } from 'react';
 

--- a/web/src/components/kebab-dropdown.tsx
+++ b/web/src/components/kebab-dropdown.tsx
@@ -1,6 +1,6 @@
 import type { FC, Ref } from 'react';
 import { Dropdown, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
-import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 
 import { useBoolean } from './hooks/useBoolean';
 import { DataTestIDs } from './data-test';


### PR DESCRIPTION
This PR:

- downgrades the immer dependency to use v9.0.21, which is the same used for perses. This removes the warning when loading the app
- Fixes other warnings related to the patternfly icons imports