### PR TITLE
OBSINTA-789: Sort alerts by start time

### DIFF
--- a/web/src/components/Incidents/processIncidents.ts
+++ b/web/src/components/Incidents/processIncidents.ts
@@ -2,21 +2,13 @@
 
 import { PrometheusLabels, PrometheusResult } from '@openshift-console/dynamic-plugin-sdk';
 import { Incident, Metric, ProcessedIncident } from './model';
-
-//this will be moved to the utils.js file when I convert them to the Typescript
-export function sortObjectsByEarliestTimestamp(incidents: PrometheusResult[]): PrometheusResult[] {
-  return incidents.sort((a, b) => {
-    const earliestA = Math.min(...a.values.map((value) => value[0]));
-    const earliestB = Math.min(...b.values.map((value) => value[0]));
-    return earliestA - earliestB;
-  });
-}
+import { sortByEarliestTimestamp } from './utils';
 
 export function processIncidents(data: PrometheusResult[]): ProcessedIncident[] {
   const incidents = groupById(data).filter(
     (incident) => incident.metric.src_alertname !== 'Watchdog',
   );
-  const sortedIncidents = sortObjectsByEarliestTimestamp(incidents);
+  const sortedIncidents = sortByEarliestTimestamp(incidents);
 
   return sortedIncidents.map((incident, index) => {
     // Determine severity flags based on values array

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -4,6 +4,7 @@ import {
   t_global_color_status_info_default,
   t_global_color_status_warning_default,
 } from '@patternfly/react-tokens';
+import { PrometheusResult } from '@openshift-console/dynamic-plugin-sdk';
 import { Dispatch } from 'redux';
 import { setIncidentsActiveFilters } from '../../store/actions';
 import {
@@ -17,6 +18,19 @@ import {
   SpanDates,
   Timestamps,
 } from './model';
+
+/**
+ * Sorts items by their earliest timestamp in ascending order.
+ * @param items - Array of Prometheus results to sort
+ * @returns Sorted array with earliest items first
+ */
+export function sortByEarliestTimestamp(items: PrometheusResult[]): PrometheusResult[] {
+  return items.sort((a, b) => {
+    const earliestA = Math.min(...a.values.map((value) => value[0]));
+    const earliestB = Math.min(...b.values.map((value) => value[0]));
+    return earliestA - earliestB;
+  });
+}
 
 function consolidateAndMergeIntervals(data: Incident, dateArray: SpanDates) {
   const severityRank = { 2: 2, 1: 1, 0: 0 };


### PR DESCRIPTION
Alerts were being sorted before filtering by the incident's time range, causing incorrect chronological order when some alert timestamps fell outside the range. Refactored to filter alerts first, then sort only the remaining alerts by their earliest visible timestamp.

Assisted-By: Claude