### PR TITLE
OU-1009: url params refreshed when its not required

### DIFF
--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
@@ -98,7 +98,7 @@ const IncidentsChart = ({
           },
         }),
       );
-      updateBrowserUrl(incidentsActiveFilters, '');
+      updateBrowserUrl(incidentsActiveFilters);
       dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
     } else {
       dispatch(
@@ -109,7 +109,7 @@ const IncidentsChart = ({
           },
         }),
       );
-      updateBrowserUrl(incidentsActiveFilters, datum.datum.group_id);
+      updateBrowserUrl(incidentsActiveFilters);
     }
   };
 

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -531,30 +531,20 @@ export const onDeleteGroupIncidentFilterChip = (
   }
 };
 
-export const makeIncidentUrlParams = (
-  params?: IncidentFiltersCombined,
-  incidentGroupId?: string,
-) => {
-  const processedParams = Object.entries(params ?? {}).reduce((acc, [key, value]) => {
-    if (Array.isArray(value)) {
-      if (value.length > 0) {
-        acc[key] = value.join(',');
-      }
-    } else {
-      acc[key] = value;
+export const makeIncidentUrlParams = (params?: IncidentFiltersCombined) => {
+  const urlParams = new URLSearchParams();
+
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    if (Array.isArray(value) && value.length > 0) {
+      urlParams.append(key, value.join(','));
     }
-    return acc;
-  }, {} as Record<string, string>);
+  });
 
-  if (incidentGroupId) {
-    processedParams['groupId'] = incidentGroupId;
-  }
-
-  return new URLSearchParams(processedParams).toString();
+  return urlParams.toString();
 };
 
-export const updateBrowserUrl = (params?: IncidentFiltersCombined, incidentGroupId?: string) => {
-  const queryString = makeIncidentUrlParams(params, incidentGroupId);
+export const updateBrowserUrl = (params?: IncidentFiltersCombined) => {
+  const queryString = makeIncidentUrlParams(params);
 
   const newUrl = `${window.location.origin}${window.location.pathname}?${queryString}`;
 


### PR DESCRIPTION
Removed const [isInitialized, setIsInitialized] = useState(false); hook, now we use useRef so the filters are preserved when we apply them and refresh the page.
Fixed the way how we apply the initial state filters, and improved the logic of loading the filters on initial load of the page.