### PR TITLE
OBSINTA-777: [Incidents] Regression tests for short incidents visualisation

### DIFF
--- a/web/cypress/fixtures/incident-scenarios/12-charts-ui-comprehensive.yaml
+++ b/web/cypress/fixtures/incident-scenarios/12-charts-ui-comprehensive.yaml
@@ -1,52 +1,7 @@
-name: "Charts UI Comprehensive Test Scenarios"
-description: "Combined scenarios for testing tooltip positioning, bar visibility, short duration alerts, varying alert counts (1-6 alerts), and alert name lengths (short to extremely long). Tests Section 2 of TESTING_CHECKLIST.md comprehensively."
+name: "Charts UI Comprehensive Test Scenarios with Edge Cases"
+description: "Streamlined scenarios (10 incidents) for testing tooltip positioning with varied name lengths, bar visibility, short duration alerts (< 5 min for Section 3.1), multi-component tooltips, and multi-severity segments. Tests Sections 2 (Charts UI) and 3.1 (Short Duration Visibility) without requiring scrolling."
 incidents:
-  # SHORT DURATION INCIDENTS (Section 2.2 - Bar Visibility, Section 2.3 - Date/Time Display)
-  # Resolved incident with 5 alerts of varying durations (0-10 minutes)
-  - id: "network-resolved-short-001"
-    component: "network"
-    layer: "core"
-    timeline:
-      start: "50m"
-      end: "40m"
-    alerts:
-      - name: "NetworkInterfaceDown0023"
-        namespace: "openshift-network"
-        severity: "critical"
-        firing: false
-        timeline:
-          start: "50m"
-          end: "40m"
-      - name: "NetworkLatencyHigh0023"
-        namespace: "openshift-network"
-        severity: "warning"
-        firing: false
-        timeline:
-          start: "47m"
-          end: "40m"
-      - name: "NetworkBandwidthUtilizationHigh0023"
-        namespace: "openshift-network"
-        severity: "warning"
-        firing: false
-        timeline:
-          start: "45m"
-          end: "40m"
-      - name: "NetworkConnectionPoolExhausted0023"
-        namespace: "openshift-network"
-        severity: "info"
-        firing: false
-        timeline:
-          start: "42m"
-          end: "40m"
-      - name: "NetworkDNSResolutionSlow0023"
-        namespace: "openshift-network"
-        severity: "info"
-        firing: false
-        timeline:
-          start: "41m"
-          end: "40m"
-
-  # Firing incident with 5 alerts of short durations
+  # 1. SHORT DURATION FIRING (newest) - Short names for baseline
   - id: "network-firing-short-002"
     component: "network"
     layer: "core"
@@ -84,130 +39,139 @@ incidents:
         timeline:
           start: "0m"
 
-  # VARYING ALERT COUNTS (Section 2.1 - Tooltip Positioning)
-  # 1 alert - bottom of chart (oldest) - Section 2.1 tooltip positioning
-  - id: "version-short-name-001"
-    component: "version"
+  # 2. SHORT DURATION RESOLVED - Medium names
+  - id: "network-resolved-short-001"
+    component: "network"
     layer: "core"
     timeline:
-      start: "8h"
+      start: "50m"
+      end: "40m"
     alerts:
-      - name: "Ver001"
-        namespace: "openshift-cluster-version"
-        severity: "info"
-        firing: true
-
-  # 1 alert - middle position
-  - id: "monitoring-one-alert-001"
-    component: "monitoring"
-    layer: "core"
-    timeline:
-      start: "7h"
-    alerts:
-      - name: "Short001"
-        namespace: "openshift-monitoring"
+      - name: "NetworkInterfaceDown0023"
+        namespace: "openshift-network"
+        severity: "critical"
+        firing: false
+        timeline:
+          start: "50m"
+          end: "40m"
+      - name: "NetworkLatencyHighExceedingThresholds0023"
+        namespace: "openshift-network"
         severity: "warning"
-        firing: true
-
-  # 2 alerts
-  - id: "storage-two-alerts-001"
-    component: "storage"
-    layer: "core"
-    timeline:
-      start: "6h30m"
-    alerts:
-      - name: "DiskPressure001"
-        namespace: "openshift-storage"
+        firing: false
+        timeline:
+          start: "47m"
+          end: "40m"
+      - name: "NetworkBandwidthUtilizationHighRequiringInvestigation0023"
+        namespace: "openshift-network"
         severity: "warning"
-        firing: true
-      - name: "VolumeSpaceLow001"
-        namespace: "openshift-storage"
-        severity: "warning"
-        firing: true
+        firing: false
+        timeline:
+          start: "45m"
+          end: "40m"
 
-  # 3 alerts - multi-component incident (Section 2.1 tooltip content)
+  # 3. MULTI-COMPONENT - Medium-long names for tooltip width testing
   - id: "network-three-alerts-001"
     component: "network"
     layer: "core"
     timeline:
-      start: "6h"
+      start: "1h30m"
     alerts:
