### PR TITLE
OU-1036: fetch metric labels from tenancy path when appropriate

### DIFF
--- a/web/src/components/metrics/promql-expression-input.tsx
+++ b/web/src/components/metrics/promql-expression-input.tsx
@@ -31,7 +31,7 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from '@codemirror/view';
-import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   Form,
@@ -51,7 +51,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useSafeFetch } from '../console/utils/safe-fetch-hook';
 
-import { PROMETHEUS_BASE_PATH } from '../utils';
+import { ALL_NAMESPACES_KEY, getPrometheusBasePath, PROMETHEUS_BASE_PATH } from '../utils';
 import { LabelNamesResponse } from '@perses-dev/prometheus-plugin';
 import {
   t_global_color_status_custom_default,
@@ -70,6 +70,7 @@ import {
   t_global_color_nonstatus_purple_default,
 } from '@patternfly/react-tokens';
 import { usePatternFlyTheme } from '../hooks/usePatternflyTheme';
+import { useMonitoring } from '../../hooks/useMonitoring';
 
 const box_shadow = `
     var(--pf-t--global--box-shadow--X--md--default)
@@ -327,6 +328,8 @@ export const PromQLExpressionInput: FC<PromQLExpressionInputProps> = ({
   onSelectionChange,
 }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
+  const [namespace] = useActiveNamespace();
+  const { prometheus } = useMonitoring();
   const { theme: pfTheme } = usePatternFlyTheme();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -340,9 +343,13 @@ export const PromQLExpressionInput: FC<PromQLExpressionInputProps> = ({
   const safeFetch = useCallback(useSafeFetch(), []);
 
   useEffect(() => {
-    safeFetch<LabelNamesResponse>(
-      `${PROMETHEUS_BASE_PATH}/${PrometheusEndpoint.LABEL}/__name__/values`,
-    )
+    // If we are using the tenancy path, then add the namespace as a query parameter at the end of
+    // the url
+    const namespaceQueryParam = namespace !== ALL_NAMESPACES_KEY ? `?namespace=${namespace}` : '';
+    const url = `${getPrometheusBasePath({ namespace, prometheus })}/${
+      PrometheusEndpoint.LABEL
+    }/__name__/values${namespaceQueryParam}`;
+    safeFetch<LabelNamesResponse>(url)
       .then((response) => {
         const metrics = response?.data;
         setMetricNames(metrics);
@@ -356,7 +363,7 @@ export const PromQLExpressionInput: FC<PromQLExpressionInputProps> = ({
           setErrorMessage(message);
         }
       });
-  }, [safeFetch, t]);
+  }, [safeFetch, t, namespace, prometheus]);
 
   const onClear = () => {
     if (viewRef.current !== null) {


### PR DESCRIPTION
This PR looks to fix an issue which caused the prometheus `/labels` endpoint to always go through the non-tenancy API path. This change is needed to allow non-admin users to use the autocomplete functionality in the `observe/metrics` pages. The thanos-querier service ([link](https://github.com/openshift/cluster-monitoring-operator/blob/main/assets/thanos-querier/service.yaml)) already provides support for this functionality, we are just looking to expose a way for the console users to access this existing endpoint.

```yaml
      * Port 9092 provides access to the `/api/v1/query`, `/api/v1/query_range/`, `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
```

This PR is being made in conjunction with a second one in the console (openshift/console#15621) which exposes this proxy. This PR must merge AFTER the one in the console codebase

**After Changes**

<img width="1182" height="920" alt="Screenshot From 2025-10-17 14-21-09" src="https://github.com/user-attachments/assets/80603599-36d0-4aa7-a4b0-c41e78fca0f8" />
<img width="1182" height="920" alt="Screenshot From 2025-10-17 14-21-27" src="https://github.com/user-attachments/assets/fbdaee66-bb77-44c4-bda3-e4e329f4622f" />
