### PR TITLE
OU-1075: IVT Troubleshooting Panel UIPlugin installation

### DIFF
--- a/web/cypress/e2e/coo/01.coo_bvt.cy.ts
+++ b/web/cypress/e2e/coo/01.coo_bvt.cy.ts
@@ -1,5 +1,6 @@
 import { commonPages } from '../../views/common';
 import { nav } from '../../views/nav';
+import { troubleshootingPanelPage } from '../../views/troubleshooting-panel';
 
 
 // Set constants for the operators that need to be installed for tests.
@@ -31,9 +32,12 @@ describe('BVT: COO', { tags: ['@smoke', '@coo'] }, () => {
     commonPages.titleShouldHaveText('Alerting');
     nav.tabs.switchTab('Silences');
     nav.tabs.switchTab('Alerting rules');
-    // nav.tabs.switchTab('Incidents');
+    nav.tabs.switchTab('Incidents');
     nav.sidenav.clickNavLink(['Observe', 'Dashboards (Perses)']);
     commonPages.titleShouldHaveText('Dashboards');
+    nav.sidenav.clickNavLink(['Observe', 'Alerting']);
+    troubleshootingPanelPage.openSignalCorrelation();
+    troubleshootingPanelPage.troubleshootingPanelPageShouldBeLoadedEnabled();
 
   });
 

--- a/web/cypress/e2e/coo/01.coo_ivt.cy.ts
+++ b/web/cypress/e2e/coo/01.coo_ivt.cy.ts
@@ -1,7 +1,5 @@
-import { Classes } from '../../../src/components/data-test';
-import { commonPages } from '../../views/common';
-import { nav } from '../../views/nav';
 import { guidedTour } from '../../views/tour';
+import { troubleshootingPanelPage } from '../../views/troubleshooting-panel';
 
 // Set constants for the operators that need to be installed for tests.
 const KBV = {
@@ -29,6 +27,7 @@ describe('IVT: Monitoring UIPlugin + Virtualization', { tags: ['@smoke', '@coo']
     cy.switchPerspective('Virtualization');
     cy.byAriaLabel('Welcome modal').should('be.visible');
     guidedTour.closeKubevirtTour();
+    troubleshootingPanelPage.signalCorrelationShouldNotBeVisible();
     cy.switchPerspective('Administrator');
 
   });

--- a/web/cypress/fixtures/coo/troubleshooting-panel-ui-plugin.yaml
+++ b/web/cypress/fixtures/coo/troubleshooting-panel-ui-plugin.yaml
@@ -1,0 +1,6 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: troubleshooting-panel
+spec:
+  type: TroubleshootingPanel

--- a/web/cypress/support/commands/operator-commands.ts
+++ b/web/cypress/support/commands/operator-commands.ts
@@ -6,6 +6,7 @@ import Shadow = Cypress.Shadow;
 import 'cypress-wait-until';
 import { operatorHubPage } from '../../views/operator-hub-page';
 import { nav } from '../../views/nav';
+import { DataTestIDs, LegacyTestIDs } from '../../../src/components/data-test';
 
 export { };
 
@@ -398,6 +399,38 @@ const operatorUtils = {
     cy.url().should('include', '/monitoring/v2/dashboards');
   },
 
+  setupTroubleshootingPanel(MCP: { namespace: string }): void {
+    cy.log('Create troubleshooting panel instance.');
+    cy.exec(`oc apply -f ./cypress/fixtures/coo/troubleshooting-panel-ui-plugin.yaml --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`);
+    
+    cy.log('Troubleshooting panel instance created. Waiting for pods to be ready.');
+    cy.exec(
+      `sleep 15 && oc wait --for=condition=Ready pods --selector=app.kubernetes.io/instance=troubleshooting-panel -n ${MCP.namespace} --timeout=60s --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+      {
+        timeout: readyTimeoutMilliseconds,
+        failOnNonZeroExit: true
+      }
+    ).then((result) => {
+      expect(result.code).to.eq(0);
+      cy.log(`Troubleshooting panel pod is now running in namespace: ${MCP.namespace}`);
+    });
+
+    cy.exec(
+      `sleep 15 && oc wait --for=condition=Ready pods --selector=app.kubernetes.io/instance=korrel8r -n ${MCP.namespace} --timeout=600s --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+      {
+        timeout: installTimeoutMilliseconds,
+        failOnNonZeroExit: true
+      }
+    ).then((result) => {
+      expect(result.code).to.eq(0);
+      cy.log(`Korrel8r pod is now running in namespace: ${MCP.namespace}`);
+    });
+
+    cy.reload(true);
+    cy.byLegacyTestID(LegacyTestIDs.ApplicationLauncher).should('be.visible').click();
+    cy.byTestID(DataTestIDs.MastHeadApplicationItem).contains('Signal Correlation').should('be.visible');
+  },
+
   revertMonitoringPluginImage(MP: { namespace: string }): void {
     if (Cypress.env('MP_IMAGE')) {
       cy.log('MP_IMAGE is set. Lets revert CMO operator CSV');
@@ -484,7 +517,6 @@ const operatorUtils = {
         if (checkResult.code === 0) {
           // Namespace exists, proceed with deletion
           cy.log('Namespace exists, proceeding with deletion');
-          cy.log('Eve');
 
           // Step 1: Delete CSV (ClusterServiceVersion)
           cy.exec(
@@ -579,14 +611,64 @@ const operatorUtils = {
                 }
               });
           };
-        
+          
           checkStatus();
+
+          cy.then(() => {
+            operatorUtils.waitForPodsDeleted(MCP.namespace);
+          });
 
         } else {
           cy.log('Namespace does not exist, skipping deletion');
         }
       });
     }
