### PR TITLE
OU-877: perses e2e testing

### DIFF
--- a/web/cypress/e2e/perses/01.coo_perses.cy.ts
+++ b/web/cypress/e2e/perses/01.coo_perses.cy.ts
@@ -1,0 +1,38 @@
+import { nav } from '../../views/nav';
+import { runBVTCOOPersesTests } from '../../support/perses/00.coo_bvt_perses.cy';
+import { guidedTour } from '../../views/tour';
+
+// Set constants for the operators that need to be installed for tests.
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+describe('BVT: COO - Dashboards (Perses) - Administrator perspective', () => {
+
+  before(() => {
+    cy.beforeBlockCOO(MCP, MP);
+  });
+
+  beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
+    nav.sidenav.clickNavLink(['Observe', 'Dashboards (Perses)']);
+  });
+
+  runBVTCOOPersesTests({
+    name: 'Administrator',
+  });
+
+});

--- a/web/cypress/e2e/virtualization/04.coo_ivt_perses.cy.ts
+++ b/web/cypress/e2e/virtualization/04.coo_ivt_perses.cy.ts
@@ -1,0 +1,75 @@
+import { nav } from '../../views/nav';
+import { runBVTCOOPersesTests } from '../../support/perses/00.coo_bvt_perses.cy';
+import { guidedTour } from '../../views/tour';
+import { commonPages } from '../../views/common';
+
+// Set constants for the operators that need to be installed for tests.
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+const KBV = {
+  namespace: 'openshift-cnv',
+  packageName: 'kubevirt-hyperconverged',
+  config: {
+    kind: 'HyperConverged',
+    name: 'kubevirt-hyperconverged',
+  },
+  crd: {
+    kubevirt: 'kubevirts.kubevirt.io',
+    hyperconverged: 'hyperconvergeds.hco.kubevirt.io',
+  }
+};
+
+describe('Installation: COO and setting up Monitoring Plugin', () => {
+
+  before(() => {
+    cy.beforeBlockCOO(MCP, MP);
+  });
+
+  it('1. Installation: COO and setting up Monitoring Plugin', () => {
+    cy.log('Installation: COO and setting up Monitoring Plugin');
+  });
+});
+
+describe('Installation: Virtualization', () => {
+
+  before(() => {
+    cy.beforeBlockVirtualization(KBV);
+  });
+
+  it('1. Installation: Virtualization', () => {
+    cy.log('Installation: Virtualization');
+    cy.switchPerspective('Virtualization');
+    guidedTour.closeKubevirtTour();
+  });
+});
+
+describe('IVT: COO - Dashboards (Perses) - Virtualization perspective', () => {
+
+  beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
+    cy.switchPerspective('Virtualization');
+    guidedTour.closeKubevirtTour();
+    nav.sidenav.clickNavLink(['Observe', 'Dashboards (Perses)']);
+    commonPages.titleShouldHaveText('Dashboards');
+  });
+
+  runBVTCOOPersesTests({
+    name: 'Virtualization',
+  });
+
+});

