### PR TITLE
OU-1032: resolve stale Redux state bug in incidents time range calculation

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -227,8 +227,8 @@ const IncidentsPage = () => {
   const title = t('Incidents');
 
   useEffect(() => {
-    setTimeRanges(getIncidentsTimeRanges(daysSpan, incidentsLastRefreshTime, dispatch));
-  }, [daysSpan, selectedGroupId, incidentsLastRefreshTime, dispatch]);
+    setTimeRanges(getIncidentsTimeRanges(daysSpan, incidentsLastRefreshTime));
+  }, [daysSpan, selectedGroupId, incidentsLastRefreshTime]);
 
   useEffect(() => {
     setDaysSpan(
@@ -308,11 +308,7 @@ const IncidentsPage = () => {
         ? incidentsActiveFilters.days[0].split(' ')[0] + 'd'
         : '',
     );
-    const calculatedTimeRanges = getIncidentsTimeRanges(
-      daysDuration,
-      incidentsLastRefreshTime,
-      dispatch,
-    );
+    const calculatedTimeRanges = getIncidentsTimeRanges(daysDuration, currentTime);
 
     const isGroupSelected = !!selectedGroupId;
     const incidentsQuery = isGroupSelected

--- a/web/src/components/Incidents/api.ts
+++ b/web/src/components/Incidents/api.ts
@@ -59,6 +59,8 @@ export const createAlertsQuery = (groupedAlertsValues) => {
     })
     .join(' or '); // Join all individual alert queries with "or"
 
+  // TODO: remove duplicated conditions, optimize query
+
   return alertsQuery;
 };
 


### PR DESCRIPTION
`getIncidentsTimeRanges()` used `incidentsLastRefreshTime` from `useSelector` immediately after dispatching an update. Since Redux state updates asynchronously, it always received the stale/old value instead of the current time.

- Changed calls to use the local `currentTime` variable instead of Redux state
- Simplified `getIncidentsTimeRanges()` signature: removed dispatch parameter and null handling