### PR TITLE
OBSINTA-777: [Incidents] Regression for Silences

### DIFF
--- a/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
@@ -1,0 +1,128 @@
+/*
+Regression test for Silences Not Applied Correctly (Section 3.2)
+
+BUG: Silences were being matched by name only, not by name + namespace + severity.
+This test verifies that silence matching uses: alertname + namespace + severity.
+
+While targeting the bug, it verifies the basic Silences Implementation.
+
+Verifies: OU-1020, OU-706
+*/
+
+import { incidentsPage } from '../../../views/incidents-page';
+
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+describe('Regression: Silences Not Applied Correctly', () => {
+
+  before(() => {
+    cy.beforeBlockCOO(MCP, MP);
+  });
+
+  beforeEach(() => {
+    cy.log('Navigate to Observe → Incidents');
+    incidentsPage.goTo();
+    cy.log('Setting up silenced alerts mixed scenario');
+    cy.mockIncidentFixture('incident-scenarios/9-silenced-alerts-mixed-scenario.yaml');
+  });
+
+  it('Silence matching verification flow - opacity and tooltip indicators', () => {
+    const selectIncidentAndWaitForAlerts = (incidentId: string, expectedAlertCount?: number) => {
+      incidentsPage.elements.incidentsChartBar(incidentId).click();
+      cy.wait(2000);
+      incidentsPage.elements.alertsChartContainer().should('be.visible');
+      incidentsPage.elements.alertsChartCard().should('be.visible');
+
+      if (expectedAlertCount !== undefined) {
+        incidentsPage.elements.alertsChartBarsVisiblePaths().should('have.length', expectedAlertCount);
+      }
+    };
+
+    const verifyAlertOpacity = (alertIndex: number, expectedOpacity: number) => {
+      incidentsPage.elements.alertsChartBarsVisiblePaths()
+        .eq(alertIndex)
+        .then(($bar) => {
+          cy.log('Bar: ' + $bar);
+          cy.log('Fill-opacity: ' + $bar.css('fill-opacity'));
+          const opacity = parseFloat($bar.css('fill-opacity') || '1');
+          expect(opacity).to.equal(expectedOpacity);
+        });
+    };
+
+    const verifyAlertTooltip = (alertIndex: number, expectedTexts: string[], shouldBeSilenced: boolean) => {
+      incidentsPage.hoverOverAlertBar(alertIndex);
+      const tooltip = incidentsPage.elements.alertsChartTooltip().should('be.visible');
+      expectedTexts.forEach(text => {
+        tooltip.should('contain.text', text);
+      });
+      tooltip.should(shouldBeSilenced ? 'contain.text' : 'not.contain.text', '(silenced)');
+    };
+
+    cy.log('1.1 Verify all incidents loaded');
+    incidentsPage.clearAllFilters();
+    incidentsPage.elements.incidentsChartBarsGroups().should('have.length.greaterThan', 0);
+    
+    cy.log('1.2 Select silenced alert incident (PAIR-2-storage-SILENCED)');
+    selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-storage-SILENCED', 1);
+    
+    cy.log('1.4 Hover over silenced alert and verify tooltip shows (silenced)');
+    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
+    cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
+
+
+    cy.log('1.3 Hover over silenced alert and verify tooltip shows (silenced)');
+    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
+    cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
+    
+
+    cy.log('2.0 Deselect incident');
+    incidentsPage.deselectIncidentByBar();
+
+    cy.log('2.1 Select non-silenced alert incident with same alert name (PAIR-2-network-UNSILENCED)');
+    selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-network-UNSILENCED', 1);
+    
+    cy.log('2.2 Verify non-silenced alert has full opacity 1.0');
+    verifyAlertOpacity(0, 1.0);
+    
+    cy.log('2.3 Hover over non-silenced alert and verify tooltip does not show (silenced)');
+    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], false);
+    cy.log('Verified: Non-silenced alert has opacity 1.0 and tooltip does not show (silenced)');
+    
+
+    cy.log('3.0 Deselect incident');
+    incidentsPage.deselectIncidentByBar();
+
+    cy.log('3.1 Select incident with both silenced and non-silenced alerts (CASE-3)');
+    selectIncidentAndWaitForAlerts('CASE-3-shared-alert-single-incident-storage-network-SILENCED-UNSILENCED', 2);
+    
+    cy.log('3.2 Verify first alert (storage namespace / silenced) has opacity 0.3');
+    verifyAlertOpacity(0, 0.3);
+    
+    cy.log('3.3 Verify second alert (network namespace / non-silenced) has opacity 1.0');
+    verifyAlertOpacity(1, 1.0);
+    
+    cy.log('3.4 Hover over first alert and verify tooltip shows (silenced) with storage');
+    verifyAlertTooltip(0, ['storage'], true);
+    
+    cy.log('3.5 Hover over second alert and verify tooltip shows network without (silenced)');
+    verifyAlertTooltip(1, ['network'], false);
+    
+    cy.log('Verified: Same alert name with different namespaces handled correctly');
+    cy.log('Verified: Silence matching uses alertname + namespace + severity');
+  });
+});
+
+