-      - name: "NetworkLatencyHigh001"
+      - name: "NetworkLatencyHighAffectingServiceResponseTimes001"
         namespace: "openshift-network"
         severity: "warning"
         firing: true
         component: "network"
-      - name: "PacketDropRateElevated001"
+      - name: "PacketDropRateElevatedIndicatingPotentialNetworkSaturation001"
         namespace: "openshift-network"
         severity: "warning"
         firing: true
         component: "compute"
-      - name: "ConnectionPoolExhausted001"
+      - name: "ConnectionPoolExhaustedRequiringImmediateScalingAction001"
         namespace: "openshift-network"
         severity: "warning"
         firing: true
         component: "storage"
 
-  # 4 alerts - multi-severity (Section 2.3 - Multi-severity segments)
-  - id: "compute-four-alerts-001"
-    component: "compute"
-    layer: "core"
-    timeline:
-      start: "5h"
-    alerts:
-      - name: "NodeMemoryPressureDetected001"
-        namespace: "openshift-monitoring"
-        severity: "critical"
-        firing: true
-      - name: "CPUUtilizationThresholdExceeded001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-      - name: "DiskIOSaturation001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-      - name: "NetworkBandwidthLimited001"
-        namespace: "openshift-monitoring"
-        severity: "info"
-        firing: true
-
-  # 5 alerts - complex timeline
-  - id: "api-server-five-alerts-001"
+  # 4. SECTION 3.1: 1-minute incident - Long component name
+  - id: "api-server-transient-001"
     component: "api-server"
     layer: "core"
     timeline:
-      start: "4h"
+      start: "2h"
+      end: "119m"
     alerts:
-      - name: "APIServerRequestLatencyAboveThresholdForExtendedDuration001"
+      - name: "APIServerRequestLatencyBriefSpikeDetectedDuringHighTrafficPeriod001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+
+  # 5. MULTI-SEVERITY GRADUAL ESCALATION - Long names for tooltip positioning edge case
+  - id: "monitoring-gradual-alerts-001"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "5h30m"
+      severityChanges:
+        - time: "5h30m"
+          severity: "info"
+        - time: "2h"
+          severity: "warning"
+        - time: "1h30m"
+          severity: "critical"
+    alerts:
+      - name: "PrometheusRuleEvaluationPerformanceDegradationDetectedRequiringOptimization001"
+        namespace: "openshift-monitoring"
+        severity: "info"
+        firing: true
+        timeline:
+          start: "5h30m"
+      - name: "PrometheusQueryLatencyIncreasingBeyondAcceptableThresholdsImpactingDashboards001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: true
+        timeline:
+          start: "2h"
+      - name: "AlertmanagerClusterFailedToSendNotificationsCriticalAlertsNotDelivered001"
         namespace: "openshift-monitoring"
         severity: "critical"
         firing: true
-      - name: "APIServerCertificateExpirationWarning001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-      - name: "APIServerConnectionPoolUtilizationHigh001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-      - name: "APIServerRateLimitingActive001"
-        namespace: "openshift-monitoring"
-        severity: "info"
-        firing: true
-      - name: "APIServerHealthcheckInfo001"
-        namespace: "openshift-monitoring"
-        severity: "info"
-        firing: true
+        timeline:
+          start: "1h30m"
 
-  # 6 alerts - extreme name lengths (Section 2.1 - long names)
+  # 6. SECTION 3.1: 9-minute incident - Medium names
+  - id: "compute-microsecond-resolution-001"
+    component: "compute"
+    layer: "core"
+    timeline:
+      start: "3h"
+      end: "171m"
+    alerts:
+      - name: "NodeTransientIssueResolvedAutomatically001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+
+  # 7. SECTION 3.1: Recently resolved - Short to medium names
+  - id: "monitoring-just-resolved-001"
+    component: "monitoring"
+    layer: "core"
+    timeline:
+      start: "4h"
+      end: "2m"
+    alerts:
+      - name: "PrometheusTargetMissingButRecovered001"
+        namespace: "openshift-monitoring"
+        severity: "warning"
+        firing: false
+
+  # 8. SIX ALERTS FOR ALERTS CHART - Mix of very short and very long names
   - id: "etcd-six-alerts-001"
     component: "etcd"
     layer: "core"
     timeline:
-      start: "3h"
+      start: "5h"
     alerts:
-      - name: "S001"
+      - name: "E001"
         namespace: "openshift-etcd"
         severity: "critical"
         firing: true
@@ -215,15 +179,15 @@ incidents:
         namespace: "openshift-etcd"
         severity: "critical"
         firing: true
-      - name: "EtcdDatabaseSizeApproachingConfiguredLimitRequiringCompaction001"
+      - name: "EtcdDatabaseSizeApproachingConfiguredLimitRequiringCompactionOperationToFreeSpace001"
         namespace: "openshift-etcd"
         severity: "warning"
         firing: true
-      - name: "EtcdLeaderElectionTimeExceedingNormalThresholdIndicatingPotentialNetworkIssues001"
+      - name: "EtcdLeaderElectionTimeExceedingNormalThresholdIndicatingPotentialNetworkOrPerformanceIssues001"
         namespace: "openshift-etcd"
         severity: "warning"
         firing: true