--- a/web/cypress/fixtures/perses/constants.ts
+++ b/web/cypress/fixtures/perses/constants.ts
@@ -1,0 +1,42 @@
+export enum persesDashboardsTimeRange {
+  CUSTOM_TIME_RANGE = 'Custom Time Range',
+  LAST_5_MINUTES = 'Last 5 minutes',
+  LAST_15_MINUTES = 'Last 15 minutes',
+  LAST_30_MINUTES = 'Last 30 minutes',
+  LAST_1_HOUR = 'Last 1 hour',
+  LAST_6_HOURS = 'Last 6 hours',
+  LAST_12_HOURS = 'Last 12 hours',
+  LAST_24_HOURS = 'Last 24 hours',
+  LAST_7_DAYS = 'Last 7 days',
+  LAST_14_DAYS = 'Last 14 days',
+}
+
+export enum persesDashboardsRefreshInterval {
+  OFF = 'Off',
+  FIVE_SECONDS = '5s',
+  TEN_SECONDS = '10s',
+  FIFTEEN_SECONDS = '15s',
+  THIRTY_SECONDS = '30s',
+  ONE_MINUTE = '1m',
+}
+
+export const persesDashboardsDashboardDropdownCOO = {
+  ACCELERATORS_COMMON_METRICS:['Accelerators common metrics', 'perses'],
+  K8S_COMPUTE_RESOURCES_CLUSTER: ['Kubernetes / Compute Resources / Cluster', 'perses'],
+}
+
+export const persesDashboardsDashboardDropdownPersesDev = {
+  PERSES_DASHBOARD_SAMPLE: ['Perses Dashboard Sample', 'perses'],
+  PROMETHEUS_OVERVIEW: ['Prometheus / Overview', 'perses'],
+  THANOS_COMPACT_OVERVIEW: ['Thanos / Compact / Overview', 'perses'],
+}
+
+export enum persesDashboardsAcceleratorsCommonMetricsPanels {
+  GPU_UTILIZATION = 'GPU Utilization',
+  MEMORY_USED_BYTES = 'Memory Used Bytes',
+  MEMORY_TOTAL_BYTES = 'Memory Total Bytes',
+  POWER_USAGE_WATTS = 'Power Usage (Watts)',
+  TEMPERATURE_CELCIUS = 'Temperature (Celsius)',
+  SM_CLOCK_HERTZ = 'SM Clock (Hertz)',
+  MEMORY_CLOCK_HERTZ = 'Memory Clock (Hertz)',
+}

