### PR TITLE
NO-JIRA:  fix handle empty queries when removing incident filters

### DIFF
--- a/web/src/components/Incidents/api.ts
+++ b/web/src/components/Incidents/api.ts
@@ -66,19 +66,28 @@ export const fetchDataForIncidentsAndAlerts = (
   range: { endTime: number; duration: number },
   customQuery: string,
 ) => {
-  return fetch(
-    buildPrometheusUrl({
-      prometheusUrlProps: {
-        endpoint: PrometheusEndpoint.QUERY_RANGE,
-        endTime: range.endTime,
-        namespace: '',
-        query: customQuery,
-        samples: 288,
-        timespan: range.duration - 1,
-      },
-      basePath: getPrometheusBasePath({
-        prometheus: 'cmo',
-      }),
+  const url = buildPrometheusUrl({
+    prometheusUrlProps: {
+      endpoint: PrometheusEndpoint.QUERY_RANGE,
+      endTime: range.endTime,
+      namespace: '',
+      query: customQuery,
+      samples: 288,
+      timespan: range.duration - 1,
+    },
+    basePath: getPrometheusBasePath({
+      prometheus: 'cmo',
     }),
-  );
+  });
+
+  if (!url) {
+    // Return empty result when query is empty to avoid making invalid API calls
+    return Promise.resolve({
+      data: {
+        result: [],
+      },
+    });
+  }
+
+  return fetch(url);
 };

--- a/web/src/components/utils.ts
+++ b/web/src/components/utils.ts
@@ -245,9 +245,10 @@ export const buildPrometheusUrl = ({
 }: {
   prometheusUrlProps: PrometheusURLProps;
   basePath: string;
-}): string => {
+}): string | null => {
   if (prometheusUrlProps.endpoint !== PrometheusEndpoint.RULES && !prometheusUrlProps.query) {
-    return '';
+    // Empty query provided, skipping API call
+    return null;
   }
 
   const params = getSearchParams(prometheusUrlProps);


### PR DESCRIPTION
  Fixes JSON parsing error that occurred when removing incident filters.
  The buildPrometheusUrl function now returns null for empty queries
  instead of an empty string, preventing invalid API calls to the root
  URL which returned HTML instead of expected JSON data.

  Assisted-By: Claude Code