--- a/web/cypress/fixtures/incident-scenarios/9-silenced-alerts-mixed-scenario.yaml
+++ b/web/cypress/fixtures/incident-scenarios/9-silenced-alerts-mixed-scenario.yaml
@@ -1,0 +1,104 @@
+name: "Silenced Alerts Mixed Scenario"
+description: "Incidents demonstrating silenced alerts across resolved and firing cases with shared alert names."
+incidents:
+  # Pair 1: Same alert name and same component; older resolved is silenced, newer is firing not silenced
+  - id: "PAIR-1-shared-alert-resolved-SILENCED"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "6h"
+      end: "1h"
+    alerts:
+      - name: "MonitoringSyntheticShared001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+        silenced: true
+        timeline:
+          start: "5h"
+          end: "2h"
+
+  - id: "PAIR-1-shared-alert-firing-UNSILENCED"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "2h"
+    alerts:
+      - name: "MonitoringSyntheticShared001" # same name and component as above
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: true
+        silenced: false
+        timeline:
+          start: "1h"
+
+
+  # Pair 2: Same alert name but different components; both firing; one silenced, one not
+  - id: "PAIR-2-shared-alert-name-storage-SILENCED"
+    component: "storage"
+    layer: "core"
+    timeline:
+      start: "3h"
+    alerts:
+      - name: "SyntheticSharedFiring002"
+        component: "storage"
+        namespace: "openshift-storage"
+        severity: "critical"
+        firing: true
+        silenced: true
+        timeline:
+          start: "2h"
+      # - name: "StorageAdditionalInfoS001"
+      #   namespace: "openshift-storage"
+      #   severity: "info"
+      #   firing: true
+      #   timeline:
+      #     start: "100m"
+
+  - id: "PAIR-2-shared-alert-name-network-UNSILENCED"
+    component: "network"
+    layer: "core"
+    timeline:
+      start: "3h"
+    alerts:
+      - name: "SyntheticSharedFiring002" # same name as storage incident, different component
+        component: "network"
+        namespace: "openshift-network"
+        severity: "critical"
+        firing: true
+        silenced: false
+        timeline:
+          start: "90m"
+      # - name: "NetworkAdditionalWarnN001"
+      #   namespace: "openshift-network"
+      #   severity: "warning"
+      #   firing: true
+      #   timeline:
+      #     start: "80m"
+
+
+
+  - id: "CASE-3-shared-alert-single-incident-storage-network-SILENCED-UNSILENCED"
+    component: "storage"
+    layer: "core"
+    timeline:
+      start: "3h"
+    alerts:
+      - name: "SyntheticSharedFiring003"
+        component: "storage"
+        namespace: "openshift-storage"
+        severity: "critical"
+        firing: true
+        silenced: true
+        timeline:
+          start: "2h"
+
+      - name: "SyntheticSharedFiring003"
+        component: "network"
+        namespace: "openshift-network"
+        severity: "critical"
+        firing: true
+        silenced: false
+        timeline:
+          start: "90m"
+

