### PR TITLE
OU-1011: Display determistic start and end dates

### DIFF
--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
@@ -57,17 +57,22 @@ const IncidentsChart = ({
   theme,
   selectedGroupId,
   onIncidentClick,
+  currentTime,
 }: {
   incidentsData: Array<Incident>;
   chartDays: number;
   theme: 'light' | 'dark';
   selectedGroupId: string;
   onIncidentClick: (groupId: string) => void;
+  currentTime: number;
 }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [chartContainerHeight, setChartContainerHeight] = useState<number>();
   const [chartHeight, setChartHeight] = useState<number>();
-  const dateValues = useMemo(() => generateDateArray(chartDays), [chartDays]);
+  const dateValues = useMemo(
+    () => generateDateArray(chartDays, currentTime),
+    [chartDays, currentTime],
+  );
 
   const { i18n } = useTranslation();
 
@@ -206,7 +211,7 @@ const IncidentsChart = ({
                 tickLabelComponent={
                   <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
                 }
-                domain={calculateIncidentsChartDomain(dateValues)}
+                domain={calculateIncidentsChartDomain(dateValues, currentTime)}
               />
               <ChartGroup horizontal data-test={DataTestIDs.IncidentsChart.ChartBars}>
                 {chartData.map((bar) => {

--- a/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
@@ -45,13 +45,13 @@ const IncidentsDetailsRowTable = ({ alerts }: IncidentsDetailsRowTableProps) => 
                 <SeverityBadge severity={alertDetails.severity} />
               </Td>
               <Td dataLabel="expanded-details-firingstart">
-                <Timestamp timestamp={alertDetails.alertsStartFiring} />
+                <Timestamp timestamp={alertDetails.alertsStartFiring * 1000} />
               </Td>
               <Td dataLabel="expanded-details-firingend">
                 {!alertDetails.resolved ? (
                   '---'
                 ) : (
-                  <Timestamp timestamp={alertDetails.alertsEndFiring} />
+                  <Timestamp timestamp={alertDetails.alertsEndFiring * 1000} />
                 )}
               </Td>
               <Td dataLabel="expanded-details-alertstate">

--- a/web/src/components/Incidents/IncidentsTable.tsx
+++ b/web/src/components/Incidents/IncidentsTable.tsx
@@ -178,7 +178,7 @@ export const IncidentsTable = () => {
                       )}
                     </Td>
                     <Td dataLabel={columnNames.startDate}>
-                      <Timestamp timestamp={getMinStartDate(alert)} />
+                      <Timestamp timestamp={getMinStartDate(alert) * 1000} />
                     </Td>
                     <Td
                       dataLabel={columnNames.state}

--- a/web/src/components/Incidents/processAlerts.spec.ts
+++ b/web/src/components/Incidents/processAlerts.spec.ts
@@ -1,14 +1,15 @@
 import { PrometheusResult } from '@openshift-console/dynamic-plugin-sdk';
 import { convertToAlerts, deduplicateAlerts } from './processAlerts';
 import { Incident } from './model';
+import { getCurrentTime } from './utils';
 
 describe('convertToAlerts', () => {
-  const now = Date.now();
+  const now = getCurrentTime();
   const nowSeconds = Math.floor(now / 1000);
 
   describe('edge cases', () => {
     it('should return empty array when no prometheus results provided', () => {
-      const result = convertToAlerts([], []);
+      const result = convertToAlerts([], [], now);
       expect(result).toEqual([]);
     });
 
@@ -27,7 +28,7 @@ describe('convertToAlerts', () => {
           values: [[nowSeconds, '1']],
         },
       ];
-      const result = convertToAlerts(prometheusResults, []);
+      const result = convertToAlerts(prometheusResults, [], now);
       expect(result).toEqual([]);
     });
 
@@ -68,7 +69,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].alertname).toBe('ClusterOperatorDegraded');
     });
@@ -112,7 +113,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       // Should include values within incident time + 30s padding
       // Plus padding points added by insertPaddingPointsForChart
@@ -147,13 +148,57 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toEqual([]);
     });
   });
 
   describe('alert processing', () => {
-    it('should convert timestamps to milliseconds for firing times', () => {
+    it('should determine resolved status from original values BUT return padded values', () => {
+      const timestamp = nowSeconds - 660; // 11 minutes ago
+
+      const prometheusResults: PrometheusResult[] = [
+        {
+          metric: {
+            alertname: 'TestAlert',
+            namespace: 'test-namespace',
+            severity: 'critical',
+            component: 'test-component',
+            layer: 'test-layer',
+            name: 'test',
+            alertstate: 'firing',
+          },
+          values: [[timestamp, '2']],
+        },
+      ];
+
+      const incidents: Array<Partial<Incident>> = [
+        {
+          group_id: 'incident1',
+          src_alertname: 'TestAlert',
+          src_namespace: 'test-namespace',
+          src_severity: 'critical',
+          values: [[timestamp, '2']],
+        },
+      ];
+
+      const result = convertToAlerts(prometheusResults, incidents, now);
+      expect(result).toHaveLength(1);
+
+      // Verify resolved is determined from ORIGINAL values (before padding)
+      // Original timestamp: 11 minutes ago (> 10 minutes, so resolved)
+      const timeSinceOriginal = nowSeconds - timestamp;
+      expect(result[0].resolved).toBe(timeSinceOriginal >= 600); // >= 10 minutes
+      expect(result[0].resolved).toBe(true); // Should be resolved
+
+      // Verify the returned values ARE the padded values
+      expect(result[0].values.length).toBe(3); // Original + 2 padding points
+      expect(result[0].values[0][0]).toBe(timestamp - 300); // Padding before
+      expect(result[0].values[1][0]).toBe(timestamp); // Original
+      expect(result[0].values[2][0]).toBe(timestamp + 300); // Padding after
+    });
+
+    it('should use padded timestamps for firing times', () => {
       const timestamp = nowSeconds - 600; // 10 minutes ago
 
       const prometheusResults: PrometheusResult[] = [
@@ -181,20 +226,22 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].alertsStartFiring).toBeGreaterThan(0);
       expect(result[0].alertsEndFiring).toBeGreaterThan(0);
-      // insertPaddingPointsForChart adds a point 5 minutes (300s) before the first timestamp
-      // So alertsStartFiring should be 300s before the original timestamp
-      const expectedStart = (timestamp - 300) * 1000;
+      // alertsStartFiring and alertsEndFiring use padded timestamps
+      // This ensures table displays same times as chart
+      const expectedStart = timestamp - 300; // Padding point 5 minutes before
       expect(result[0].alertsStartFiring).toBe(expectedStart);
-      // alertsEndFiring should be the original timestamp
-      expect(result[0].alertsEndFiring).toBe(timestamp * 1000);
+      const expectedEnd = timestamp + 300; // Padding point 5 minutes after
+      expect(result[0].alertsEndFiring).toBe(expectedEnd);
     });
 
     it('should mark alert as resolved if ended more than 10 minutes ago', () => {
-      const oldTimestamp = nowSeconds - 900; // 15 minutes ago
+      const oldTimestamp = nowSeconds - 960; // 16 minutes ago
+      // After padding (+300s), last timestamp will be 11 minutes ago (960-300=660s ago)
+      // which is > 10 minutes, so it should be resolved
 
       const prometheusResults: PrometheusResult[] = [
         {
@@ -221,14 +268,16 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].alertstate).toBe('resolved');
       expect(result[0].resolved).toBe(true);
     });
 
     it('should mark alert as firing if ended less than 10 minutes ago', () => {
-      const recentTimestamp = nowSeconds - 300; // 5 minutes ago
+      const recentTimestamp = nowSeconds - 840; // 14 minutes ago
+      // After padding (+300s), last timestamp will be 9 minutes ago (840-300=540s ago)
+      // which is < 10 minutes, so it should still be firing
 
       const prometheusResults: PrometheusResult[] = [
         {
@@ -255,7 +304,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].alertstate).toBe('firing');
       expect(result[0].resolved).toBe(false);
@@ -308,7 +357,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(2);
       expect(result[0].alertname).toBe('Alert1'); // Earlier alert first
       expect(result[1].alertname).toBe('Alert2');
@@ -351,7 +400,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(2);
       expect(result[0].x).toBe(2); // Earliest alert has highest x
       expect(result[1].x).toBe(1); // Latest alert has lowest x
@@ -386,7 +435,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].silenced).toBe(true);
     });
@@ -417,7 +466,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].silenced).toBe(false);
     });
