### PR TITLE
OBSINTA-777: Tests for Incidents Redux Related Regressions

### DIFF
--- a/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
+++ b/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
@@ -1,0 +1,186 @@
+/*
+Regression tests for Redux state management and effects issues (Section 4.5).
+
+Test cases:
+1. Initial Loading Bug: All incidents should load on fresh page load without
+   requiring days filter manipulation.
+   Verifies: OU-1002
+2. Dropdown Closure on Deselection: Verifies dropdowns close when incident is
+   deselected via bar click OR chip removal.
+   Verifies: OU-1033
+3. Filter State Preservation: When incident ID is selected and a non-matching
+   severity filter is added, both filters should remain applied.
+   Verifies: OU-1030
+*/
+
+import { incidentsPage } from '../../../views/incidents-page';
+
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+describe('Regression: Redux State Management', () => {
+
+  before(() => {
+    cy.beforeBlockCOO(MCP, MP);
+  });
+
+  beforeEach(() => {
+    cy.log('Navigate to Observe → Incidents');
+    incidentsPage.goTo();
+    cy.log('Setting up comprehensive filtering test scenarios');
+    cy.mockIncidentFixture('incident-scenarios/7-comprehensive-filtering-test-scenarios.yaml');
+  });
+
+  it('1. Fresh load should display all 12 incidents without days filter manipulation', () => {
+    cy.log('1.1 Verify all incidents load immediately on fresh page load');
+    
+    incidentsPage.clearAllFilters();
+    incidentsPage.elements.incidentsChartContainer().should('be.visible');
+    
+    // The bug: initially not all incidents are loaded, requiring days filter toggle
+    // Use waitUntil to give it time to load, but it should load quickly if working properly
+    cy.waitUntil(
+      () => incidentsPage.elements.incidentsChartBarsGroups().then($groups => $groups.length === 12),
+      {
+        timeout: 10000,
+        interval: 500,
+        errorMsg: 'All 12 incidents should load within 10 seconds on fresh page load'
+      }
+    );
+    cy.log('SUCCESS: All 12 incidents loaded on fresh page load');
+    
+    cy.log('1.2 Verify incident count remains stable without manipulation');
+    incidentsPage.elements.incidentsChartBarsGroups().should('have.length', 12);
+    cy.log('Incident count stable: 12 incidents maintained');
+    
+    cy.log('1.3 Verify days filter is set to default value');
+    incidentsPage.elements.daysSelectToggle().should('contain.text', '7 days');
+    cy.log('Default days filter confirmed: 7 days');
+  });
+
+
+  it('2. Dropdown should close and not reposition after incident deselection', () => {
+    const dropdownScenarios = [
+      {
+        name: 'Filter type',
+        setup: () => {},
+        toggleElement: () => incidentsPage.elements.filtersSelectToggle(),
+        listElement: () => incidentsPage.elements.filtersSelectList(),
+      },
+      {
+        name: 'Severity value',
+        setup: () => {
+          incidentsPage.elements.filtersSelectToggle().click();
+          incidentsPage.elements.filtersSelectOption('Severity').click();
+        },
+        toggleElement: () => incidentsPage.elements.severityFilterToggle(),
+        listElement: () => incidentsPage.elements.severityFilterList(),
+      },
+      {
+        name: 'Days filter',
+        setup: () => {},
+        toggleElement: () => incidentsPage.elements.daysSelectToggle(),
+        listElement: () => incidentsPage.elements.daysSelectList(),
+      }
+    ];
+
+    const deselectionMethods = [
+      {
+        name: 'bar click',
+        action: () => {
+          incidentsPage.elements.incidentsChartBarsVisiblePathsNonEmpty()
+            .first()
+            .click({ force: true });
+        }
+      },
+      {
+        name: 'chip removal',
+        action: () => {
+          incidentsPage.removeFilterCategory('Incident ID');
+        }
+      }
+    ];
+
+    incidentsPage.clearAllFilters();
+
+    dropdownScenarios.forEach((dropdown) => {
+      deselectionMethods.forEach((deselection) => {
+        cy.log(`Testing: ${dropdown.name} dropdown with ${deselection.name} deselection`);
+        
+        incidentsPage.elements.incidentsChartBarsVisiblePathsNonEmpty()
+          .first()
+          .click({ force: true });
+        
+        incidentsPage.elements.alertsChartContainer().should('be.visible');
+        incidentsPage.elements.incidentIdFilterChip().should('be.visible');
+        
+        dropdown.setup();
+        
+        dropdown.toggleElement().click();
+        dropdown.listElement().should('be.visible');
+        
+        deselection.action();
+        cy.wait(2000)
+        
+        dropdown.listElement().should('not.exist');
+        cy.log(`SUCCESS: ${dropdown.name} dropdown closed after ${deselection.name}`);
+      });
+    });
+  });
+
+  it('3. Adding filter when incident selected should not remove the incident ID filter', () => {
+    cy.log('3.1 Clear all filters and ensure critical incidents exist');
+    incidentsPage.clearAllFilters();
+    
+    cy.log('3.2 Apply critical severity filter');
+    incidentsPage.toggleFilter('Critical');
+    
+    incidentsPage.elements.incidentsChartBarsGroups().should('have.length.greaterThan', 0);
+    
+    cy.log('3.3 Click on the first critical incident to select it by ID');
+    incidentsPage.elements.incidentsChartBarsVisiblePathsNonEmpty()
+      .first()
+      .click({ force: true });
+    
+    cy.log('3.4 Verify incident ID filter chip appears');
+    incidentsPage.elements.incidentIdFilterChip().should('be.visible');
+
+    cy.log('3.5 Verify both Critical and Incident ID chips are present');
+    incidentsPage.elements.filterChipValue('Critical').should('be.visible');
+    incidentsPage.elements.incidentIdFilterChip().should('be.visible');
+    
+    cy.log('3.6 Deselect Critical and Apply Warning filter (which does not match the critical incident)');
+    incidentsPage.toggleFilter('Critical');
+    incidentsPage.toggleFilter('Warning');
+    
+    cy.log('3.7 Verify incident is filtered out (no bars visible)');
+    incidentsPage.elements.incidentsChartBarsGroups().should('have.length', 0);
+    cy.log('Incident correctly filtered out due to Warning filter');
+    
+    cy.log('3.8 Verify BOTH Warning filter and Incident ID filter are still applied');
+    incidentsPage.elements.filterChipValue('Warning').should('be.visible');
+    incidentsPage.elements.incidentIdFilterChip().should('be.visible');
+    
+    cy.log('SUCCESS: Incident ID filter was not removed when non-matching severity filter was added');
+    
+    cy.log('3.9 Remove Warning filter and verify incident reappears');
+    incidentsPage.toggleFilter('Warning');
+    
+    cy.log('3.10 With only Incident ID filter, incident should be visible again');
+    incidentsPage.elements.incidentsChartBarsGroups().should('have.length', 1);
+    incidentsPage.elements.incidentIdFilterChip().should('be.visible');
+    cy.log('SUCCESS: Incident reappears when conflicting filter removed');
+  });
+});

