### PR TITLE
NO-JIRA: use tanstack-query for dashboard config fetching

### DIFF
--- a/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
@@ -19,9 +19,8 @@ type LegacyDashboardsPageProps = {
 const LegacyDashboardsPage_: FC<LegacyDashboardsPageProps> = ({ urlBoard }) => {
   const { project, setProject } = useOpenshiftProject();
   const {
-    legacyDashboardsError,
+    legacyDashboards,
     legacyRows,
-    legacyDashboardsLoading,
     legacyDashboardsMetadata,
     changeLegacyDashboard,
     legacyDashboard,
@@ -38,11 +37,14 @@ const LegacyDashboardsPage_: FC<LegacyDashboardsPageProps> = ({ urlBoard }) => {
         dashboardName={legacyDashboard}
       >
         <Overview>
-          {legacyDashboardsLoading ? (
+          {legacyDashboards.dashboardsLoading ? (
             <LoadingInline />
-          ) : legacyDashboardsError ? (
+          ) : legacyDashboards?.dashboardError ? (
             <ErrorAlert
-              error={{ message: legacyDashboardsError, name: t('Error Loading Dashboards') }}
+              error={{
+                message: legacyDashboards.dashboardError,
+                name: t('Error Loading Dashboards'),
+              }}
             />
           ) : (
             <LegacyDashboard rows={legacyRows} perspective={perspective} />

--- a/web/src/components/dashboards/perses/dashboard-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-page.tsx
@@ -1,5 +1,4 @@
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { FC } from 'react';
 import { LoadingInline } from '../../console/console-shared/src/components/loading/LoadingInline';
 import { PersesWrapper } from './PersesWrapper';
@@ -9,15 +8,7 @@ import { ProjectEmptyState } from './emptystates/ProjectEmptyState';
 import { useDashboardsData } from './hooks/useDashboardsData';
 import PersesBoard from './perses-dashboards';
 import { ProjectBar } from './project/ProjectBar';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: 0,
-    },
-  },
-});
+import { MonitoringProvider } from '../../../contexts/MonitoringContext';
 
 const MonitoringDashboardsPage_: FC = () => {
   const {
@@ -63,9 +54,11 @@ const MonitoringDashboardsPage_: FC = () => {
 
 const MonitoringDashboardsPageWrapper: FC = () => {
   return (
-    <QueryClientProvider client={queryClient}>
+    <MonitoringProvider
+      monitoringContext={{ plugin: 'monitoring-console-plugin', prometheus: 'cmo' }}
+    >
       <MonitoringDashboardsPage_ />
-    </QueryClientProvider>
+    </MonitoringProvider>
   );
 };
 

--- a/web/src/contexts/MonitoringContext.tsx
+++ b/web/src/contexts/MonitoringContext.tsx
@@ -2,7 +2,17 @@ import React, { useMemo } from 'react';
 import { MonitoringPlugins, Prometheus } from '../components/utils';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 0,
+    },
+  },
+});
 
 type MonitoringContextType = {
   /** Dictates which plugin this code is being run in */
@@ -67,7 +77,9 @@ export const MonitoringProvider: React.FC<{
 
   return (
     <MonitoringContext.Provider value={monContext}>
-      <QueryParamProvider adapter={ReactRouter5Adapter}>{children}</QueryParamProvider>
+      <QueryParamProvider adapter={ReactRouter5Adapter}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </QueryParamProvider>
     </MonitoringContext.Provider>
   );
 };


### PR DESCRIPTION
An example usage of the useQuery for fetching data in the monitoring-plugin. I'd like to take this PR as a place to discuss if this is something we want to move forward with, and if so how we should structure our codebase differently. In the perses codebase they have a set of "client" files which contain the fetch and hook functions, with the data returned being used in their components. Since our team doesn't have control over the backend, we can't structure the API endpoints to return the data as we need it, so we may need a third functional layer there which performs the data formatting, because (as seen in this PR) we may want to adjust or filter the data without needing to refetch. Let me know what you think