-      - name: "EtcdMemberCommunicationLatencyHigherThanExpectedBaselinePerformanceMetrics001"
+      - name: "EtcdMemberCommunicationLatencyHigherThanExpectedBaselinePerformanceMetricsRequiringInvestigation001"
         namespace: "openshift-etcd"
         severity: "info"
         firing: true
@@ -232,100 +196,26 @@ incidents:
         severity: "info"
         firing: true
 
-  # ALERT NAME LENGTH VARIATIONS (Section 2.1 - Tooltip content with varying lengths)
-  - id: "monitoring-medium-name-001"
-    component: "monitoring"
-    layer: "core"
-    timeline:
-      start: "2h30m"
-    alerts:
-      - name: "PrometheusTargetScrapeDurationExceeded001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-
-  - id: "storage-long-name-001"
-    component: "storage"
-    layer: "core"
-    timeline:
-      start: "2h"
-    alerts:
-      - name: "PersistentVolumeClaimPendingDueToInsufficientStorageCapacityAvailableInCluster001"
-        namespace: "openshift-storage"
-        severity: "critical"
-        firing: true
-
-  - id: "storage-long-component-name-001"
-    component: "storage-very-very-long-component-name"
-    layer: "core"
-    timeline:
-      start: "1h30m"
-    alerts:
-      - name: "StandardAlert001"
-        namespace: "openshift-storage-very-very-long-namespace-name"
-        severity: "critical"
-        firing: true
-
+  # 9. EXTREMELY LONG NAME (180+ chars) - Critical for viewport overflow testing
   - id: "others-very-long-name-001"
     component: "Others"
     layer: "Others"
     timeline:
-      start: "1h"
+      start: "6h"
     alerts:
-      - name: "CustomApplicationDatabaseConnectionPoolExhaustedRequiringImmediateAttentionFromOperationsTeamToInvestigateAndResolveUnderlyingInfrastructureLimitationsOrConfigurationIssues001"
-        namespace: "custom-application-namespace"
+      - name: "CustomApplicationDatabaseConnectionPoolExhaustedRequiringImmediateAttentionFromOperationsTeamToInvestigatePotentialMemoryLeaksAndResolveUnderlyingInfrastructureLimitationsOrConfigurationIssuesThatMayBeImpactingOverallSystemPerformance001"
+        namespace: "custom-application-namespace-with-very-long-name"
         severity: "critical"
         firing: true
 
-  # GRADUAL ESCALATION (Section 2.1 - Alerts chart tooltip positioning, Section 2.3 - Multi-severity segments)
-  # Tests tooltip positioning for multiple bars in alerts chart
-  - id: "monitoring-gradual-alerts-001"
-    component: "monitoring"
+  # 10. OLDEST INCIDENT - Very short name for sorting test
+  - id: "VSN-001"
+    component: "version"
     layer: "core"
     timeline:
-      start: "6h"
-      severityChanges:
-        - time: "6h"
-          severity: "info"
-        - time: "4h"
-          severity: "warning"
-        - time: "2h"
-          severity: "critical"
+      start: "8h"
     alerts:
-      - name: "PrometheusRuleEvaluationSlowFirst001"
-        namespace: "openshift-monitoring"
+      - name: "V001"
+        namespace: "openshift-cluster-version"
         severity: "info"
         firing: true
-        timeline:
-          start: "6h"
-      - name: "PrometheusQueryLatencyIncreasingSecond001"
-        namespace: "openshift-monitoring"
-        severity: "info"
-        firing: true
-        timeline:
-          start: "5h"
-      - name: "AlertmanagerConfigReloadFailedThird001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-        timeline:
-          start: "4h"
-      - name: "PrometheusTargetScrapeFailuresFourth001"
-        namespace: "openshift-monitoring"
-        severity: "warning"
-        firing: true
-        timeline:
-          start: "3h"
-      - name: "AlertmanagerClusterFailedToSendNotificationsFifth001"
-        namespace: "openshift-monitoring"
-        severity: "critical"
-        firing: true
-        timeline:
-          start: "2h"
-      - name: "PrometheusRemoteWriteDesiredShardsSixth001"
-        namespace: "openshift-monitoring"
-        severity: "critical"
-        firing: true
-        timeline:
-          start: "1h"
-


### PR DESCRIPTION
This PR extends the comprehensive charts UI regression test to verify that short duration incidents (<5 minutes) are properly visible and selectable in the charts view.

**Changes:**
- Enhanced charts UI comprehensive test with short duration incident scenarios (1-min and 10-min incidents)
- Added `selectIncidentById` and `deselectIncidentById` methods to the incidents page object
- Refactored and simplified test fixture for better maintainability
- Ensures proper bar rendering and alert loading for brief incidents

**Test Coverage:**
- Validates visibility of short-lived incidents in charts
- Tests incident selection/deselection functionality
- Verifies correct rendering of incident bars for varying durations