### PR TITLE
OU-1015: fix: incidents dropdown stays open fix

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -324,6 +324,11 @@ const IncidentsPage = () => {
 
   const handleIncidentChartClick = useCallback(
     (groupId) => {
+      setFiltersExpanded({
+        severity: false,
+        state: false,
+        groupId: false,
+      });
       if (groupId === selectedGroupId) {
         dispatch(
           setIncidentsActiveFilters({

--- a/web/src/components/Incidents/ToolbarItemFilter.tsx
+++ b/web/src/components/Incidents/ToolbarItemFilter.tsx
@@ -92,6 +92,9 @@ const IncidentFilterToolbarItem: React.FC<IncidentFilterToolbarItemProps> = ({
                 categoryName.toLowerCase(),
               );
             }
+            if (categoryName === 'Incident ID') {
+              setIncidentIsExpanded(false);
+            }
           }}
           onOpenChange={(isOpen) => setIncidentIsExpanded(isOpen)}
           toggle={(toggleRef) => (


### PR DESCRIPTION
https://issues.redhat.com/browse/OU-1015

Ensures that incidents dropdown stays closed after selection and data fetch