### PR TITLE
OU-1033: close the first dropdown when deselecting incident

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -153,6 +153,19 @@ const IncidentsPage = () => {
     (state: MonitoringState) => state.plugins.mcp.incidentsData.incidentsLastRefreshTime,
   );
 
+  const closeDropDownFilters = (): void => {
+    setFiltersExpanded({
+      severity: false,
+      state: false,
+      groupId: false,
+    });
+
+    setFilterTypeExpanded({
+      filterType: false,
+    });
+    setDaysFilterIsExpanded(false);
+  };
+
   useEffect(() => {
     const hasUrlParams = Object.keys(urlParams).length > 0;
     if (hasUrlParams) {
@@ -306,6 +319,7 @@ const IncidentsPage = () => {
           setIncidentForAlertProcessing(processIncidentsForAlerts(prometheusResults));
           dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
         } else {
+          closeDropDownFilters();
           setIncidentForAlertProcessing([]);
           dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
         }
@@ -344,11 +358,8 @@ const IncidentsPage = () => {
 
   const handleIncidentChartClick = useCallback(
     (groupId) => {
-      setFiltersExpanded({
-        severity: false,
-        state: false,
-        groupId: false,
-      });
+      closeDropDownFilters();
+
       if (groupId === selectedGroupId) {
         dispatch(
           setIncidentsActiveFilters({
@@ -389,6 +400,7 @@ const IncidentsPage = () => {
             data-test={DataTestIDs.IncidentsPage.Toolbar}
             collapseListedFiltersBreakpoint="xl"
             clearAllFilters={() => {
+              closeDropDownFilters();
               dispatch(
                 setIncidentsActiveFilters({
                   incidentsActiveFilters: {


### PR DESCRIPTION
This is to close the dropdown menu before selecting/deselecting the incident to avoid:

<img width="1200" height="607" alt="Snímek obrazovky z 2025-10-14 13-16-41" src="https://github.com/user-attachments/assets/4fd65ac8-d273-410f-b008-07db9f577efb" />
