### PR TITLE
NO-JIRA: Fix tooltip vertical position

### DIFF
--- a/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
@@ -144,8 +144,8 @@ const AlertsChart = ({ theme }: { theme: 'light' | 'dark' }) => {
                       ? `${datum.name} (currently silenced)`
                       : datum.name;
 
-                    return `Severity: ${datum.severity}
-                    Alert Name: ${alertName}
+                    return `Alert Name: ${alertName}
+                    Severity: ${datum.severity}
                     Namespace: ${datum.namespace || '---'}
                     Component: ${datum.component}
                     Start: ${startDate}

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
@@ -31,6 +31,22 @@ import { dateTimeFormatter } from '../../console/utils/datetime';
 import { useTranslation } from 'react-i18next';
 import { DataTestIDs } from '../../data-test';
 
+/**
+ * Processes component list: moves "Others" to end and limits display to 3 components
+ * @param componentList - Array of component names
+ * @returns Formatted component string with ellipsis if truncated
+ */
+const formatComponentList = (componentList: string[] | undefined): string => {
+  const components = [...(componentList || [])];
+  const othersIndex = components.findIndex((c) => c.toLowerCase() === 'others');
+  if (othersIndex !== -1) {
+    const [others] = components.splice(othersIndex, 1);
+    components.push(others);
+  }
+  const hasMore = components.length > 3;
+  return components.slice(0, 3).join(', ') + (hasMore ? ', ...' : '');
+};
+
 const IncidentsChart = ({
   incidentsData,
   chartDays,
@@ -126,9 +142,11 @@ const IncidentsChart = ({
                     const endDate = datum.firing
                       ? '---'
                       : dateTimeFormatter(i18n.language).format(new Date(datum.y));
-                    return `Severity: ${datum.name}
-                    ID: ${datum.group_id}
-                    Component(s): ${datum.componentList?.join(', ')}
+                    const components = formatComponentList(datum.componentList);
+
+                    return `ID: ${datum.group_id}
+                    Severity: ${datum.name}
+                    Components: ${components}
                     Start: ${startDate}
                     End: ${endDate}`;
                   }}

--- a/web/src/components/Incidents/IncidentsTooltip.tsx
+++ b/web/src/components/Incidents/IncidentsTooltip.tsx
@@ -7,18 +7,17 @@ export const IncidentsTooltip = ({
   x,
   y,
   x0,
-  height,
   text,
 }: {
   x?: number;
   y?: number;
   x0?: number;
-  height?: number;
   text?: string | Array<string>;
 }) => {
-  const posx = x - (x - x0) / 2 - TOOLTIP_MAX_WIDTH / 2;
-  const posy = y - Math.min(height || 0, TOOLTIP_MAX_HEIGHT) / 2 - 20;
   const textArray: Array<string> = Array.isArray(text) ? text : [text];
+  const posx = x - (x - x0) / 2 - TOOLTIP_MAX_WIDTH / 2;
+  const tooltipHeight = textArray.length === 6 ? 165 : 145;
+  const posy = y - tooltipHeight;
 
   return (
     <VictoryPortal>

--- a/web/src/components/Incidents/IncidentsTooltip.tsx
+++ b/web/src/components/Incidents/IncidentsTooltip.tsx
@@ -2,7 +2,7 @@ import { VictoryPortal } from 'victory';
 import './incidents-styles.css';
 
 const TOOLTIP_MAX_HEIGHT = 300;
-const TOOLTIP_MAX_WIDTH = 500;
+const TOOLTIP_MAX_WIDTH = 650;
 export const IncidentsTooltip = ({
   x,
   y,

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -677,7 +677,9 @@ export const calculateChartDomain = (
   const minTimestamp = maxTimestamp - daysInSeconds;
 
   const timespan = maxTimestamp - minTimestamp;
-  const padding = timespan * 0.02;
+  // Padding based on number of days: 1 day = 4%, 3 days = 6%, 7+ days = 8%
+  const paddingPercent = dateValues.length === 1 ? 0.04 : dateValues.length === 3 ? 0.06 : 0.08;
+  const padding = timespan * paddingPercent;
   const domainMin = new Date((minTimestamp - padding) * 1000);
   const domainMax = new Date((maxTimestamp + padding) * 1000);
   return [domainMin, domainMax] as [Date, Date];


### PR DESCRIPTION
The `height` parameter was not the tooltip height (probably it was the whole chart height), so the vertical position computation was wrong. 

The height is now estimated based on the number of text lines in the tooltip.