--- a/web/cypress/views/incidents-page.ts
+++ b/web/cypress/views/incidents-page.ts
@@ -94,6 +94,22 @@ export const incidentsPage = {
       alertsChartSvg: () => incidentsPage.elements.alertsChartCard().find('svg'),
       alertsChartBarsGroups: () => incidentsPage.elements.alertsChartSvg().find('g[role="presentation"]'),
       alertsChartBarsPaths: () => incidentsPage.elements.alertsChartSvg().find('path[role="presentation"]'),
+      alertsChartBarsVisiblePaths: () => {
+        return cy.get('body').then($body => {
+          const exists = $body.find('g[role="presentation"][data-test*="alerts-chart-bar-"]').length > 0;
+          if (exists) {
+            return cy.get('g[role="presentation"][data-test*="alerts-chart-bar-"]')
+              .find('path[role="presentation"]')
+              .filter((index, element) => {
+                const fillOpacity = Cypress.$(element).css('fill-opacity') || Cypress.$(element).attr('fill-opacity');
+                return parseFloat(fillOpacity || '0') > 0;
+              });
+          } else {
+            cy.log('Alert chart bars were not found. Test continues.');
+            return cy.wrap([]);
+          }
+        });
+      },
       alertsChartEmptyState: () => cy.byTestID(DataTestIDs.AlertsChart.EmptyState),
   
       // Tables and data
@@ -522,6 +538,8 @@ export const incidentsPage = {
    */
   getSelectedIncidentAlerts: () => {
     cy.log('incidentsPage.getSelectedIncidentAlerts: Collecting alert information from selected incident');
+
+    incidentsPage.elements.incidentsDetailsTable().should('exist');
     
     return incidentsPage.elements.incidentsTableRows()
       .then(($rows) => {

--- a/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
@@ -233,13 +233,14 @@ const AlertsChart = ({ theme }: { theme: 'light' | 'dark' }) => {
                   <ChartLabel style={{ fill: theme === 'light' ? '#1b1d21' : '#e0e0e0' }} />
                 }
               />
-              <ChartGroup horizontal>
+              <ChartGroup horizontal data-test={DataTestIDs.AlertsChart.ChartContainer}>
                 {chartData.map((bar, index) => {
                   return (
                     //we have several arrays and for each array we make a ChartBar
                     <ChartBar
                       data={bar}
                       key={index}
+                      data-test={`${DataTestIDs.AlertsChart.ChartBar}-${index}`}
                       style={{
                         data: {
                           fill: ({ datum }) => datum.fill,

--- a/web/src/components/data-test.ts
+++ b/web/src/components/data-test.ts
@@ -116,6 +116,7 @@ export const DataTestIDs = {
     Title: 'alerts-chart-title',
     EmptyState: 'alerts-chart-empty-state',
     ChartContainer: 'alerts-chart-container',
+    ChartBar: 'alerts-chart-bar',
   },
 
   // Incidents Table Test IDs


### PR DESCRIPTION
## Add Silence Matching Regression Test

### Summary
Adds comprehensive e2e regression test for silences matching logic (Section 3.2 from test documentation).
Injects data-test-ids for the alert chart.


### Bug
Silences were being matched by alert name only, not by the complete signature of `alertname + namespace + severity`. This caused alerts with the same name but different namespaces to incorrectly share silence status.

**Verifies**: OU-1020, [OU-706](https://issues.redhat.com//browse/OU-706)

### Tests
New test file `03.reg_api_calls.cy.ts` that verifies silence matching works correctly by testing:

1. **Silenced alert behavior**
   - Reduced opacity (0.3) for visual distinction
   - Tooltip displays "(silenced)" indicator

2. **Non-silenced alert behavior**
   - Full opacity (1.0)
   - Tooltip does NOT display "(silenced)" indicator

3. **Same alert name, different namespaces**
   - Each namespace is evaluated independently
   - Single incident can contain both silenced and non-silenced alerts with same name

### Technical Details
- Uses fixture `9-silenced-alerts-mixed-scenario.yaml` with test scenarios
- Extracted helper functions to eliminate duplication:
  - `selectIncidentAndWaitForAlerts()` - incident selection with wait
  - `verifyAlertOpacity()` - opacity assertion
  - `verifyAlertTooltip()` - tooltip content verification
- Single comprehensive test flow following e2e best practices

