### PR TITLE
 OBSINTA-857: Cypress add SKIP_ALL_INSTALL

### DIFF
--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -82,6 +82,11 @@ Set the following var to enable Cypress debug mode to log in headless mode.
 export CYPRESS_DEBUG=true
 ```
 
+Set the following var to skip all operator installation, cleanup, and verifications (useful for pre-provisioned environments where COO and Monitoring Plugin are already installed). Note: This skips COO installation which would otherwise remove any existing monitoring plugin from the cluster.
+```bash
+export CYPRESS_SKIP_ALL_INSTALL=false
+```
+
 Integration Testing variables
 
 Set the var to skip Openshift Virtualization and all the required operators installation.

--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -82,7 +82,7 @@ Set the following var to enable Cypress debug mode to log in headless mode.
 export CYPRESS_DEBUG=true
 ```
 
-Set the following var to skip all operator installation, cleanup, and verifications (useful for pre-provisioned environments where COO and Monitoring Plugin are already installed). Note: This skips COO installation which would otherwise remove any existing monitoring plugin from the cluster.
+Set the following var to skip all operator installation, cleanup, and verifications (useful for pre-provisioned environments where COO and Monitoring UI Plugin are already installed).
 ```bash
 export CYPRESS_SKIP_ALL_INSTALL=false
 ```

--- a/web/cypress/configure-env.sh
+++ b/web/cypress/configure-env.sh
@@ -176,6 +176,7 @@ print_current_config() {
   print_var "CYPRESS_MOCK_NEW_METRICS" "${CYPRESS_MOCK_NEW_METRICS-}"
   print_var "CYPRESS_SESSION" "${CYPRESS_SESSION-}"
   print_var "CYPRESS_DEBUG" "${CYPRESS_DEBUG-}"
+  print_var "CYPRESS_SKIP_ALL_INSTALL" "${CYPRESS_SKIP_ALL_INSTALL-}"
   print_var "CYPRESS_SKIP_KBV_INSTALL" "${CYPRESS_SKIP_KBV_INSTALL-}"
   print_var "CYPRESS_KBV_UI_INSTALL" "${CYPRESS_KBV_UI_INSTALL-}"
   print_var "CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE" "${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE-}"
@@ -225,6 +226,7 @@ main() {
   local def_mock_new_metrics=${CYPRESS_MOCK_NEW_METRICS-}
   local def_session=${CYPRESS_SESSION-}
   local def_debug=${CYPRESS_DEBUG-}
+  local def_skip_all_install=${CYPRESS_SKIP_ALL_INSTALL-}
   local def_skip_kbv=${CYPRESS_SKIP_KBV_INSTALL-}
   local def_kbv_ui_install=${CYPRESS_KBV_UI_INSTALL-}
   local def_konflux_kbv_bundle=${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE-}
@@ -435,6 +437,11 @@ main() {
   local debug="false"
   [[ "$debug_ans" == "y" ]] && debug="true"
 
+  local skip_all_install_ans
+  skip_all_install_ans=$(ask_yes_no "Skip all operator installation/cleanup and verifications? (sets CYPRESS_SKIP_ALL_INSTALL, for pre-provisioned environments)" "$(bool_to_default_yn "$def_skip_all_install")")
+  local skip_all_install="false"
+  [[ "$skip_all_install_ans" == "y" ]] && skip_all_install="true"
+
   local skip_kbv_install_ans
   skip_kbv_install_ans=$(ask_yes_no "Skip Openshift Virtualization installation? (sets CYPRESS_SKIP_KBV_INSTALL)" "$(bool_to_default_yn "$def_skip_kbv")")
   local skip_kbv_install="false"
@@ -481,6 +488,8 @@ main() {
   export_lines+=("export CYPRESS_MOCK_NEW_METRICS='$(printf %s "$mock_new_metrics" | escape_for_single_quotes)'" )
   export_lines+=("export CYPRESS_SESSION='$(printf %s "$session" | escape_for_single_quotes)'" )
   export_lines+=("export CYPRESS_DEBUG='$(printf %s "$debug" | escape_for_single_quotes)'" )
+  export_lines+=("export CYPRESS_SKIP_ALL_INSTALL='$(printf %s "$skip_all_install" | escape_for_single_quotes)'" )
+
   if [[ -n "$skip_kbv_install" ]]; then
     export_lines+=("export CYPRESS_SKIP_KBV_INSTALL='$(printf %s "$skip_kbv_install" | escape_for_single_quotes)'" )
   fi
@@ -529,6 +538,7 @@ main() {
   echo "  CYPRESS_MOCK_NEW_METRICS=${CYPRESS_MOCK_NEW_METRICS:-$mock_new_metrics}"
   echo "  CYPRESS_SESSION=${CYPRESS_SESSION:-$session}"
   echo "  CYPRESS_DEBUG=${CYPRESS_DEBUG:-$debug}"
+  echo "  CYPRESS_SKIP_ALL_INSTALL=${CYPRESS_SKIP_ALL_INSTALL:-$skip_all_install}"
   echo "  CYPRESS_SKIP_KBV_INSTALL=${CYPRESS_SKIP_KBV_INSTALL:-$skip_kbv_install}"
   echo "  CYPRESS_KBV_UI_INSTALL=${CYPRESS_KBV_UI_INSTALL:-$kbv_ui_install}"
   [[ -n "${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE-}$konflux_kbv_bundle" ]] && echo "  CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE=${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE:-$konflux_kbv_bundle}"

--- a/web/cypress/fixtures/export.sh
+++ b/web/cypress/fixtures/export.sh
@@ -41,3 +41,7 @@ export CYPRESS_MOCK_NEW_METRICS=false
 
 # Set the following var to enable Cypress session management for faster test execution.
 export CYPRESS_SESSION=true
+
+# Skip all operator installation, cleanup, and verifications (for pre-provisioned environments where COO and Monitoring Plugin are already installed)
+# Note: This skips COO installation which would otherwise remove any existing monitoring plugin from the cluster
+export CYPRESS_SKIP_ALL_INSTALL=false


### PR DESCRIPTION
In local setup, I run the testsuite against cluster without the COO installed. This variable skips not only COO installation, but also the verification and the setup of the UI monitoring plugin.

Additionally, it refactors the aboutModal and getPodInfo calls to be skipped when CYPRESS_DEBUG is not true and moves them inside the sessions.