### PR TITLE
OU-1011: add a 5 minute to the first alert timestamp

### DIFF
--- a/web/src/components/Incidents/processAlerts.ts
+++ b/web/src/components/Incidents/processAlerts.ts
@@ -166,7 +166,16 @@ export function processAlerts(
       }
       const matchingRule = alertingRules.find((rule) => rule.name === alert.metric.alertname);
 
-      const alertsStartFiring = sortedValues[0][0] * 1000;
+      // Create a new timestamp 5 minutes (300 seconds) earlier than the first timestamp
+      const originalAlertsStartFiring = sortedValues[0][0] * 1000;
+      const newFirstTimestamp = sortedValues[0][0] - 5 * 60;
+
+      // Create a copy of the first value from the array of timestamps and update its timestamp
+      const newFirstValue: [number, string] = [newFirstTimestamp, sortedValues[0][1]];
+      // Unshift the new value to the beginning of the sortedValues array
+      sortedValues.unshift(newFirstValue);
+
+      const alertsStartFiring = originalAlertsStartFiring - 5 * 60 * 1000;
       const alertsEndFiring = sortedValues[sortedValues.length - 1][0] * 1000;
       const resolved = Date.now() - alertsEndFiring > 10 * 60 * 1000;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OU-1011

I added a copy of the first timestamp to each alert that is 5 minutes earlier than the current first timestamp.