+  },
+
+  waitForPodsDeleted(namespace: string, maxWaitMs: number = 120000): void {
+    const kubeconfigPath = Cypress.env('KUBECONFIG_PATH');
+    const checkIntervalMs = 5000;
+    const startTime = Date.now();
+    const podPatterns = 'monitoring|perses|perses-0|health-analyzer|troubleshooting-panel|korrel8r';
+    
+    const checkPods = () => {
+      const elapsed = Date.now() - startTime;
+      
+      if (elapsed > maxWaitMs) {
+        throw new Error(`Timeout: Pods still exist after ${maxWaitMs / 1000}s`);
+      }
+      
+      cy.exec(
+        `oc get pods -n ${namespace} --kubeconfig ${kubeconfigPath} -o name 2>&1 | grep -E '${podPatterns}' | wc -l`,
+        { failOnNonZeroExit: false }
+      ).then((result) => {
+        const count = parseInt(result.stdout.trim(), 10);
+        
+        if (count === 0 || result.stderr.includes('not found')) {
+          cy.log(`✓ All target pods deleted after ${elapsed}ms`);
+        } else {
+          cy.log(`${elapsed}ms - ${count} pod(s) still exist, retrying...`);
+          cy.wait(checkIntervalMs).then(checkPods);
+        }
+      });
+    };
+    
+    checkPods();
+  },
+
+  cleanupTroubleshootingPanel(MCP: { namespace: string, config1?: { kind: string, name: string } }): void {
+    const config1 = MCP.config1 || { kind: 'UIPlugin', name: 'troubleshooting-panel' };
+
+    if (Cypress.env('SKIP_ALL_INSTALL')) {
+      cy.log('SKIP_ALL_INSTALL is set. Skipping Troubleshooting Panel instance deletion.');
+      return;
+    }
+
+    cy.log('Delete Troubleshooting Panel instance.');
+    cy.executeAndDelete(
+      `oc delete ${config1.kind} ${config1.name} --ignore-not-found --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+    );
+
   },
 
   RemoveClusterAdminRole(): void {
@@ -697,6 +779,7 @@ Cypress.Commands.add('beforeBlock', (MP: { namespace: string, operatorName: stri
       cy.log('SKIP_ALL_INSTALL is set. Skipping COO cleanup and operator verifications (preserves existing setup).');
       return;
     }
+    operatorUtils.cleanupTroubleshootingPanel(MCP);
     operatorUtils.cleanup(MCP);
     operatorUtils.revertMonitoringPluginImage(MP);
     cy.log('Cleanup COO (no session) completed');
@@ -711,6 +794,7 @@ Cypress.Commands.add('beforeBlock', (MP: { namespace: string, operatorName: stri
     operatorUtils.waitForCOOReady(MCP);
     operatorUtils.setupMonitoringConsolePlugin(MCP);
     operatorUtils.setupDashboardsAndPlugins(MCP);
+    operatorUtils.setupTroubleshootingPanel(MCP);
     operatorUtils.setupMonitoringPluginImage(MP);
     operatorUtils.RemoveClusterAdminRole();
     operatorUtils.collectDebugInfo(MP, MCP);

--- a/web/cypress/views/troubleshooting-panel.ts
+++ b/web/cypress/views/troubleshooting-panel.ts
@@ -1,0 +1,30 @@
+import { DataTestIDs, Classes, LegacyTestIDs, IDs } from "../../src/components/data-test";
+
+export const troubleshootingPanelPage = {
+
+  openSignalCorrelation: () => {
+    cy.log('troubleshootingPanelPage.openSignalCorrelation');
+    cy.byLegacyTestID(LegacyTestIDs.ApplicationLauncher).should('be.visible').click();
+    cy.byTestID(DataTestIDs.MastHeadApplicationItem).contains('Signal Correlation').should('be.visible').click();
+  },
+
+  signalCorrelationShouldNotBeVisible: () => {
+    cy.log('troubleshootingPanelPage.signalCorrelationShouldNotBeVisible');
+    cy.byLegacyTestID(LegacyTestIDs.ApplicationLauncher).should('be.visible').click();
+    cy.byTestID(DataTestIDs.MastHeadApplicationItem).contains('Signal Correlation').should('not.exist');
+    cy.byLegacyTestID(LegacyTestIDs.ApplicationLauncher).should('be.visible').click();
+  },
+
+  troubleshootingPanelPageShouldBeLoadedEnabled: () => {
+    cy.log('troubleshootingPanelPage.troubleshootingPanelPageShouldBeLoadedEnabled');
+    cy.get('h1').contains('Troubleshooting').should('be.visible');
+    cy.byAriaLabel('Close').should('be.visible');
+    cy.byButtonText('Focus').should('be.visible');
+    cy.get('#query-toggle').should('be.visible');
+    //svg path for refresh button
+    cy.get('.tp-plugin__panel-query-container').find('path').eq(1).should('have.attr', 'd', 'M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z');
+    cy.byDataID('korrel8r_graph').should('be.visible');
+  },
+
+  
+};

--- a/web/src/components/data-test.ts
+++ b/web/src/components/data-test.ts
@@ -169,6 +169,7 @@ export const LegacyTestIDs = {
   SelectAllSilencesCheckbox: 'select-all-silences-checkbox',
   PersesDashboardSection: 'dashboard',
   NamespaceBarDropdown: 'namespace-bar-dropdown',
+  ApplicationLauncher: 'application-launcher',
 };
 
 export const IDs = {


### PR DESCRIPTION
For future validation of Monitoring - Alert Details page with Troubleshooting Panel link, this PR aims to:
- install Troubleshooting Panel UIPlugin when installing COO and deleting it when cleaning up COO
- validate Signal Correlation entry in Application Launcher when Admin perspective
- validate Signal Correlation entry does not exist in Application Launcher when Virtualization perspective