### PR TITLE
OCPBUGS-63588: [release-4.19] allow tenancy access to metrics tags

### DIFF
--- a/web/src/components/console/graphs/helpers.ts
+++ b/web/src/components/console/graphs/helpers.ts
@@ -7,7 +7,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
 
 export const PROMETHEUS_BASE_PATH = window.SERVER_FLAGS.prometheusBaseURL;
-const PROMETHEUS_TENANCY_BASE_PATH = window.SERVER_FLAGS.prometheusTenancyBaseURL;
+export const PROMETHEUS_TENANCY_BASE_PATH = window.SERVER_FLAGS.prometheusTenancyBaseURL;
 const PROMETHEUS_PROXY_PATH = '/api/proxy/plugin/monitoring-console-plugin/thanos-proxy';
 
 export const ALERTMANAGER_BASE_PATH = window.SERVER_FLAGS.alertManagerBaseURL;

--- a/web/src/components/metrics/promql-expression-input.tsx
+++ b/web/src/components/metrics/promql-expression-input.tsx
@@ -31,7 +31,7 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from '@codemirror/view';
-import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   Form,
@@ -50,7 +50,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useSafeFetch } from '../console/utils/safe-fetch-hook';
 
-import { PROMETHEUS_BASE_PATH } from '../console/graphs/helpers';
+import { PROMETHEUS_BASE_PATH, PROMETHEUS_TENANCY_BASE_PATH } from '../console/graphs/helpers';
 import { LabelNamesResponse } from '@perses-dev/prometheus-plugin';
 import {
   t_global_color_status_custom_default,
@@ -69,6 +69,7 @@ import {
   t_global_color_nonstatus_purple_default,
 } from '@patternfly/react-tokens';
 import { usePatternFlyTheme } from '../hooks/usePatternflyTheme';
+import { usePerspective } from '../hooks/usePerspective';
 
 const box_shadow = `
     var(--pf-t--global--box-shadow--X--md--default)
@@ -332,6 +333,8 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
   const viewRef = React.useRef<EditorView | null>(null);
   const [metricNames, setMetricNames] = React.useState<Array<string>>([]);
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
+  const { perspective } = usePerspective();
+  const [namespace] = useActiveNamespace();
 
   const placeholder = t('Expression (press Shift+Enter for newlines)');
 
@@ -339,9 +342,12 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   React.useEffect(() => {
-    safeFetch<LabelNamesResponse>(
-      `${PROMETHEUS_BASE_PATH}/${PrometheusEndpoint.LABEL}/__name__/values`,
-    )
+    let url = `${PROMETHEUS_BASE_PATH}/${PrometheusEndpoint.LABEL}/__name__/values`;
+    if (perspective === 'dev') {
+      // eslint-disable-next-line max-len
+      url = `${PROMETHEUS_TENANCY_BASE_PATH}/${PrometheusEndpoint.LABEL}/__name__/values?namespace=${namespace}`;
+    }
+    safeFetch<LabelNamesResponse>(url)
       .then((response) => {
         const metrics = response?.data;
         setMetricNames(metrics);
@@ -355,7 +361,7 @@ export const PromQLExpressionInput: React.FC<PromQLExpressionInputProps> = ({
           setErrorMessage(message);
         }
       });
-  }, [safeFetch, t]);
+  }, [safeFetch, t, namespace, perspective]);
 
   const onClear = () => {
     if (viewRef.current !== null) {


### PR DESCRIPTION
This PR looks to fix an issue which caused the prometheus `/labels` endpoint to always go through the non-tenancy API path. This change is needed to allow non-admin users to use the autocomplete functionality in the `observe/metrics` pages. The thanos-querier service ([link](https://github.com/openshift/cluster-monitoring-operator/blob/main/assets/thanos-querier/service.yaml)) already provides support for this functionality, we are just looking to expose a way for the console users to access this existing endpoint.

```yaml
      * Port 9092 provides access to the `/api/v1/query`, `/api/v1/query_range/`, `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
```

This PR is being made in conjunction with a second one in the console (openshift/console#15645) which exposes this proxy. This PR must merge AFTER the one in the console codebase