### PR TITLE
[release-4.20] OCPBUGS-63440: fetch metric labels with tenancy 

### DIFF
--- a/web/src/components/console/graphs/helpers.ts
+++ b/web/src/components/console/graphs/helpers.ts
@@ -7,7 +7,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
 
 export const PROMETHEUS_BASE_PATH = window.SERVER_FLAGS.prometheusBaseURL;
-const PROMETHEUS_TENANCY_BASE_PATH = window.SERVER_FLAGS.prometheusTenancyBaseURL;
+export const PROMETHEUS_TENANCY_BASE_PATH = window.SERVER_FLAGS.prometheusTenancyBaseURL;
 const PROMETHEUS_PROXY_PATH = '/api/proxy/plugin/monitoring-console-plugin/thanos-proxy';
 
 export const ALERTMANAGER_BASE_PATH = window.SERVER_FLAGS.alertManagerBaseURL;


### PR DESCRIPTION
This PR looks to fix an issue which caused the prometheus `/labels` endpoint to always go through the non-tenancy API path. This change is needed to allow non-admin users to use the autocomplete functionality in the `observe/metrics` pages. The thanos-querier service ([link](https://github.com/openshift/cluster-monitoring-operator/blob/main/assets/thanos-querier/service.yaml)) already provides support for this functionality, we are just looking to expose a way for the console users to access this existing endpoint.

```yaml
      * Port 9092 provides access to the `/api/v1/query`, `/api/v1/query_range/`, `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
```

This PR is being made in conjunction with a second one in the console (openshift/console#15632) which exposes this proxy. This PR must merge AFTER the one in the console codebase