--- a/web/cypress/support/commands/utility-commands.ts
+++ b/web/cypress/support/commands/utility-commands.ts
@@ -1,3 +1,4 @@
+import { Classes, DataTestIDs, LegacyTestIDs } from "../../../src/components/data-test";
 export {};
 
 declare global {
@@ -57,21 +58,39 @@ Cypress.Commands.add('waitUntilWithCustomTimeout', (
 
   Cypress.Commands.add('changeNamespace', (namespace: string) => {
     cy.log('Changing Namespace to: ' + namespace);
-    cy.byLegacyTestID('namespace-bar-dropdown').find('button').scrollIntoView().should('be.visible').click();
-    cy.get('[data-test="showSystemSwitch"]').then(($element)=> {
-      if ($element.attr('data-checked-state') !== 'true') {
-        cy.byTestID('showSystemSwitch').siblings('span').eq(0).should('be.visible').click();
+    cy.wait(2000);
+    cy.get('body').then(($body) => {
+      const hasNamespaceBarDropdown = $body.find('[data-test-id="'+LegacyTestIDs.NamespaceBarDropdown+'"]').length > 0;
+      if (hasNamespaceBarDropdown) {
+        cy.byLegacyTestID(LegacyTestIDs.NamespaceBarDropdown).find('button').scrollIntoView().should('be.visible');
+        cy.byLegacyTestID(LegacyTestIDs.NamespaceBarDropdown).find('button').scrollIntoView().should('be.visible').click({force: true});
+      } else {
+        cy.byClass(Classes.NamespaceDropdown).scrollIntoView().should('be.visible');
+        cy.byClass(Classes.NamespaceDropdown).scrollIntoView().should('be.visible').click({force: true});
       }
     });
-    cy.byTestID('dropdown-text-filter').type(namespace);
-    cy.byTestID('dropdown-menu-item-link').contains(namespace).should('be.visible').click();
+    cy.get('body').then(($body) => {
+      const hasShowSystemSwitch = $body.find('[data-test="'+DataTestIDs.NamespaceDropdownShowSwitch+'"]').length > 0;
+      if (hasShowSystemSwitch) {
+        cy.get('[data-test="'+DataTestIDs.NamespaceDropdownShowSwitch+'"]').then(($element)=> {
+          if ($element.attr('data-checked-state') !== 'true') {
+            cy.byTestID(DataTestIDs.NamespaceDropdownShowSwitch).siblings('span').eq(0).should('be.visible');
+            cy.byTestID(DataTestIDs.NamespaceDropdownShowSwitch).siblings('span').eq(0).should('be.visible').click({force: true});
+          }
+        });
+      }
+    });
+    cy.byTestID(DataTestIDs.NamespaceDropdownTextFilter).type(namespace, {delay: 100});
+    cy.byTestID(DataTestIDs.NamespaceDropdownMenuLink).contains(namespace).should('be.visible');
+    cy.byTestID(DataTestIDs.NamespaceDropdownMenuLink).contains(namespace).should('be.visible').click({force: true});
     cy.log('Namespace changed to: ' + namespace);
   });
 
   Cypress.Commands.add('aboutModal', () => {
     cy.log('Getting OCP version');
-    cy.byTestID('help-dropdown-toggle').should('be.visible').click();
-    cy.byTestID('application-launcher-item').contains('About').should('be.visible').click();
+    cy.byTestID(DataTestIDs.MastHeadHelpIcon).should('be.visible');
+    cy.byTestID(DataTestIDs.MastHeadHelpIcon).should('be.visible').click({force: true});
+    cy.byTestID(DataTestIDs.MastHeadApplicationItem).contains('About').should('be.visible').click();
     cy.byAriaLabel('About modal').find('div[class*="co-select-to-copy"]').eq(0).should('be.visible').then(($ocpversion) => {
       cy.log('OCP version: ' + $ocpversion.text());
     });
@@ -97,14 +116,25 @@ Cypress.Commands.add('waitUntilWithCustomTimeout', (
     cy.log('Get pod image');
     cy.clickNavLink(['Workloads', 'Pods']);
     cy.changeNamespace(namespace);
-    cy.byTestID('name-filter-input').should('be.visible').type(pod);
-    cy.get(`a[data-test^="${pod}"]`).eq(0).as('podLink').click();
-    cy.get('@podLink').should('be.visible').click();
-    cy.byPFRole('rowgroup').find('td').eq(1).scrollIntoView().should('be.visible').then(($td) => {
-      cy.log('Pod image: ' + $td.text());
-      
+    cy.byTestID('page-heading').contains('Pods').should('be.visible');
+    cy.wait(5000);
+    // Check for DataViewFilters component using Cypress's built-in retry-ability
+    cy.get('body').then(($body) => {
+      const hasDataViewFilters = $body.find('[data-ouia-component-id="DataViewFilters"]').length > 0;
+      if (hasDataViewFilters) {
+        cy.byOUIAID('DataViewFilters').find('button').contains('Status').scrollIntoView().should('be.visible').click();
+        cy.byOUIAID('OUIA-Generated-Menu').find('button').contains('Name').scrollIntoView().should('be.visible').click();
+        cy.byAriaLabel('Name filter').scrollIntoView().should('be.visible').type(pod);
+      } else {
+        cy.byTestID('name-filter-input').should('be.visible').type(pod);
+      }
     });
-    cy.log('Get pod image completed');
+    cy.get(`a[data-test^="${pod}"]`).eq(0).as('podLink').click();
+      cy.get('@podLink').should('be.visible').click();
+      cy.byPFRole('rowgroup').find('td').eq(1).scrollIntoView().should('be.visible').then(($td) => {
+        cy.log('Pod image: ' + $td.text());
+      });
+      cy.log('Get pod image completed');
   });
 
   

--- a/web/cypress/support/perses/00.coo_bvt_perses.cy.ts
+++ b/web/cypress/support/perses/00.coo_bvt_perses.cy.ts
@@ -1,0 +1,58 @@
+import { persesDashboardsAcceleratorsCommonMetricsPanels, persesDashboardsDashboardDropdownCOO, persesDashboardsDashboardDropdownPersesDev } from '../../fixtures/perses/constants';
+import { commonPages } from '../../views/common';
+import { persesDashboardsPage } from '../../views/perses-dashboards';
+import { persesDataTestIDs } from '../../../src/components/data-test';
+
+export interface PerspectiveConfig {
+  name: string;
+  beforeEach?: () => void;
+}
+
+export function runBVTCOOPersesTests(perspective: PerspectiveConfig) {
+  testBVTCOOPerses(perspective);
+}
+
+export function testBVTCOOPerses(perspective: PerspectiveConfig) {
+
+  it(`1.${perspective.name} perspective - Dashboards (Perses) page`, () => {
+    cy.log(`1.1. use sidebar nav to go to Observe > Dashboards (Perses)`);
+    commonPages.titleShouldHaveText('Dashboards');
+    persesDashboardsPage.shouldBeLoaded();
+
+    persesDashboardsPage.timeRangeDropdownAssertion();
+    persesDashboardsPage.refreshIntervalDropdownAssertion();
+    persesDashboardsPage.dashboardDropdownAssertion(persesDashboardsDashboardDropdownCOO);
+    cy.wait(1000);
+    cy.changeNamespace('perses-dev');
+    persesDashboardsPage.dashboardDropdownAssertion(persesDashboardsDashboardDropdownPersesDev);
+  });
+
+  it(`2.${perspective.name} perspective - Accelerators common metrics dashboard `, () => {
+    cy.log(`2.1. use sidebar nav to go to Observe > Dashboards (Perses) > Accelerators common metrics dashboard`);
+    cy.changeNamespace('openshift-cluster-observability-operator');
+    persesDashboardsPage.clickDashboardDropdown(persesDashboardsDashboardDropdownCOO.ACCELERATORS_COMMON_METRICS[0] as keyof typeof persesDashboardsDashboardDropdownCOO);
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-cluster').should('be.visible');
+    persesDashboardsPage.panelGroupHeaderAssertion('Accelerators');
+    persesDashboardsPage.panelHeadersAcceleratorsCommonMetricsAssertion();
+    persesDashboardsPage.expandPanel(persesDashboardsAcceleratorsCommonMetricsPanels.GPU_UTILIZATION);
+    persesDashboardsPage.collapsePanel(persesDashboardsAcceleratorsCommonMetricsPanels.GPU_UTILIZATION);
+  });
+
+  it(`3.${perspective.name} perspective - Perses Dashboard Sample dashboard`, () => {
+    cy.log(`3.1. use sidebar nav to go to Observe > Dashboards (Perses) > Perses Dashboard Sample dashboard`);
+    cy.changeNamespace('perses-dev');
+    persesDashboardsPage.clickDashboardDropdown(persesDashboardsDashboardDropdownPersesDev.PERSES_DASHBOARD_SAMPLE[0] as keyof typeof persesDashboardsDashboardDropdownPersesDev);
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-job').should('be.visible');
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-instance').should('be.visible');
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-interval').should('be.visible');
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-text').should('be.visible');
+    persesDashboardsPage.panelGroupHeaderAssertion('Row 1');
+    persesDashboardsPage.expandPanel('RAM Used');
+    persesDashboardsPage.collapsePanel('RAM Used');
+    persesDashboardsPage.statChartValueAssertion('RAM Used', true);
+    persesDashboardsPage.searchAndSelectVariable('job', 'node-exporter');
+    persesDashboardsPage.statChartValueAssertion('RAM Used', false);
+  
+  });
+
+}

--- a/web/cypress/support/selectors.ts
+++ b/web/cypress/support/selectors.ts
@@ -22,6 +22,10 @@ declare global {
       bySemanticElement(element: string, text?: string): Chainable<JQuery<HTMLElement>>;
       byAriaLabel(label: string, options?: Partial<Loggable & Timeoutable & Withinable & Shadow>): Chainable<JQuery<HTMLElement>>;
       byPFRole(role: string, options?: Partial<Loggable & Timeoutable & Withinable & Shadow>): Chainable<JQuery<HTMLElement>>;
+      byDataTestID(
+        selector: string,
+        options?: Partial<Loggable & Timeoutable & Withinable & Shadow>,
+      ): Chainable<Element>;
     }
   }
 }
@@ -37,6 +41,11 @@ Cypress.Commands.add(
     cy.get(`[data-test="${selector}"]`, options);
   },
 );
+
+//MaterialUI data-testid selectors
+Cypress.Commands.add('byDataTestID', (selector: string, options?: Partial<Loggable & Timeoutable & Withinable & Shadow>) => {
+  cy.get(`[data-testid="${selector}"]`, options);
+});
 
 // deprecated!  new IDs should use 'data-test', ie. `cy.byTestID(...)`
 Cypress.Commands.add('byLegacyTestID', (selector: string) =>

--- a/web/cypress/views/perses-dashboards.ts
+++ b/web/cypress/views/perses-dashboards.ts
@@ -1,0 +1,126 @@
+import { commonPages } from "./common";
+import { DataTestIDs, Classes, LegacyTestIDs, persesAriaLabels, persesDataTestIDs } from "../../src/components/data-test";
+import { MonitoringPageTitles } from "../fixtures/monitoring/constants";
+import { persesDashboardsTimeRange, persesDashboardsRefreshInterval, persesDashboardsDashboardDropdownCOO, persesDashboardsDashboardDropdownPersesDev, persesDashboardsAcceleratorsCommonMetricsPanels } from "../fixtures/perses/constants";
+
+export const persesDashboardsPage = {
+
+  shouldBeLoaded: () => {
+    cy.log('persesDashboardsPage.shouldBeLoaded');
+    commonPages.titleShouldHaveText(MonitoringPageTitles.DASHBOARDS);
+    cy.byAriaLabel(persesAriaLabels.TimeRangeDropdown).contains(persesDashboardsTimeRange.LAST_30_MINUTES).should('be.visible');
+    cy.byAriaLabel(persesAriaLabels.ZoomInButton).should('be.visible');
+    cy.byAriaLabel(persesAriaLabels.ZoomOutButton).should('be.visible');
+    cy.byAriaLabel(persesAriaLabels.RefreshButton).should('be.visible');
+    cy.byAriaLabel(persesAriaLabels.RefreshIntervalDropdown).contains(persesDashboardsRefreshInterval.OFF).should('be.visible');
+    cy.byTestID(DataTestIDs.PersesDashboardDropdown).find('input').should('be.visible');
+    cy.byTestID(DataTestIDs.PersesDashboardDropdown).find('button').should('be.visible');
+    cy.byLegacyTestID(LegacyTestIDs.PersesDashboardSection).should('be.visible');
+
+  },
+
+  clickTimeRangeDropdown: (timeRange: persesDashboardsTimeRange) => {
+    cy.log('persesDashboardsPage.clickTimeRangeDropdown');
+    cy.byAriaLabel(persesAriaLabels.TimeRangeDropdown).should('be.visible').click({force: true});
+    cy.byPFRole('option').contains(timeRange).should('be.visible').click({force: true});
+  },
+
+  timeRangeDropdownAssertion: () => {
+    cy.log('persesDashboardsPage.timeRangeDropdownAssertion');
+    cy.byAriaLabel(persesAriaLabels.TimeRangeDropdown).should('be.visible').click({force: true});
+    const timeRanges = Object.values(persesDashboardsTimeRange);
+    timeRanges.forEach((timeRange) => {
+      cy.log('Time range: ' + timeRange);
+      cy.byPFRole('option').contains(timeRange).should('be.visible');
+    });
+    cy.byAriaLabel(persesAriaLabels.TimeRangeDropdown).should('be.visible').click({force: true});
+  },
+
+  clickRefreshButton: () => {
+    cy.log('persesDashboardsPage.clickRefreshButton');
+    cy.byAriaLabel(persesAriaLabels.RefreshButton).should('be.visible').click();
+  },
+
+  clickRefreshIntervalDropdown: (interval: persesDashboardsRefreshInterval) => {
+    cy.log('persesDashboardsPage.clickRefreshIntervalDropdown');
+    cy.byAriaLabel(persesAriaLabels.RefreshIntervalDropdown).should('be.visible').click({force: true});
+    cy.byPFRole('option').contains(interval).should('be.visible').click({force: true});
+  },
+
+  refreshIntervalDropdownAssertion: () => {
+    cy.log('persesDashboardsPage.refreshIntervalDropdownAssertion');
+    cy.byAriaLabel(persesAriaLabels.RefreshIntervalDropdown).should('be.visible').click({force: true});
+
+    const intervals = Object.values(persesDashboardsRefreshInterval);
+    intervals.forEach((interval) => {
+      cy.log('Refresh interval: ' + interval);
+      cy.byPFRole('option').contains(interval).should('be.visible');
+    });
+    //Closing the dropdown by clicking on the OFF option, because the dropdown is not accessible while the menu is open, even forcing it
+    cy.byPFRole('option').contains(persesDashboardsRefreshInterval.OFF).should('be.visible').click({force: true});
+    
+  },
+
+  clickDashboardDropdown: (dashboard: keyof typeof persesDashboardsDashboardDropdownCOO | keyof typeof persesDashboardsDashboardDropdownPersesDev) => {
+    cy.log('persesDashboardsPage.clickDashboardDropdown');
+    cy.byTestID(DataTestIDs.PersesDashboardDropdown).find('button').should('be.visible').click({force: true});
+    cy.byPFRole('option').contains(dashboard).should('be.visible').click({force: true});
+  },
+
+  dashboardDropdownAssertion: (constants: typeof persesDashboardsDashboardDropdownCOO | typeof persesDashboardsDashboardDropdownPersesDev) => {
+    cy.log('persesDashboardsPage.dashboardDropdownAssertion');
+    cy.byTestID(DataTestIDs.PersesDashboardDropdown).find('button').should('be.visible').click({force: true});
+    const dashboards = Object.values(constants);
+    dashboards.forEach((dashboard) => {
+      cy.log('Dashboard: ' + dashboard[0]);
+      cy.get(Classes.MenuItem).contains(dashboard[0]).should('be.visible');
+      if (dashboard[1] !== '') {
+        cy.get(Classes.MenuItem).should('contain', dashboard[0]).and('contain', dashboard[1]);
+      }
+    });
+    cy.wait(1000);
+    cy.byTestID(DataTestIDs.PersesDashboardDropdown).find('button').should('be.visible').click({force: true});
+  },
+
+  panelGroupHeaderAssertion: (panelGroupHeader: string) => {
+    cy.log('persesDashboardsPage.panelGroupHeaderAssertion');
+    cy.byDataTestID(persesDataTestIDs.panelGroupHeader).contains(panelGroupHeader).should('be.visible');
+  },
+
+  panelHeadersAcceleratorsCommonMetricsAssertion: () => {
+    cy.log('persesDashboardsPage.panelHeadersAcceleratorsCommonMetricsAssertion');
+
+    const panels = Object.values(persesDashboardsAcceleratorsCommonMetricsPanels);
+    panels.forEach((panel) => {
+      cy.log('Panel: ' + panel);
+      cy.byDataTestID(persesDataTestIDs.panelHeader).find('h6').contains(panel).scrollIntoView().should('be.visible');
+    });
+  },
+
+  expandPanel: (panel: keyof typeof persesDashboardsAcceleratorsCommonMetricsPanels | string) => {
+    cy.log('persesDashboardsPage.expandPanel');
+    cy.byDataTestID(persesDataTestIDs.panelHeader).find('h6').contains(panel).scrollIntoView().siblings('div').eq(2).find('[data-testid="ArrowExpandIcon"]').click({force: true});
+  },
+
+  collapsePanel: (panel: keyof typeof persesDashboardsAcceleratorsCommonMetricsPanels | string) => {
+    cy.log('persesDashboardsPage.collapsePanel');
+    cy.byDataTestID(persesDataTestIDs.panelHeader).find('h6').contains(panel).scrollIntoView().siblings('div').eq(2).find('[data-testid="ArrowCollapseIcon"]').click({force: true});
+  },
+
+  statChartValueAssertion: (panel: keyof typeof persesDashboardsAcceleratorsCommonMetricsPanels | string, noData: boolean) => {
+    cy.log('persesDashboardsPage.statChartValueAssertion');
+    cy.wait(2000);
+    if (noData) {
+      cy.byDataTestID(persesDataTestIDs.panelHeader).find('h6').contains(panel).scrollIntoView().parents('header').siblings('figure').find('p').should('contain', 'No data').should('be.visible');
+    } else {
+      cy.byDataTestID(persesDataTestIDs.panelHeader).find('h6').contains(panel).scrollIntoView().parents('header').siblings('figure').find('h3').should('not.contain', 'No data').should('be.visible');
+    }
+  },
+
+  searchAndSelectVariable: (variable: string, value: string) => {
+    cy.log('persesDashboardsPage.searchAndSelectVariable');
+    cy.byDataTestID(persesDataTestIDs.variableDropdown+'-'+variable).find('input').type(value);
+    cy.byPFRole('option').contains(value).click({force: true});
+    cy.wait(1000);
+  },
+}

--- a/web/src/components/data-test.ts
+++ b/web/src/components/data-test.ts
@@ -19,6 +19,8 @@ export const DataTestIDs = {
   ExpireXSilencesButton: 'expire-x-silences-button',
   Expression: 'expression',
   KebabDropdownButton: 'kebab-dropdown-button',
+  MastHeadHelpIcon: 'help-dropdown-toggle',
+  MastHeadApplicationItem: 'application-launcher-item',
   MetricGraph: 'metric-graph',
   MetricGraphNoDatapointsFound: 'datapoints-msg',
   MetricGraphTimespanDropdown: 'graph-timespan-dropdown',
@@ -51,7 +53,11 @@ export const DataTestIDs = {
   MetricsPageYellowNoDatapointsFound: 'yellow-no-datapoints-found',
   NameInput: 'name-filter-input',
   NameLabelDropdown: 'console-select-menu-toggle',
+  NamespaceDropdownMenuLink: 'dropdown-menu-item-link',
   NameLabelDropdownOptions: 'console-select-item',
+  NamespaceDropdownShowSwitch: 'showSystemSwitch',
+  NamespaceDropdownTextFilter: 'dropdown-text-filter',
+  PersesDashboardDropdown: 'dashboard-dropdown',
   SeverityBadgeHeader: 'severity-badge-header',
   SeverityBadge: 'severity-badge',
   SilenceAlertDropdownItem: 'silence-alert-dropdown-item',
@@ -160,6 +166,8 @@ export const LegacyDashboardPageTestIDs = {
 export const LegacyTestIDs = {
   ItemFilter: 'item-filter',
   SelectAllSilencesCheckbox: 'select-all-silences-checkbox',
+  PersesDashboardSection: 'dashboard',
+  NamespaceBarDropdown: 'namespace-bar-dropdown',
 };
 
 export const IDs = {
@@ -192,6 +200,7 @@ export const Classes = {
   MetricsPageUngraphableResultsDescription: '.pf-v6-c-empty-state__body',
   MetricsPageQueryAutocomplete: '.cm-tooltip-autocomplete.cm-tooltip.cm-tooltip-below',
   MoreLessTag: '.pf-v6-c-label-group__label, .pf-v5-c-chip-group__label',
+  NamespaceDropdown: '.pf-v6-c-menu-toggle.co-namespace-dropdown__menu-toggle',
   SectionHeader: '.pf-v6-c-title.pf-m-h2, .co-section-heading',
   TableHeaderColumn: '.pf-v6-c-table__button, .pf-c-table__button',
   SilenceAlertTitle: '.pf-v6-c-alert__title, .pf-v5-c-alert__title',
@@ -203,4 +212,18 @@ export const Classes = {
   SilenceKebabDropdown: '.pf-v6-c-menu-toggle.pf-m-plain, .pf-v5-c-dropdown__toggle.pf-m-plain',
   SilenceLabelRow: '.pf-v6-l-grid.pf-m-all-12-col-on-sm.pf-m-all-4-col-on-md.pf-m-gutter, .row',
   SilenceState: '.pf-v6-l-stack__item, .co-break-word',
+};
+
+export const persesAriaLabels = {
+  TimeRangeDropdown: 'Select time range. Currently set to [object Object]',
+  RefreshButton: 'Refresh',
+  RefreshIntervalDropdown: 'Select refresh interval. Currently set to 0s',
+  ZoomInButton: 'Zoom in',
+  ZoomOutButton: 'Zoom out',
+};
+
+export const persesDataTestIDs = {
+  variableDropdown: 'variable',
+  panelGroupHeader: 'panel-group-header',
+  panelHeader: 'panel',
 };


### PR DESCRIPTION
E2E testing for Perses in a way to be reusable in different perspectives.
- e2e folder contains a new folder: perses and a cypress file calling out testing scenarios that are exported and located under support folder, following recommendations from claude code;
- this way the same testing scenarios can be called out just changing the before, beforeEach changing the perspective;
- this approach will be applied to Monitoring testing in other PR.
- how to run will be written as part of Testing for monitoring-plugin repo as a whole, but this cypress testing also takes into consideration exported CYPRESS variables to install or skip installation of COO, to be decoupled of any other COO test.
- uninstallation is not part of this test due to CI/CD approach to reuse sessions and skip installation, to speed up execution time. A separated uninstallation testing will be developed.

<img width="754" height="371" alt="image" src="https://github.com/user-attachments/assets/4f1de61a-f974-464e-8721-a49b52c56f11" />
