### PR TITLE
OCPBUGS-62282: add missing translation string

### DIFF
--- a/web/locales/en/plugin__monitoring-plugin.json
+++ b/web/locales/en/plugin__monitoring-plugin.json
@@ -96,6 +96,7 @@
   "Refresh interval": "Refresh interval",
   "Dashboards": "Dashboards",
   "Inspect": "Inspect",
+  "Export as CSV": "Export as CSV",
   "Error loading card": "Error loading card",
   "Metrics dashboards": "Metrics dashboards",
   "panel.styles attribute not found": "panel.styles attribute not found",
@@ -124,7 +125,6 @@
   "Show table": "Show table",
   "Show series": "Show series",
   "Hide series": "Hide series",
-  "Export as CSV": "Export as CSV",
   "Disable query": "Disable query",
   "Enable query": "Enable query",
   "Query must be enabled": "Query must be enabled",
@@ -224,5 +224,7 @@
   "Metrics targets": "Metrics targets",
   "Error loading latest targets data": "Error loading latest targets data",
   "Search by endpoint or namespace...": "Search by endpoint or namespace...",
-  "Text": "Text"
+  "Text": "Text",
+  "Alerting Rule": "Alerting Rule",
+  "Alerting Rules": "Alerting Rules"
 }

--- a/web/src/components/utils.ts
+++ b/web/src/components/utils.ts
@@ -31,6 +31,8 @@ export const AlertResource: MonitoringResource = {
 
 export const RuleResource: MonitoringResource = {
   kind: 'AlertRule',
+  // t('Alerting Rule')
+  // t('Alerting Rules')
   label: 'Alerting Rule',
   plural: '/monitoring/alertrules',
   abbr: 'AR',


### PR DESCRIPTION
Add missing translation string which is causing CI failures in the `openshift/console` release-4.17 tests

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_console/15545/pull-ci-openshift-console-release-4.17-e2e-gcp-console/1972992950069628928