@@ -463,7 +512,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       // Should use the silenced value from the latest timestamp
       expect(result[0].silenced).toBe(true);
@@ -497,7 +546,7 @@ describe('convertToAlerts', () => {
         },
       ];
 
-      const result = convertToAlerts(prometheusResults, incidents);
+      const result = convertToAlerts(prometheusResults, incidents, now);
       expect(result).toHaveLength(1);
       expect(result[0].alertname).toBe('MyAlert');
       expect(result[0].namespace).toBe('my-namespace');

--- a/web/src/components/Incidents/processAlerts.ts
+++ b/web/src/components/Incidents/processAlerts.ts
@@ -2,11 +2,11 @@
 
 import { PrometheusResult, PrometheusRule } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, GroupedAlert, Incident, Severity } from './model';
-import { insertPaddingPointsForChart, sortByEarliestTimestamp } from './utils';
-
-// Constants for time-based calculations
-const ALERT_WINDOW_PADDING_SECONDS = 30;
-const ALERT_RESOLVED_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+import {
+  insertPaddingPointsForChart,
+  isResolved,
+  PROMETHEUS_QUERY_INTERVAL_SECONDS,
+} from './utils';
 
 /**
  * Deduplicates alert objects by their `alertname`, `namespace`, `component`, and `severity` fields and merges their values
@@ -201,6 +201,7 @@ function mergeIncidentsByKey(incidents: Array<Partial<Incident>>): Array<Partial
 export function convertToAlerts(
   prometheusResults: Array<PrometheusResult>,
   selectedIncidents: Array<Partial<Incident>>,
+  currentTime: number,
 ): Array<Alert> {
   // Merge selected incidents by composite key. Consolidates duplicates caused by non-key labels
   // like `pod` or `silenced` that aren't supported by cluster health analyzer.
@@ -211,13 +212,8 @@ export function convertToAlerts(
     (incident) => incident.values?.map((value) => value[0]) ?? [],
   );
 
-  // Handle edge case where there are no timestamps
-  if (timestamps.length === 0) {
-    return [];
-  }
-
-  const firstTimestamp = Math.min(...timestamps);
-  const lastTimestamp = Math.max(...timestamps);
+  const incidentFirstTimestamp = Math.min(...timestamps);
+  const incidentLastTimestamp = Math.max(...timestamps);
 
   // Watchdog is a heartbeat metric, not a real issue
   const validAlerts = prometheusResults.filter((alert) => alert.metric.alertname !== 'Watchdog');
@@ -225,13 +221,15 @@ export function convertToAlerts(
   const distinctAlerts = deduplicateAlerts(validAlerts);
 
   // Filter alerts to only include values within the incident's time window
+  const ALERT_WINDOW_PADDING_SECONDS = PROMETHEUS_QUERY_INTERVAL_SECONDS / 2;
+
   const alerts = distinctAlerts
-    .map((alert: PrometheusResult): PrometheusResult | null => {
+    .map((alert: PrometheusResult): Alert | null => {
       // Keep only values within the incident time range (with padding)
       const values: Array<[number, string]> = alert.values.filter(
         ([date]) =>
-          date >= firstTimestamp - ALERT_WINDOW_PADDING_SECONDS &&
-          date <= lastTimestamp + ALERT_WINDOW_PADDING_SECONDS,
+          date >= incidentFirstTimestamp - ALERT_WINDOW_PADDING_SECONDS &&
+          date <= incidentLastTimestamp + ALERT_WINDOW_PADDING_SECONDS,
       );
 
       // Exclude alerts with no values in this time window
@@ -239,53 +237,54 @@ export function convertToAlerts(
         return null;
       }
 
+      // Determine resolved status based on original values before padding
       const sortedValues = values.sort((a, b) => a[0] - b[0]);
-      const paddedValues = insertPaddingPointsForChart(sortedValues);
+      let lastTimestamp = sortedValues[sortedValues.length - 1][0];
+      const resolved = isResolved(lastTimestamp, currentTime);
+
+      // Find the associated incident, if it's one of the select ones
+      // Since incidents are already merged by (group_id, src_alertname, src_namespace, src_severity),
+      // there should be at most one matching incident
+      const matchingIncident = incidents.find(
+        (incident) =>
+          incident.src_alertname === alert.metric.alertname &&
+          incident.src_namespace === alert.metric.namespace &&
+          incident.src_severity === alert.metric.severity,
+      );
+
+      // Use silenced value from incident data (cluster_health_components_map)
+      // Default to false if no matching incident found
+      const silenced = matchingIncident?.silenced ?? false;
+
+      // Add padding points for chart rendering
+      const paddedValues = insertPaddingPointsForChart(sortedValues, currentTime);
+      const firstTimestamp = paddedValues[0][0];
+      lastTimestamp = paddedValues[paddedValues.length - 1][0];
 
       return {
-        ...alert,
+        alertname: alert.metric.alertname,
+        namespace: alert.metric.namespace,
+        severity: alert.metric.severity as Severity,
+        component: alert.metric.component,
+        layer: alert.metric.layer,
+        name: alert.metric.name,
+        alertstate: resolved ? 'resolved' : 'firing',
         values: paddedValues,
+        alertsStartFiring: firstTimestamp,
+        alertsEndFiring: lastTimestamp,
+        resolved,
+        x: 0, // Will be set after sorting
+        silenced,
       };
     })
-    .filter((alert): alert is PrometheusResult => alert !== null);
-
-  const sortedAlerts = sortByEarliestTimestamp(alerts);
-
-  return sortedAlerts.map((alert, index) => {
-    const alertsStartFiring = alert.values[0][0] * 1000;
-    const alertsEndFiring = alert.values[alert.values.length - 1][0] * 1000;
-    const resolved = Date.now() - alertsEndFiring > ALERT_RESOLVED_THRESHOLD_MS;
-
-    // Find the associated incident, if it's one of the select ones
-    // Since incidents are already merged by (group_id, src_alertname, src_namespace, src_severity),
-    // there should be at most one matching incident
-    const matchingIncident = incidents.find(
-      (incident) =>
-        incident.src_alertname === alert.metric.alertname &&
-        incident.src_namespace === alert.metric.namespace &&
-        incident.src_severity === alert.metric.severity,
-    );
-
-    // Use silenced value from incident data (cluster_health_components_map)
-    // Default to false if no matching incident found
-    const silenced = matchingIncident?.silenced ?? false;
-
-    return {
-      alertname: alert.metric.alertname,
-      namespace: alert.metric.namespace,
-      severity: alert.metric.severity as Severity,
-      component: alert.metric.component,
-      layer: alert.metric.layer,
-      name: alert.metric.name,
-      alertstate: resolved ? 'resolved' : 'firing',
-      values: alert.values,
-      alertsStartFiring,
-      alertsEndFiring,
-      resolved,
+    .filter((alert): alert is Alert => alert !== null)
+    .sort((a, b) => a.alertsStartFiring - b.alertsStartFiring)
+    .map((alert, index, sortedAlerts) => ({
+      ...alert,
       x: sortedAlerts.length - index,
-      silenced,
-    };
-  });
+    }));
+
+  return alerts;
 }
 
 export const groupAlertsForTable = (

--- a/web/src/components/Incidents/utils.spec.ts
+++ b/web/src/components/Incidents/utils.spec.ts
@@ -3,31 +3,65 @@ import { insertPaddingPointsForChart } from './utils';
 describe('insertPaddingPointsForChart', () => {
   describe('edge cases', () => {
     it('should return empty array when input is empty', () => {
-      const result = insertPaddingPointsForChart([]);
+      const currentTime = 2000 * 1000; // 2000 seconds in ms
+      const result = insertPaddingPointsForChart([], currentTime);
       expect(result).toEqual([]);
     });
 
-    it('should handle a single data point', () => {
+    it('should handle a single data point without after padding when currentTime < item + interval', () => {
       const input: Array<[number, string]> = [[1000, 'critical']];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1200 * 1000; // 1200 seconds in ms (< 1000 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
       // Should add padding point 5 minutes (300 seconds) before the single point
+      // No after padding since currentTime < 1000 + 300
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual([700, 'critical']); // 1000 - 300 = 700
       expect(result[1]).toEqual([1000, 'critical']);
     });
+
+    it('should handle a single data point with after padding when currentTime >= item + interval', () => {
+      const input: Array<[number, string]> = [[1000, 'critical']];
+      const currentTime = 1300 * 1000; // 1300 seconds in ms (>= 1000 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
+
+      // Should add padding point before and after
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual([700, 'critical']); // 1000 - 300 = 700
+      expect(result[1]).toEqual([1000, 'critical']);
+      expect(result[2]).toEqual([1300, 'critical']); // 1000 + 300 = 1300
+    });
   });
 
   describe('continuous sequences (no gaps)', () => {
-    it('should only add padding before first point when all points are within 5 minutes', () => {
+    it('should add padding before first point and after last point when currentTime allows', () => {
       const input: Array<[number, string]> = [
         [1000, 'warning'],
         [1100, 'warning'], // 100 seconds later (< 5 min)
         [1200, 'warning'], // 100 seconds later (< 5 min)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1500 * 1000; // 1500 seconds (>= 1200 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      // Should have 4 points: 1 padding + 3 original
+      // Should have 5 points: 1 padding before + 3 original + 1 padding after
+      expect(result).toHaveLength(5);
+      expect(result[0]).toEqual([700, 'warning']); // Padding before first
+      expect(result[1]).toEqual([1000, 'warning']);
+      expect(result[2]).toEqual([1100, 'warning']);
+      expect(result[3]).toEqual([1200, 'warning']);
+      expect(result[4]).toEqual([1500, 'warning']); // Padding after last
+    });
+
+    it('should add only before padding when currentTime < last + interval', () => {
+      const input: Array<[number, string]> = [
+        [1000, 'warning'],
+        [1100, 'warning'], // 100 seconds later (< 5 min)
+        [1200, 'warning'], // 100 seconds later (< 5 min)
+      ];
+      const currentTime = 1400 * 1000; // 1400 seconds (< 1200 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
+
+      // Should have 4 points: 1 padding before + 3 original (no after padding)
       expect(result).toHaveLength(4);
       expect(result[0]).toEqual([700, 'warning']); // Padding before first
       expect(result[1]).toEqual([1000, 'warning']);
@@ -40,31 +74,37 @@ describe('insertPaddingPointsForChart', () => {
         [1000, 'info'],
         [1300, 'info'], // Exactly 300 seconds (5 minutes)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1600 * 1000; // 1600 seconds (>= 1300 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
       // At threshold (300s), should NOT create a gap
-      // Only padding before first point
-      expect(result).toHaveLength(3);
+      // Should have before padding, 2 original points, and after padding
+      expect(result).toHaveLength(4);
       expect(result[0]).toEqual([700, 'info']); // Padding before first
       expect(result[1]).toEqual([1000, 'info']);
       expect(result[2]).toEqual([1300, 'info']);
+      expect(result[3]).toEqual([1600, 'info']); // Padding after last
     });
   });
 
   describe('sequences with gaps', () => {
-    it('should add padding point before a gap > 5 minutes', () => {
+    it('should add padding point before and after a gap > 5 minutes', () => {
       const input: Array<[number, string]> = [
         [1000, 'critical'],
         [1500, 'critical'], // 500 seconds later (> 5 min threshold of 301s)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1800 * 1000; // 1800 seconds (>= 1500 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      // Should have: padding before first + first point + padding before gap + second point
-      expect(result).toHaveLength(4);
+      // Should have: padding before first + first point + padding after first
+      // + padding before second + second point + padding after second
+      expect(result).toHaveLength(6);
       expect(result[0]).toEqual([700, 'critical']); // Padding before first
       expect(result[1]).toEqual([1000, 'critical']);
-      expect(result[2]).toEqual([1200, 'critical']); // Padding before gap: 1500 - 300
-      expect(result[3]).toEqual([1500, 'critical']);
+      expect(result[2]).toEqual([1300, 'critical']); // Padding after first (gap with next)
+      expect(result[3]).toEqual([1200, 'critical']); // Padding before second (gap)
+      expect(result[4]).toEqual([1500, 'critical']);
+      expect(result[5]).toEqual([1800, 'critical']); // Padding after last
     });
 
     it('should add padding point when gap is exactly threshold + 1 second', () => {
@@ -72,28 +112,33 @@ describe('insertPaddingPointsForChart', () => {
         [1000, 'warning'],
         [1302, 'warning'], // 302 seconds later (> threshold of 301)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1602 * 1000; // 1602 seconds (>= 1302 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
       // Should detect gap since it's > threshold (301s)
-      expect(result).toHaveLength(4);
+      expect(result).toHaveLength(6);
       expect(result[0]).toEqual([700, 'warning']); // Padding before first
       expect(result[1]).toEqual([1000, 'warning']);
-      expect(result[2]).toEqual([1002, 'warning']); // Padding before gap: 1302 - 300
-      expect(result[3]).toEqual([1302, 'warning']);
+      expect(result[2]).toEqual([1300, 'warning']); // Padding after first (gap with next)
+      expect(result[3]).toEqual([1002, 'warning']); // Padding before second (gap)
+      expect(result[4]).toEqual([1302, 'warning']);
+      expect(result[5]).toEqual([1602, 'warning']); // Padding after last
     });
 
-    it('should NOT add padding when gap is exactly at threshold (301s)', () => {
+    it('should NOT add padding after when gap is exactly at threshold (301s)', () => {
       const input: Array<[number, string]> = [
         [1000, 'warning'],
         [1301, 'warning'], // 301 seconds later (= threshold, not > threshold)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1601 * 1000; // 1601 seconds (>= 1301 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
       // Should NOT detect gap since 301 is not > 301
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
       expect(result[0]).toEqual([700, 'warning']); // Padding before first
       expect(result[1]).toEqual([1000, 'warning']);
       expect(result[2]).toEqual([1301, 'warning']); // No padding before this
+      expect(result[3]).toEqual([1601, 'warning']); // Padding after last
     });
 
     it('should handle multiple gaps in sequence', () => {
@@ -103,16 +148,20 @@ describe('insertPaddingPointsForChart', () => {
         [2100, 'warning'], // No gap (100s)
         [3000, 'info'], // Gap of 900s
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 3300 * 1000; // 3300 seconds (>= 3000 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result).toHaveLength(7);
+      expect(result).toHaveLength(10);
       expect(result[0]).toEqual([700, 'critical']); // Padding before first
       expect(result[1]).toEqual([1000, 'critical']);
-      expect(result[2]).toEqual([1700, 'critical']); // Padding before first gap
-      expect(result[3]).toEqual([2000, 'critical']);
-      expect(result[4]).toEqual([2100, 'warning']); // No padding (continuous)
-      expect(result[5]).toEqual([2700, 'info']); // Padding before second gap
-      expect(result[6]).toEqual([3000, 'info']);
+      expect(result[2]).toEqual([1300, 'critical']); // Padding after first (gap with next)
+      expect(result[3]).toEqual([1700, 'critical']); // Padding before second (gap)
+      expect(result[4]).toEqual([2000, 'critical']);
+      expect(result[5]).toEqual([2100, 'warning']); // No padding (continuous)
+      expect(result[6]).toEqual([2400, 'warning']); // Padding after warning (gap with next)
+      expect(result[7]).toEqual([2700, 'info']); // Padding before info (gap)
+      expect(result[8]).toEqual([3000, 'info']);
+      expect(result[9]).toEqual([3300, 'info']); // Padding after last
     });
   });
 
@@ -122,13 +171,16 @@ describe('insertPaddingPointsForChart', () => {
         [1000, 'critical'],
         [2000, 'warning'],
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 2300 * 1000; // 2300 seconds (>= 2000 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      // Padding points should have same severity as the point they precede
+      // Padding points should have same severity as the point they precede/follow
       expect(result[0][1]).toBe('critical'); // Padding before first critical
       expect(result[1][1]).toBe('critical'); // Original critical
-      expect(result[2][1]).toBe('warning'); // Padding before warning (due to gap)
-      expect(result[3][1]).toBe('warning'); // Original warning
+      expect(result[2][1]).toBe('critical'); // Padding after critical (gap with next)
+      expect(result[3][1]).toBe('warning'); // Padding before warning (due to gap)
+      expect(result[4][1]).toBe('warning'); // Original warning
+      expect(result[5][1]).toBe('warning'); // Padding after warning
     });
 
     it('should handle different severity types', () => {
@@ -137,12 +189,14 @@ describe('insertPaddingPointsForChart', () => {
         [1100, '1'], // Warning (numeric)
         [1200, '0'], // Info (numeric)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1500 * 1000; // 1500 seconds (>= 1200 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result[0]).toEqual([700, '2']); // Padding preserves severity
+      expect(result[0]).toEqual([700, '2']); // Padding before first
       expect(result[1]).toEqual([1000, '2']);
       expect(result[2]).toEqual([1100, '1']);
       expect(result[3]).toEqual([1200, '0']);
+      expect(result[4]).toEqual([1500, '0']); // Padding after last
     });
   });
 
@@ -156,18 +210,22 @@ describe('insertPaddingPointsForChart', () => {
         [2100, 'warning'], // Continuous (100s)
         [3000, 'info'], // Gap (900s)
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 3300 * 1000; // 3300 seconds (>= 3000 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(12);
       expect(result[0]).toEqual([700, 'critical']); // Initial padding
       expect(result[1]).toEqual([1000, 'critical']);
       expect(result[2]).toEqual([1100, 'critical']);
       expect(result[3]).toEqual([1200, 'critical']);
-      expect(result[4]).toEqual([1700, 'warning']); // Padding before gap
-      expect(result[5]).toEqual([2000, 'warning']);
-      expect(result[6]).toEqual([2100, 'warning']);
-      expect(result[7]).toEqual([2700, 'info']); // Padding before gap
-      expect(result[8]).toEqual([3000, 'info']);
+      expect(result[4]).toEqual([1500, 'critical']); // Padding after critical (gap with next)
+      expect(result[5]).toEqual([1700, 'warning']); // Padding before warning (gap)
+      expect(result[6]).toEqual([2000, 'warning']);
+      expect(result[7]).toEqual([2100, 'warning']);
+      expect(result[8]).toEqual([2400, 'warning']); // Padding after warning (gap with next)
+      expect(result[9]).toEqual([2700, 'info']); // Padding before info (gap)
+      expect(result[10]).toEqual([3000, 'info']);
+      expect(result[11]).toEqual([3300, 'info']); // Padding after last
     });
 
     it('should handle very large timestamps', () => {
@@ -175,12 +233,14 @@ describe('insertPaddingPointsForChart', () => {
         [1704067200, 'critical'], // 2024-01-01 00:00:00 UTC
         [1704067500, 'critical'], // 5 minutes later
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1704067800 * 1000; // 5 minutes after last point
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
       expect(result[0]).toEqual([1704066900, 'critical']); // 5 min before first
       expect(result[1]).toEqual([1704067200, 'critical']);
       expect(result[2]).toEqual([1704067500, 'critical']);
+      expect(result[3]).toEqual([1704067800, 'critical']); // 5 min after last
     });
 
     it('should preserve original array order', () => {
@@ -189,7 +249,8 @@ describe('insertPaddingPointsForChart', () => {
         [1100, 'warning'],
         [1200, 'info'],
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1500 * 1000; // 1500 seconds (>= 1200 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
       // Verify timestamps are in ascending order
       for (let i = 1; i < result.length; i++) {
@@ -201,11 +262,13 @@ describe('insertPaddingPointsForChart', () => {
   describe('boundary conditions', () => {
     it('should handle points at minimum timestamp (0)', () => {
       const input: Array<[number, string]> = [[0, 'critical']];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 300 * 1000; // 300 seconds (>= 0 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
       expect(result[0]).toEqual([-300, 'critical']); // Negative timestamp is valid
       expect(result[1]).toEqual([0, 'critical']);
+      expect(result[2]).toEqual([300, 'critical']); // Padding after
     });
 
     it('should handle very small time differences', () => {
@@ -213,12 +276,14 @@ describe('insertPaddingPointsForChart', () => {
         [1000, 'critical'],
         [1001, 'critical'], // 1 second apart
       ];
-      const result = insertPaddingPointsForChart(input);
+      const currentTime = 1301 * 1000; // 1301 seconds (>= 1001 + 300)
+      const result = insertPaddingPointsForChart(input, currentTime);
 
-      expect(result).toHaveLength(3);
-      expect(result[0]).toEqual([700, 'critical']); // Only initial padding
+      expect(result).toHaveLength(4);
+      expect(result[0]).toEqual([700, 'critical']); // Padding before first
       expect(result[1]).toEqual([1000, 'critical']);
       expect(result[2]).toEqual([1001, 'critical']);
+      expect(result[3]).toEqual([1301, 'critical']); // Padding after last
     });
   });
 });

--- a/web/src/components/Incidents/utils.ts
+++ b/web/src/components/Incidents/utils.ts
@@ -20,37 +20,115 @@ import {
 } from './model';
 
 /**
+ * The Prometheus query step interval in seconds.
+ *
+ * All time-related operations are aligned to this interval:
+ * - Prometheus queries use step=300 (calculated from samples=288 for 24h timespan)
+ * - Current time is rounded to 5-minute boundaries
+ * - Resolved threshold is 10 minutes (2x query interval)
+ * - Chart padding points are added 5 minutes before incidents
+ * - Gap detection identifies gaps larger than 5 minutes
+ */
+export const PROMETHEUS_QUERY_INTERVAL_SECONDS = 300; // 5 minutes
+
+/**
+ * Returns the current time in milliseconds, rounded down to the nearest query interval.
+ * For example: 10:03 -> 10:00, 10:05 -> 10:05, 10:06 -> 10:05
+ *
+ * This rounding is done for several important reasons:
+ * 1. **Prometheus query alignment**: Our Prometheus queries use step=300 (5 minutes), so we won't
+ *    receive data updates more frequently than every 5 minutes anyway.
+ * 2. **Consistent sampling intervals**: By rounding to 5-minute boundaries, we ensure that the same
+ *    timestamps are used across refreshes. This prevents the chart data from shifting slightly with
+ *    each refresh, which would cause unnecessary re-renders and visual instability.
+ * 3. **Query efficiency**: Multiple requests within the same 5-minute window will use identical
+ *    timestamps, improving cache hit rates and reducing redundant queries.
+ *
+ * Centralized function for getting current time, making it easy to mock in tests.
+ *
+ * @returns Current timestamp in milliseconds since Unix epoch, rounded to nearest query interval
+ */
+export const getCurrentTime = (): number => {
+  const now = Date.now();
+  const intervalMs = PROMETHEUS_QUERY_INTERVAL_SECONDS * 1000;
+  return Math.floor(now / intervalMs) * intervalMs;
+};
+
+/**
+ * Determines if an incident or alert is resolved based on the time elapsed since the last data point.
+ *
+ * An incident/alert is considered resolved if the last data point is older than or equal to
+ * twice the Prometheus query interval (10 minutes). This threshold provides a buffer to avoid
+ * premature resolution during transient data delays.
+ * This centralized logic ensures consistent resolved detection across incidents and alerts.
+ *
+ * @param lastTimestamp - The timestamp of the last data point in seconds (Prometheus format)
+ * @param currentTime - The current time in milliseconds (JavaScript Date.now() format)
+ * @returns true if resolved (last data point >= 2x query interval old), false if still firing
+ */
+export const isResolved = (lastTimestamp: number, currentTime: number): boolean => {
+  const delta = currentTime - lastTimestamp * 1000;
+  const threshold = 2 * PROMETHEUS_QUERY_INTERVAL_SECONDS * 1000;
+  return delta >= threshold;
+};
+
+/**
  * Inserts padding data points to ensure the chart renders correctly.
  * This allows the chart to properly render events, especially single data points.
  *
+ * Padding points are added at the Prometheus query interval (5 minutes):
+ * - Before the first data point
+ * - Before any data point after a gap larger than the query interval
+ * - After the last data point (if currentTime >= last item + interval)
+ * - After the last item of a continuous sequence (gap with next point > interval)
+ *
  * @param values - Array of [timestamp, severity] tuples (assumed to be sorted by time)
+ * @param currentTime - The current time in milliseconds (for determining if last item needs padding)
  * @returns New array with additional data points inserted where needed
  */
 export function insertPaddingPointsForChart(
   values: Array<[number, string]>,
+  currentTime: number,
 ): Array<[number, string]> {
   if (values.length === 0) {
     return values;
   }
 
   const result: Array<[number, string]> = [];
-  const fiveMinutes = 5 * 60;
-  const threshold = fiveMinutes + 1;
+  const threshold = PROMETHEUS_QUERY_INTERVAL_SECONDS + 1;
+  const currentTimeSeconds = currentTime / 1000;
 
   for (let i = 0; i < values.length; i++) {
     const current = values[i];
-    const previous = i > 0 ? result[result.length - 1] : null;
+    const previous = i > 0 ? values[i - 1] : null;
+    const next = i < values.length - 1 ? values[i + 1] : null;
 
-    // Add a data point with the same severity 5 minutes earlier if:
+    // Add a data point with the same severity one query interval earlier if:
     // - This is the first item (no previous item)
-    // - This is the first item of a continuous sequence (gap with previous point > 5 min)
+    // - This is the first item of a continuous sequence (gap with previous point > interval)
     if (!previous || current[0] - previous[0] > threshold) {
-      const timestamp = current[0] - fiveMinutes;
+      const timestamp = current[0] - PROMETHEUS_QUERY_INTERVAL_SECONDS;
       const severity = current[1];
       result.push([timestamp, severity]);
     }
 
     result.push(current);
+
+    // Add a data point with the same severity one query interval later if:
+    // - This is the last item and currentTime >= this item + interval
+    // - This is the last item of a continuous sequence (gap with next point > interval)
+    const isLastItem = !next;
+    const hasGapWithNext = next && next[0] - current[0] > threshold;
+
+    if (isLastItem && currentTimeSeconds >= current[0] + PROMETHEUS_QUERY_INTERVAL_SECONDS) {
+      const timestamp = current[0] + PROMETHEUS_QUERY_INTERVAL_SECONDS;
+      const severity = current[1];
+      result.push([timestamp, severity]);
+    } else if (hasGapWithNext) {
+      const timestamp = current[0] + PROMETHEUS_QUERY_INTERVAL_SECONDS;
+      const severity = current[1];
+      result.push([timestamp, severity]);
+    }
   }
 
   return result;
@@ -157,7 +235,7 @@ function generateIntervalsWithGaps(filteredValues: Array<Timestamps>, dateArray:
 }
 
 /**
- * Checks if there is a gap larger than 5 minutes between consecutive timestamps.
+ * Checks if there is a gap larger than the Prometheus query interval between consecutive timestamps.
  * @param {Array} filteredValues - The array of filtered timestamps and severities.
  * @param {number} index - The current index in the array.
  * @returns {boolean} - Whether a gap exists.
@@ -165,7 +243,8 @@ function generateIntervalsWithGaps(filteredValues: Array<Timestamps>, dateArray:
 function hasGap(filteredValues: Array<Timestamps>, index: number) {
   const previousTimestamp = filteredValues[index - 1][0];
   const currentTimestamp = filteredValues[index][0];
-  return (currentTimestamp - previousTimestamp) / 60 > 5;
+  const gapMinutes = (currentTimestamp - previousTimestamp) / 60;
+  return gapMinutes > PROMETHEUS_QUERY_INTERVAL_SECONDS / 60;
 }
 
 /**
@@ -192,6 +271,7 @@ function createNodataInterval(
  */
 export const createIncidentsChartBars = (incident: Incident, dateArray: SpanDates) => {
   const groupedData = consolidateAndMergeIntervals(incident, dateArray);
+
   const data: {
     y0: Date;
     y: Date;
@@ -331,8 +411,8 @@ export const createAlertsChartBars = (alert: IncidentsDetailsAlert): AlertsChart
  * //   1754900043
  * // ]
  */
-export function generateDateArray(days: number): Array<number> {
-  const currentDate = new Date();
+export function generateDateArray(days: number, currentTime: number): Array<number> {
+  const currentDate = new Date(currentTime);
 
   const dateArray: Array<number> = [];
   for (let i = 0; i < days; i++) {
@@ -356,10 +436,13 @@ export function generateDateArray(days: number): Array<number> {
  * const alertsDateRange = generateAlertsDateArray(alertsData);
  * // Returns timestamps spanning from earliest alert minus padding to latest alert plus padding
  */
-export function generateAlertsDateArray(alertsData: Array<Alert>): Array<number> {
+export function generateAlertsDateArray(
+  alertsData: Array<Alert>,
+  currentTime: number,
+): Array<number> {
   if (!Array.isArray(alertsData) || alertsData.length === 0) {
     // Fallback to current day if no alerts data
-    const now = new Date();
+    const now = new Date(currentTime);
     now.setHours(0, 0, 0, 0);
     return [now.getTime() / 1000];
   }
@@ -379,7 +462,7 @@ export function generateAlertsDateArray(alertsData: Array<Alert>): Array<number>
 
   // Handle edge case where no valid timestamps found
   if (minTimestamp === Infinity || maxTimestamp === -Infinity) {
-    const now = new Date();
+    const now = new Date(currentTime);
     now.setHours(0, 0, 0, 0);
     return [now.getTime() / 1000];
   }
@@ -708,23 +791,33 @@ const onSelect = (event, selection, dispatch, incidentsActiveFilters, filterCate
  */
 export const calculateIncidentsChartDomain = (
   dateValues: Array<number>,
+  currentTime: number,
 ): [Date, Date] | undefined => {
   if (dateValues.length === 0) return undefined;
 
   // Upper bound is always current time
-  const now = new Date();
-  const maxTimestamp = now.getTime() / 1000;
+  const maxTimestamp = currentTime / 1000;
 
   // Calculate minTimestamp based on number of days
   const daysInSeconds = dateValues.length * 86400; // Convert days to seconds
   const minTimestamp = maxTimestamp - daysInSeconds;
 
-  const timespan = maxTimestamp - minTimestamp;
-  // Padding based on number of days: 1 day = 4%, 3 days = 6%, 7+ days = 8%
-  const paddingPercent = dateValues.length === 1 ? 0.04 : dateValues.length === 3 ? 0.06 : 0.08;
-  const padding = timespan * paddingPercent;
-  const domainMin = new Date((minTimestamp - padding) * 1000);
-  const domainMax = new Date((maxTimestamp + padding) * 1000);
+  // Padding in hours converted to seconds
+  // 1 day = 3 hours, 3 days = 6 hours, 7 days = 12 hours, else = 24 hours
+  let paddingHours: number;
+  if (dateValues.length === 1) {
+    paddingHours = 0.6;
+  } else if (dateValues.length === 3) {
+    paddingHours = 2;
+  } else if (dateValues.length === 7) {
+    paddingHours = 4;
+  } else {
+    paddingHours = 6;
+  }
+  const paddingSeconds = paddingHours * 3600; // Convert hours to seconds
+
+  const domainMin = new Date((minTimestamp - paddingSeconds) * 1000);
+  const domainMax = new Date((maxTimestamp + paddingSeconds) * 1000);
   return [domainMin, domainMax] as [Date, Date];
 };
 

--- a/web/src/store/actions.ts
+++ b/web/src/store/actions.ts
@@ -43,6 +43,7 @@ export enum ActionType {
   SetIncidentsChartSelection = 'setIncidentsChartSelection',
   SetFilteredIncidentsData = 'setFilteredIncidentsData',
   SetIncidentPageFilterType = 'setIncidentPageFilterType',
+  SetIncidentsLastRefreshTime = 'setIncidentsLastRefreshTime',
 }
 
 export type Perspective = 'admin' | 'dev' | 'acm' | 'virtualization-perspective';
@@ -190,6 +191,9 @@ export const setFilteredIncidentsData = (filteredIncidentsData) =>
 export const setIncidentPageFilterType = (filterTypeSelected) =>
   action(ActionType.SetIncidentPageFilterType, filterTypeSelected);
 
+export const setIncidentsLastRefreshTime = (timestamp: number) =>
+  action(ActionType.SetIncidentsLastRefreshTime, { timestamp });
+
 type Actions = {
   AlertingSetErrored: typeof alertingSetErrored;
   AlertingSetLoading: typeof alertingSetLoading;
@@ -231,6 +235,7 @@ type Actions = {
   setIncidentsChartSelection: typeof setIncidentsChartSelection;
   setFilteredIncidentsData: typeof setFilteredIncidentsData;
   setIncidentPageFilterType: typeof setIncidentPageFilterType;
+  setIncidentsLastRefreshTime: typeof setIncidentsLastRefreshTime;
 };
 
 export type ObserveAction = Action<Actions>;

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -385,6 +385,11 @@ const monitoringReducer = produce((draft: ObserveState, action: ObserveAction): 
       break;
     }
 
+    case ActionType.SetIncidentsLastRefreshTime: {
+      draft.incidentsData.incidentsLastRefreshTime = action.payload.timestamp;
+      break;
+    }
+
     default:
       break;
   }

--- a/web/src/store/store.ts
+++ b/web/src/store/store.ts
@@ -48,6 +48,7 @@ export type ObserveState = {
       groupId: Array<string>;
     };
     incidentPageFilterType: string;
+    incidentsLastRefreshTime: number | null;
   };
   queryBrowser: {
     pollInterval: string | null;
@@ -94,6 +95,7 @@ export const defaultObserveState: ObserveState = {
       groupId: [],
     },
     incidentPageFilterType: 'Severity',
+    incidentsLastRefreshTime: null,
   },
   alerting: {},
   hideGraphs: false,


### PR DESCRIPTION
- Centralize Date.now() into getCurrentTime(), rounded to 5-minute intervals
- Add incidentsLastRefreshTime to redux state, updated at every Prometheus query and used as time reference for the session (prevents timeline from shifting on refresh as Date.now() updates)
- Add ±5 min padding points for chart rendering because: (a) Prometheus data points are lower bounds of 5-min intervals, and (b) alerts firing mid-interval won't have data points
- Ensure table timestamps match chart display

Assisted by: Claude (claude-sonnet, claude-3-5-haiku)