--- a/web/cypress/fixtures/incident-scenarios/7-comprehensive-filtering-test-scenarios.yaml
+++ b/web/cypress/fixtures/incident-scenarios/7-comprehensive-filtering-test-scenarios.yaml
@@ -1,0 +1,316 @@
+name: "Comprehensive Filtering Test Scenarios"
+description: "Multiple incidents with various severity patterns for testing filtering functionality. Includes single-severity incidents, multi-alert incidents with dominant severities, and escalating severity incidents with gradual progression."
+incidents:
+  # Single severity incidents - Critical only
+  - id: "monitoring-critical-single-001"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "6h"
+      end: "2h"
+    alerts:
+      - name: "AlertmanagerClusterDown001"
+        namespace: "openshift-monitoring"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "330m"
+          end: "150m"
+      - name: "PrometheusTargetDown001"
+        namespace: "openshift-monitoring"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "6h"
+          end: "2h"
+
+
+  # Single severity incidents - Warning only
+  - id: "storage-warning-single-001"
+    component: "storage"
+    layer: "core"
+    timeline:
+      start: "8h"
+      end: "1h"
+    alerts:
+      - name: "PersistentVolumeUsageHigh001"
+        namespace: "openshift-storage"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "8h"
+          end: "1h"
+      - name: "StorageNodeDiskSpaceWarning001"
+        namespace: "openshift-storage"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "7h"
+          end: "90m"
+
+  # Single severity incidents - Info only
+  - id: "network-info-single-001"
+    component: "network"
+    layer: "core"
+    timeline:
+      start: "4h"
+      end: "30m"
+    alerts:
+      - name: "NetworkBandwidthUtilizationInfo001"
+        namespace: "openshift-network"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "4h"
+          end: "30m"
+      - name: "NetworkConnectionPoolInfo001"
+        namespace: "openshift-network"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "210m"
+          end: "45m"
+
+  # Multi-alert incident with Critical dominant (Critical + Warning + Info)
+  - id: "compute-critical-dominant-001"
+    component: "compute"
+    layer: "core"
+    timeline:
+      start: "12h"
+      end: "3h"
+    alerts:
+      - name: "NodeNotReady001"
+        namespace: "openshift-monitoring"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "12h"
+          end: "3h"
+      - name: "NodeMemoryPressure001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "11h"
+          end: "4h"
+      - name: "NodeDiskPressure001"
+        namespace: "openshift-monitoring"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "10h"
+          end: "5h"
+
+  # Multi-alert incident with Warning dominant (Warning + Info)
+  - id: "api-server-warning-dominant-001"
+    component: "api-server"
+    layer: "core"
+    timeline:
+      start: "9h"
+      end: "2h"
+    alerts:
+      - name: "APIServerRequestLatencyWarning001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "9h"
+          end: "2h"
+      - name: "APIServerCertificateInfo001"
+        namespace: "openshift-monitoring"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "8h"
+          end: "3h"
+      - name: "APIServerConnectionInfo001"
+        namespace: "openshift-monitoring"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "7h"
+          end: "4h"
+
+  # Multi-alert incident with Critical dominant (Critical + Warning)
+  - id: "etcd-critical-warning-001"
+    component: "etcd"
+    layer: "core"
+    timeline:
+      start: "15h"
+      end: "5h"
+    alerts:
+      - name: "EtcdClusterUnavailable001"
+        namespace: "openshift-etcd"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "15h"
+          end: "5h"
+      - name: "EtcdHighLatency001"
+        namespace: "openshift-etcd"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "14h"
+          end: "6h"
+      - name: "EtcdBackupFailed001"
+        namespace: "openshift-etcd"
+        severity: "warning"
+        firing: false
+        timeline:
+          start: "13h"
+          end: "7h"
+
+  # Multi-alert incident with Critical dominant (Critical + Info)
+  - id: "version-critical-info-001"
+    component: "version"
+    layer: "core"
+    timeline:
+      start: "20h"
+      end: "8h"
+    alerts:
+      - name: "ClusterVersionUpdateFailed001"
+        namespace: "openshift-cluster-version"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "20h"
+          end: "8h"
+      - name: "ClusterVersionUpdateAvailable001"
+        namespace: "openshift-cluster-version"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "19h"
+          end: "9h"
+      - name: "ClusterVersionOperatorInfo001"
+        namespace: "openshift-cluster-version"
+        severity: "info"
+        firing: false
+        timeline:
+          start: "18h"
+          end: "10h"
+
+  # Escalating severity incident - Info → Warning → Critical
+  - id: "monitoring-escalating-complete-001"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "24h"
+      severityChanges:
+        - time: "24h"
+          severity: "info"
+        - time: "18h"
+          severity: "warning"
+        - time: "12h"
+          severity: "critical"
+    alerts:
+      - name: "PrometheusConfigReloadInfo001"
+        namespace: "openshift-monitoring"
+        severity: "info"
+        firing: true
+        timeline:
+          start: "24h"
+      - name: "PrometheusQueryLatencyWarning001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: true
+        timeline:
+          start: "18h"
+      - name: "PrometheusRuleEvaluationFailure001"
+        namespace: "openshift-monitoring"
+        severity: "critical"
+        firing: true
+        timeline:
+          start: "12h"
+
+  # Escalating severity incident - Warning → Critical
+  - id: "storage-escalating-partial-001"
+    component: "storage"
+    layer: "core"
+    timeline:
+      start: "16h"
+      severityChanges:
+        - time: "16h"
+          severity: "warning"
+        - time: "8h"
+          severity: "critical"
+    alerts:
+      - name: "CephHealthWarning001"
+        namespace: "openshift-storage"
+        severity: "warning"
+        firing: true
+        timeline:
+          start: "16h"
+      - name: "CephOSDDown001"
+        namespace: "openshift-storage"
+        severity: "critical"
+        firing: true
+        timeline:
+          start: "8h"
+      - name: "CephMonitorDown001"
+        namespace: "openshift-storage"
+        severity: "critical"
+        firing: true
+        timeline:
+          start: "6h"
+
+  # Currently firing single severity - Critical
+  - id: "network-firing-critical-001"
+    component: "network"
+    layer: "core"
+    timeline:
+      start: "3h"
+    alerts:
+      - name: "NetworkInterfaceDown001"
+        namespace: "openshift-network"
+        severity: "critical"
+        firing: true
+        timeline:
+          start: "3h"
+      - name: "NetworkControllerDown001"
+        namespace: "openshift-network"
+        severity: "critical"
+        firing: true
+        timeline:
+          start: "150m"
+
+  # Currently firing single severity - Warning
+  - id: "compute-firing-warning-001"
+    component: "compute"
+    layer: "core"
+    timeline:
+      start: "5h"
+    alerts:
+      - name: "NodeHighCPUUsage001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: true
+        timeline:
+          start: "5h"
+      - name: "NodeHighMemoryUsage001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: true
+        timeline:
+          start: "4h"
+
+  # Currently firing single severity - Info
+  - id: "others-firing-info-001"
+    component: "Others"
+    layer: "Others"
+    timeline:
+      start: "2h"
+    alerts:
+      - name: "CustomApplicationInfo001"
+        namespace: "custom-namespace"
+        severity: "info"
+        firing: true
+        timeline:
+          start: "2h"
+      - name: "ApplicationHealthcheckInfo001"
+        namespace: "custom-namespace"
+        severity: "info"
+        firing: true
+        timeline:
+          start: "90m"


### PR DESCRIPTION
Adds regressions tests for bugs related to redux state and react effects.

Test cases:
1. Initial Loading Bug: All incidents should load on fresh page load without
   requiring days filter manipulation.
   Verifies: [OU-1002](https://issues.redhat.com//browse/OU-1002)
2. Dropdown Closure on Deselection: Verifies dropdowns close when incident is
   deselected via bar click OR chip removal.
   Verifies: [OU-1033](https://issues.redhat.com//browse/OU-1033)
3. Filter State Preservation: When incident ID is selected and a non-matching
   severity filter is added, both filters should remain applied.
   Verifies: [OU-1030](https://issues.redhat.com//browse/OU-1030)

Naming of the testfile (04.) is referring the identified areas for regressions for Incidents., 1,2,3 will be merged later.

[OU-1002](https://issues.redhat.com//browse/OU-1002)
[OU-1030](https://issues.redhat.com//browse/OU-1030)
[OU-1033](https://issues.redhat.com//browse/OU-1033)