### PR TITLE
OU-1082: claude slash commands cypress-setup and cypress-run

### DIFF
--- a/.claude/commands/cypress/cypress-run.md
+++ b/.claude/commands/cypress/cypress-run.md
@@ -1,0 +1,382 @@
+---
+name: cypress-run 
+description: Display Cypress test commands - choose execution mode (headless recommended)
+parameters:
+  - name: execution-mode
+    description: Choose execution mode - headless (recommended), headed, or interactive
+    required: true
+    type: string
+---
+
+# Cypress Test Commands
+
+**Prerequisites**: 
+1. Run `/cypress-setup` first to configure your environment.
+2. Ensure the "Cypress Tests" terminal window is open (created by `/cypress-setup`)
+
+**Note**: All commands are executed in the "Cypress Tests" terminal window using the helper scripts.
+
+---
+
+## Execution Modes
+
+1. **Headless** (Recommended) - Fast, automated testing without visible browser
+2. **Headed** - Watch tests execute in visible browser for debugging
+3. **Interactive** - Visual UI to pick and run tests manually
+
+---
+
+## How to Run Commands in Cypress Tests Terminal
+
+All npm commands should be executed in the "Cypress Tests" terminal using the helper scripts:
+
+**macOS:**
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run <command>"
+```
+
+**Linux:**
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh --run "npm run <command>"
+```
+
+**Instructions**: Based on the `execution-mode` parameter provided by the user:
+- If `execution-mode` is "interactive": Display ONLY the "Interactive Mode" section below
+- If `execution-mode` is "headless": display ONLY the "Headless Mode" section with interactive options to be chosen
+- If `execution-mode` is "headed": display ONLY the "Headed Mode" section with interactive options to be chosen
+
+**IMPORTANT**: Always execute the selected command using the appropriate script:
+- macOS: `./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "<command>"`
+- Linux: `./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh --run "<command>"`
+
+
+---
+
+# Interactive Mode
+
+**Cypress Interactive Test Runner** - Pick and run tests visually with Cypress UI.
+
+## What is Interactive Mode?
+
+Interactive mode opens the Cypress Test Runner UI where you can:
+- Browse and select tests visually
+- Watch tests run in real-time with time-travel debugging
+- Inspect DOM snapshots at each step
+- See detailed command logs
+- Rerun tests with a single click
+- Perfect for test development and debugging
+
+## Command
+
+**Open Cypress Interactive UI (run in Cypress Tests terminal):**
+
+macOS:
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run cypress:open"
+```
+
+Linux:
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh --run "npm run cypress:open"
+```
+
+This opens a visual interface where you can:
+1. Choose a browser (Chrome, Firefox, Edge, Electron)
+2. Browse your test files
+3. Click any test to run it
+4. Watch it execute step-by-step
+5. Debug failures interactively
+
+## Benefits
+
+- **Visual Testing**: See exactly what's happening
+- **Fast Iteration**: Make changes and rerun instantly
+- **Easy Debugging**: Inspect any step of your test
+- **Browser DevTools**: Full access to browser debugging tools
+- **Selector Playground**: Helps you write better selectors
+
+## When to Use
+
+- Developing new tests
+- Debugging test failures
+- Learning how tests work
+- Demonstrating tests to others
+
+---
+
+# Headless Mode Commands
+
+All commands below run tests in headless mode (no visible browser).
+
+## Dynamic Command Discovery
+
+**IMPORTANT**: Before showing test commands, you MUST dynamically read:
+
+### 1. Available NPM Scripts
+Read `web/package.json` and extract all scripts matching `test-cypress-*` and `cypress:*` patterns.
+Present them as available test suite commands.
+
+### 2. Available Test Spec Files  
+Scan `web/cypress/e2e/` directory recursively and list all `.cy.ts` files.
+Present them as available spec file targets for `--spec` option.
+
+---
+
+## Quick Reference - Base Commands
+
+**Run with npm script (if defined in package.json):**
+```bash
+npm run <script-name>
+```
+
+**Run all tests headless:**
+```bash
+npm run cypress:run
+```
+
+**Run specific spec file:**
+```bash
+npm run cypress:run -- --spec "cypress/e2e/<path-to-file>.cy.ts"
+```
+
+**Run with custom tags:**
+```bash
+npm run cypress:run -- --env grepTags="<YOUR_TAGS_HERE>"
+```
+
+---
+
+## NPM Scripts from package.json
+
+**Instructions**: Read `web/package.json` and list ALL scripts that start with:
+- `test-cypress-*` (predefined test suites)
+- `cypress:*` (base cypress commands)
+
+For each script found, display:
+```bash
+npm run <script-name>
+```
+
+Add a brief description based on the grepTags or other flags in the script definition.
+
+---
+
+## Spec Files from cypress/e2e
+
+**Instructions**: Scan `web/cypress/e2e/` recursively and organize by folder:
+
+For each `.cy.ts` file found, show the command:
+```bash
+npm run cypress:run -- --spec "cypress/e2e/<relative-path>"
+```
+
+Group files by their parent folder (monitoring, coo, perses, virtualization, incidents, etc.)
+
+---
+
+## Custom Tag Combinations - Headless
+
+**Base command for custom tags:**
+```bash
+npm run cypress:run -- --env grepTags="YOUR_TAGS_HERE"
+```
+
+**Tag Operators:**
+- `+` = AND (e.g., `@alerts+@smoke` = alerts AND smoke)
+- `--` = NOT (e.g., `@monitoring --@flaky` = monitoring but NOT flaky)
+- `,` = OR (e.g., `@alerts,@metrics` = alerts OR metrics)
+
+**Common tag patterns:**
+
+| Goal | Command |
+|------|---------|
+| Smoke tests only | `npm run cypress:run -- --env grepTags="@smoke"` |
+| Exclude flaky | `npm run cypress:run -- --env grepTags="<tag> --@flaky"` |
+| Exclude demo | `npm run cypress:run -- --env grepTags="<tag> --@demo"` |
+| Fast smoke | `npm run cypress:run -- --env grepTags="@smoke --@slow --@flaky"` |
+
+---
+
+## Running Multiple Spec Files
+
+**Comma-separate spec paths:**
+```bash
+npm run cypress:run -- --spec "cypress/e2e/<file1>.cy.ts,cypress/e2e/<file2>.cy.ts"
+```
+
+---
+
+## Advanced Headless Options
+
+**Run with specific browser:**
+```bash
+npm run cypress:run -- --browser firefox
+npm run cypress:run -- --browser edge
+npm run cypress:run -- --browser chrome
+```
+
+**Disable video recording:**
+```bash
+npm run cypress:run -- --config video=false
+```
+
+**Disable screenshots:**
+```bash
+npm run cypress:run -- --config screenshotOnRunFailure=false
+```
+
+---
+
+# Headed Mode Commands
+
+All commands below open a visible browser window.
+
+## Quick Start - Headed
+
+**Interactive Mode (Cypress UI, pick tests manually):**
+```bash
+npm run cypress:open
+```
+
+**Base headed mode command:**
+```bash
+npm run cypress:run -- --headed
+```
+
+---
+
+## Dynamic Command Discovery
+
+**IMPORTANT**: Before showing test commands, you MUST dynamically read:
+
+### 1. Available Test Spec Files  
+Scan `web/cypress/e2e/` directory recursively and list all `.cy.ts` files.
+Present them as available spec file targets with `--headed` flag.
+
+### 2. Available Tags
+Extract grepTags patterns from `web/package.json` scripts to show common tag combinations.
+
+---
+
+## Running Test Suites - Headed
+
+To run any tag-based suite in headed mode, add `--headed` flag:
+```bash
+npm run cypress:run -- --headed --env grepTags="<TAG_COMBINATION>"
+```
+
+**Examples based on common tags:**
+```bash
+# Monitoring tests (headed)
+npm run cypress:run -- --headed --env grepTags="@monitoring --@flaky"
+
+# Smoke tests (headed)
+npm run cypress:run -- --headed --env grepTags="@smoke --@flaky"
+
+# COO tests (headed)
+npm run cypress:run -- --headed --env grepTags="@coo --@flaky"
+```
+
+---
+
+## Running Specific Files - Headed
+
+**Template:**
+```bash
+npm run cypress:run -- --headed --spec "cypress/e2e/<path-to-file>.cy.ts"
+```
+
+**Instructions**: Scan `web/cypress/e2e/` and for each `.cy.ts` file, the headed command is:
+```bash
+npm run cypress:run -- --headed --spec "cypress/e2e/<relative-path>"
+```
+
+---
+
+## Advanced Headed Options
+
+**Headed with specific browser:**
+```bash
+npm run cypress:run -- --headed --browser chrome
+npm run cypress:run -- --headed --browser firefox
+npm run cypress:run -- --headed --browser edge
+```
+
+**Headed without video:**
+```bash
+npm run cypress:run -- --headed --config video=false
+```
+
+---
+
+## Available Tags Reference
+
+Use these tags with `--env grepTags`:
+
+**Feature Tags:**
+- `@monitoring` - Core monitoring plugin tests
+- `@monitoring-dev` - Developer user tests
+- `@alerts` - Alert-related tests
+- `@metrics` - Metrics explorer tests
+- `@dashboards` - Legacy dashboard tests
+- `@perses` - Perses dashboard tests
+- `@coo` - Observability Operator tests
+- `@acm` - Advanced Cluster Management tests
+- `@virtualization` - OpenShift Virtualization tests
+- `@incidents` - Incidents feature tests
+
+**Modifier Tags:**
+- `@smoke` - Quick smoke tests
+- `@slow` - Longer running tests
+- `@flaky` - Known flaky tests
+- `@demo` - Demo/showcase tests
+
+**Tag Operators:**
+- `+` = AND (e.g., `@alerts+@smoke` = alerts AND smoke)
+- `--` = NOT (e.g., `@monitoring --@flaky` = monitoring but NOT flaky)
+- `,` = OR (e.g., `@alerts,@metrics` = alerts OR metrics)
+
+---
+
+## Related Commands
+
+- **`/cypress-setup`** - Configure testing environment and open Cypress Tests terminal
+
+---
+
+## Running Commands via Scripts
+
+All cypress commands should be executed in the "Cypress Tests" terminal using:
+
+**macOS:**
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "<your-command>"
+```
+
+**Linux:**
+```bash
+./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh --run "<your-command>"
+```
+
+**Examples:**
+```bash
+# Run smoke tests (macOS)
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run test-cypress-smoke"
+
+# Run specific spec file (macOS)
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run cypress:run -- --spec 'cypress/e2e/monitoring/00.bvt_admin.cy.ts'"
+
+# Run with custom tags (macOS)
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run cypress:run -- --env grepTags='@monitoring --@flaky'"
+
+# Open interactive mode (macOS)
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --run "npm run cypress:open"
+```
+
+---
+
+## Documentation
+
+- `web/cypress/README.md` - Setup and execution guide
+- `web/cypress/E2E_TEST_SCENARIOS.md` - Complete test catalog
+- `web/cypress/CYPRESS_TESTING_GUIDE.md` - Testing best practices

--- a/.claude/commands/cypress/cypress-setup.md
+++ b/.claude/commands/cypress/cypress-setup.md
@@ -1,0 +1,75 @@
+---
+name: cypress-setup
+description: Automated Cypress environment setup with interactive configuration
+parameters: []
+---
+
+# Cypress Environment Setup
+
+This command sets up the Cypress testing environment by checking prerequisites, installing dependencies, and interactively configuring environment variables.
+
+## Instructions for Claude
+
+Follow these steps in order, always:
+
+### Step 1: Check Prerequisites
+
+1. **Check Node.js version** - Required: >= 18
+   - Run `node --version` and verify it's >= 18
+   - If not, inform the user they need to install Node.js 18 or higher
+
+### Step 2: Navigate and Install Dependencies
+
+1. **Navigate to the cypress directory**:
+   ```bash
+   cd web/cypress
+   ```
+
+2. **Install npm dependencies**:
+   ```bash
+   npm install
+   ```
+
+### Step 3: Interactive Environment Configuration
+
+**Important**: After Step 2, you should be in the `web/cypress` directory. All paths below are relative to that directory.
+
+1. Detect the existence of `./export-env.sh` (in the current `web/cypress` directory)
+
+2. If exists, show its variables, ask if user wants to source it. If user does not want to source it, run `./configure-env.sh` (in the current `web/cypress` directory) in the new terminal window
+
+3. If doesn't exist, prompt the user for each configuration value in `./configure-env.sh` (in the current `web/cypress` directory) in the new terminal window
+
+---
+
+## Configuration Questions
+
+### Step 4: Open a new terminal window without asking for approval
+
+Use the scripts in `.claude/commands/cypress/scripts/` to open a new terminal window named **"Cypress Tests"**.
+
+**To source existing export-env.sh:**
+```bash
+# macOS
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh
+
+# Linux
+./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh
+```
+
+**To run configure-env.sh interactively (when export-env.sh doesn't exist or user wants to reconfigure):**
+```bash
+# macOS
+./.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh --configure
+
+# Linux
+./.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh --configure
+```
+
+The `--configure` flag will run `./configure-env.sh` interactively, question by question, then source the generated `./export-env.sh`
+
+### Step 5: Inform the user
+
+Let the user know that a new terminal window has been opened with the Cypress environment pre-configured, and they can run tests using `/cypress-run` in that window.
+
+---

--- a/.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh
+++ b/.claude/commands/cypress/scripts/open-cypress-terminal-linux.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Open a named Terminal window for Cypress testing on Linux
+# Usage:
+#   ./open-cypress-terminal-linux.sh                    # Source export-env.sh
+#   ./open-cypress-terminal-linux.sh --configure        # Run configure-env.sh interactively
+#   ./open-cypress-terminal-linux.sh --run "command"    # Run a command in the Cypress Tests terminal
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Navigate from .claude/commands/cypress/scripts/ to web/cypress
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CYPRESS_DIR="$REPO_ROOT/web/cypress"
+TERMINAL_NAME="Cypress Tests"
+
+show_usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+    --configure         Run configure-env.sh interactively in the terminal
+    --run "command"     Run a specific command in the Cypress Tests terminal
+    --help              Show this help message
+
+Examples:
+    $(basename "$0")                                    # Open terminal and source export-env.sh
+    $(basename "$0") --configure                        # Run configure-env.sh interactively
+    $(basename "$0") --run "npm run cypress:open"       # Run a cypress command
+    $(basename "$0") --run "npm run test-cypress-smoke" # Run smoke tests
+EOF
+}
+
+# Detect available terminal emulator
+detect_terminal() {
+    if command -v gnome-terminal &>/dev/null; then
+        echo "gnome-terminal"
+    elif command -v konsole &>/dev/null; then
+        echo "konsole"
+    elif command -v xfce4-terminal &>/dev/null; then
+        echo "xfce4-terminal"
+    elif command -v xterm &>/dev/null; then
+        echo "xterm"
+    else
+        echo ""
+    fi
+}
+
+# Open terminal with gnome-terminal
+open_gnome_terminal() {
+    local cmd="$1"
+    gnome-terminal --title="$TERMINAL_NAME" -- bash -c "cd '$CYPRESS_DIR' && $cmd; exec bash"
+}
+
+# Open terminal with konsole
+open_konsole() {
+    local cmd="$1"
+    konsole --new-tab -p tabtitle="$TERMINAL_NAME" -e bash -c "cd '$CYPRESS_DIR' && $cmd; exec bash"
+}
+
+# Open terminal with xfce4-terminal
+open_xfce4_terminal() {
+    local cmd="$1"
+    xfce4-terminal --title="$TERMINAL_NAME" -e "bash -c 'cd \"$CYPRESS_DIR\" && $cmd; exec bash'"
+}
+
+# Open terminal with xterm
+open_xterm() {
+    local cmd="$1"
+    xterm -T "$TERMINAL_NAME" -e "cd '$CYPRESS_DIR' && $cmd; exec bash" &
+}
+
+# Open terminal based on detected emulator
+open_terminal() {
+    local cmd="$1"
+    local terminal
+    terminal=$(detect_terminal)
+
+    if [[ -z "$terminal" ]]; then
+        echo "Error: No supported terminal emulator found" >&2
+        echo "Please install one of: gnome-terminal, konsole, xfce4-terminal, xterm" >&2
+        exit 1
+    fi
+
+    echo "Using terminal: $terminal"
+
+    case "$terminal" in
+        gnome-terminal) open_gnome_terminal "$cmd" ;;
+        konsole) open_konsole "$cmd" ;;
+        xfce4-terminal) open_xfce4_terminal "$cmd" ;;
+        xterm) open_xterm "$cmd" ;;
+    esac
+}
+
+# Main
+main() {
+    local mode="source"
+    local cmd=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --configure)
+                mode="configure"
+                shift
+                ;;
+            --run)
+                mode="run"
+                cmd="${2:-}"
+                if [[ -z "$cmd" ]]; then
+                    echo "Error: --run requires a command argument" >&2
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --help|-h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    case "$mode" in
+        source)
+            echo "Opening '$TERMINAL_NAME' terminal..."
+            open_terminal "source ./export-env.sh && echo '✅ Environment loaded from export-env.sh' && echo 'You can now run Cypress tests.'"
+            ;;
+        configure)
+            echo "Opening '$TERMINAL_NAME' terminal with configuration..."
+            open_terminal "./configure-env.sh && source ./export-env.sh && echo '' && echo '✅ Environment configured and loaded.'"
+            ;;
+        run)
+            echo "Opening '$TERMINAL_NAME' terminal and running: $cmd"
+            open_terminal "source ./export-env.sh && $cmd"
+            ;;
+    esac
+
+    echo "Done."
+}
+
+main "$@"
+

--- a/.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh
+++ b/.claude/commands/cypress/scripts/open-cypress-terminal-macos.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Open a named Terminal window for Cypress testing on macOS
+# Usage:
+#   ./open-cypress-terminal-macos.sh                    # Source export-env.sh
+#   ./open-cypress-terminal-macos.sh --configure        # Run configure-env.sh interactively
+#   ./open-cypress-terminal-macos.sh --run "command"    # Run a command in the Cypress Tests terminal
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Navigate from .claude/commands/cypress/scripts/ to web/cypress
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CYPRESS_DIR="$REPO_ROOT/web/cypress"
+TERMINAL_NAME="Cypress Tests"
+
+show_usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+    --configure         Run configure-env.sh interactively in the terminal
+    --run "command"     Run a specific command in the Cypress Tests terminal
+    --help              Show this help message
+
+Examples:
+    $(basename "$0")                                    # Open terminal and source export-env.sh
+    $(basename "$0") --configure                        # Run configure-env.sh interactively
+    $(basename "$0") --run "npm run cypress:open"       # Run a cypress command
+    $(basename "$0") --run "npm run test-cypress-smoke" # Run smoke tests
+EOF
+}
+
+# Check if Cypress Tests terminal already exists and get its window ID
+find_cypress_terminal() {
+    osascript -e '
+        tell application "Terminal"
+            repeat with w in windows
+                if custom title of w is "'"$TERMINAL_NAME"'" then
+                    return id of w
+                end if
+            end repeat
+            return ""
+        end tell
+    ' 2>/dev/null || echo ""
+}
+
+# Run command in existing Cypress Tests terminal
+run_in_existing_terminal() {
+    local cmd="$1"
+    osascript <<EOF
+        tell application "Terminal"
+            repeat with w in windows
+                if custom title of w is "$TERMINAL_NAME" then
+                    do script "$cmd" in w
+                    activate
+                    return
+                end if
+            end repeat
+        end tell
+EOF
+}
+
+# Open new terminal with source export-env.sh
+open_with_source() {
+    osascript <<EOF
+        tell application "Terminal"
+            do script "cd '$CYPRESS_DIR' && source ./export-env.sh && echo '✅ Environment loaded from export-env.sh' && echo 'You can now run Cypress tests.' && echo ''"
+            delay 0.5
+            set custom title of front window to "$TERMINAL_NAME"
+            activate
+        end tell
+EOF
+}
+
+# Open new terminal and run configure-env.sh
+open_with_configure() {
+    osascript <<EOF
+        tell application "Terminal"
+            do script "cd '$CYPRESS_DIR' && ./configure-env.sh && source ./export-env.sh && echo '' && echo '✅ Environment configured and loaded.' && echo 'You can now run Cypress tests.' && echo ''"
+            delay 0.5
+            set custom title of front window to "$TERMINAL_NAME"
+            activate
+        end tell
+EOF
+}
+
+# Main
+main() {
+    local mode="source"
+    local cmd=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --configure)
+                mode="configure"
+                shift
+                ;;
+            --run)
+                mode="run"
+                cmd="${2:-}"
+                if [[ -z "$cmd" ]]; then
+                    echo "Error: --run requires a command argument" >&2
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --help|-h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    case "$mode" in
+        source)
+            local existing_id
+            existing_id=$(find_cypress_terminal)
+            if [[ -n "$existing_id" ]]; then
+                echo "Found existing '$TERMINAL_NAME' terminal, reusing it..."
+                run_in_existing_terminal "source ./export-env.sh && echo '✅ Environment reloaded.'"
+            else
+                echo "Opening new '$TERMINAL_NAME' terminal..."
+                open_with_source
+            fi
+            ;;
+        configure)
+            local existing_id
+            existing_id=$(find_cypress_terminal)
+            if [[ -n "$existing_id" ]]; then
+                echo "Found existing '$TERMINAL_NAME' terminal, running configure-env.sh..."
+                run_in_existing_terminal "./configure-env.sh && source ./export-env.sh && echo '' && echo '✅ Environment reconfigured.'"
+            else
+                echo "Opening new '$TERMINAL_NAME' terminal with configuration..."
+                open_with_configure
+            fi
+            ;;
+        run)
+            local existing_id
+            existing_id=$(find_cypress_terminal)
+            if [[ -n "$existing_id" ]]; then
+                echo "Running command in '$TERMINAL_NAME' terminal: $cmd"
+                run_in_existing_terminal "$cmd"
+            else
+                echo "No '$TERMINAL_NAME' terminal found. Opening new one first..."
+                open_with_source
+                sleep 1
+                run_in_existing_terminal "$cmd"
+            fi
+            ;;
+    esac
+
+    echo "Done."
+}
+
+main "$@"
+

--- a/web/cypress/CYPRESS_TESTING_GUIDE.md
+++ b/web/cypress/CYPRESS_TESTING_GUIDE.md
@@ -157,21 +157,21 @@ export const runAlertTests = (perspective: string) => {
 cd web/cypress
 
 # Run all regression tests
-npm run cypress:run --spec "cypress/e2e/**/regression/**"
+npm run cypress:run -- --spec "cypress/e2e/**/regression/**"
 
 # Run specific feature regression
-npm run cypress:run --spec "cypress/e2e/monitoring/regression/01.reg_alerts_admin.cy.ts"
-npm run cypress:run --spec "cypress/e2e/monitoring/regression/02.reg_metrics_admin.cy.ts"
-npm run cypress:run --spec "cypress/e2e/monitoring/regression/03.reg_legacy_dashboards_admin.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/regression/01.reg_alerts_admin.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/regression/02.reg_metrics_admin.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/regression/03.reg_legacy_dashboards_admin.cy.ts"
 
 # Run BVT (Build Verification Tests)
-npm run cypress:run --spec "cypress/e2e/monitoring/00.bvt_admin.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/00.bvt_admin.cy.ts"
 
 # Run COO tests
-npm run cypress:run --spec "cypress/e2e/coo/01.coo_bvt.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/coo/01.coo_bvt.cy.ts"
 
 # Run ACM Alerting tests
-npm run cypress:run --spec "cypress/e2e/coo/02.acm_alerting_ui.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/coo/02.acm_alerting_ui.cy.ts"
 
 # Interactive mode (GUI)
 npm run cypress:open

--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -212,22 +212,22 @@ npm run cypress:run
 
 ```bash
 # COO BVT tests
-npm run cypress:run --spec "cypress/e2e/coo/01.coo_bvt.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/coo/01.coo_bvt.cy.ts"
 
 # ACM Alerting tests
-npm run cypress:run --spec "cypress/e2e/coo/02.acm_alerting_ui.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/coo/02.acm_alerting_ui.cy.ts"
 
 # Monitoring BVT tests
-npm run cypress:run --spec "cypress/e2e/monitoring/00.bvt_admin.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/00.bvt_admin.cy.ts"
 
 # All Monitoring Regression tests
-npm run cypress:run --spec "cypress/e2e/monitoring/regression/**"
+npm run cypress:run -- --spec "cypress/e2e/monitoring/regression/**"
 
 # All Virtualization IVT tests
-npm run cypress:run --spec "cypress/e2e/virtualization/**"
+npm run cypress:run -- --spec "cypress/e2e/virtualization/**"
 
 # Incidents tests (requires CYPRESS_TIMEZONE and optionally CYPRESS_MOCK_NEW_METRICS)
-npm run cypress:run --spec "cypress/e2e/**/incidents*.cy.ts"
+npm run cypress:run -- --spec "cypress/e2e/**/incidents*.cy.ts"
 ```
 
 **Note**: Incidents tests require `CYPRESS_TIMEZONE` to be set to match your cluster's timezone configuration. See [Incidents Testing Configuration](#incidents-testing-configuration) for details.

--- a/web/cypress/configure-env.sh
+++ b/web/cypress/configure-env.sh
@@ -295,7 +295,11 @@ main() {
       # User declined current, try to find kubeconfigs from Downloads
       if [[ -d "$HOME/Downloads" ]]; then
         local kubeconfig_files
-        mapfile -t kubeconfig_files < <(ls -t "$HOME/Downloads"/*kubeconfig* 2>/dev/null | head -10)
+        # Use 'while read' instead of 'mapfile' for bash 3.x compatibility (macOS)
+        kubeconfig_files=()
+        while IFS= read -r file; do
+          kubeconfig_files+=("$file")
+        done < <(ls -t "$HOME/Downloads"/*kubeconfig* 2>/dev/null | head -10)
         
         if [[ ${#kubeconfig_files[@]} -gt 0 ]]; then
           echo ""
@@ -357,7 +361,11 @@ main() {
     # No current kubeconfig set, try to find kubeconfigs from Downloads
     if [[ -d "$HOME/Downloads" ]]; then
       local kubeconfig_files
-      mapfile -t kubeconfig_files < <(ls -t "$HOME/Downloads"/*kubeconfig* 2>/dev/null | head -10)
+      # Use 'while read' instead of 'mapfile' for bash 3.x compatibility (macOS)
+      kubeconfig_files=()
+      while IFS= read -r file; do
+        kubeconfig_files+=("$file")
+      done < <(ls -t "$HOME/Downloads"/*kubeconfig* 2>/dev/null | head -10)
       
       if [[ ${#kubeconfig_files[@]} -gt 0 ]]; then
         echo ""
@@ -534,27 +542,27 @@ main() {
 
   echo ""
   echo "Configured values:" 
-  echo "  CYPRESS_BASE_URL=$CYPRESS_BASE_URL"
-  echo "  CYPRESS_LOGIN_IDP=${CYPRESS_LOGIN_IDP:-$login_idp}"
-  echo "  CYPRESS_LOGIN_USERS=${CYPRESS_LOGIN_USERS:-$login_users}"
-  echo "  CYPRESS_KUBECONFIG_PATH=${CYPRESS_KUBECONFIG_PATH:-$kubeconfig}"
-  [[ -n "${CYPRESS_MP_IMAGE-}$mp_image" ]] && echo "  CYPRESS_MP_IMAGE=${CYPRESS_MP_IMAGE:-$mp_image}"
-  [[ -n "${CYPRESS_COO_NAMESPACE-}$coo_namespace" ]] && echo "  CYPRESS_COO_NAMESPACE=${CYPRESS_COO_NAMESPACE:-$coo_namespace}"
-  echo "  CYPRESS_SKIP_COO_INSTALL=${CYPRESS_SKIP_COO_INSTALL:-$skip_coo_install}"
-  echo "  CYPRESS_COO_UI_INSTALL=${CYPRESS_COO_UI_INSTALL:-$coo_ui_install}"
-  [[ -n "${CYPRESS_KONFLUX_COO_BUNDLE_IMAGE-}$konflux_bundle" ]] && echo "  CYPRESS_KONFLUX_COO_BUNDLE_IMAGE=${CYPRESS_KONFLUX_COO_BUNDLE_IMAGE:-$konflux_bundle}"
-  [[ -n "${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}$custom_coo_bundle" ]] && echo "  CYPRESS_CUSTOM_COO_BUNDLE_IMAGE=${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE:-$custom_coo_bundle}"
-  [[ -n "${CYPRESS_MCP_CONSOLE_IMAGE-}$mcp_console_image" ]] && echo "  CYPRESS_MCP_CONSOLE_IMAGE=${CYPRESS_MCP_CONSOLE_IMAGE:-$mcp_console_image}"
-  [[ -n "${CYPRESS_TIMEZONE-}$timezone" ]] && echo "  CYPRESS_TIMEZONE=${CYPRESS_TIMEZONE:-$timezone}"
-  echo "  CYPRESS_MOCK_NEW_METRICS=${CYPRESS_MOCK_NEW_METRICS:-$mock_new_metrics}"
-  echo "  CYPRESS_SESSION=${CYPRESS_SESSION:-$session}"
-  echo "  CYPRESS_DEBUG=${CYPRESS_DEBUG:-$debug}"
-  echo "  CYPRESS_SKIP_ALL_INSTALL=${CYPRESS_SKIP_ALL_INSTALL:-$skip_all_install}"
-  echo "  CYPRESS_SKIP_KBV_INSTALL=${CYPRESS_SKIP_KBV_INSTALL:-$skip_kbv_install}"
-  echo "  CYPRESS_KBV_UI_INSTALL=${CYPRESS_KBV_UI_INSTALL:-$kbv_ui_install}"
-  [[ -n "${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE-}$konflux_kbv_bundle" ]] && echo "  CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE=${CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE:-$konflux_kbv_bundle}"
-  [[ -n "${CYPRESS_CUSTOM_KBV_BUNDLE_IMAGE-}$custom_kbv_bundle" ]] && echo "  CYPRESS_CUSTOM_KBV_BUNDLE_IMAGE=${CYPRESS_CUSTOM_KBV_BUNDLE_IMAGE:-$custom_kbv_bundle}"
-  [[ -n "${CYPRESS_FBC_STAGE_KBV_IMAGE-}$fbc_stage_kbv_image" ]] && echo "  CYPRESS_FBC_STAGE_KBV_IMAGE=${CYPRESS_FBC_STAGE_KBV_IMAGE:-$fbc_stage_kbv_image}"
+  echo "  CYPRESS_BASE_URL=$base_url"
+  echo "  CYPRESS_LOGIN_IDP=$login_idp"
+  echo "  CYPRESS_LOGIN_USERS=$login_users"
+  echo "  CYPRESS_KUBECONFIG_PATH=$kubeconfig"
+  [[ -n "$mp_image" ]] && echo "  CYPRESS_MP_IMAGE=$mp_image"
+  [[ -n "$coo_namespace" ]] && echo "  CYPRESS_COO_NAMESPACE=$coo_namespace"
+  echo "  CYPRESS_SKIP_COO_INSTALL=$skip_coo_install"
+  echo "  CYPRESS_COO_UI_INSTALL=$coo_ui_install"
+  [[ -n "$konflux_bundle" ]] && echo "  CYPRESS_KONFLUX_COO_BUNDLE_IMAGE=$konflux_bundle"
+  [[ -n "$custom_coo_bundle" ]] && echo "  CYPRESS_CUSTOM_COO_BUNDLE_IMAGE=$custom_coo_bundle"
+  [[ -n "$mcp_console_image" ]] && echo "  CYPRESS_MCP_CONSOLE_IMAGE=$mcp_console_image"
+  [[ -n "$timezone" ]] && echo "  CYPRESS_TIMEZONE=$timezone"
+  echo "  CYPRESS_MOCK_NEW_METRICS=$mock_new_metrics"
+  echo "  CYPRESS_SESSION=$session"
+  echo "  CYPRESS_DEBUG=$debug"
+  echo "  CYPRESS_SKIP_ALL_INSTALL=$skip_all_install"
+  echo "  CYPRESS_SKIP_KBV_INSTALL=$skip_kbv_install"
+  echo "  CYPRESS_KBV_UI_INSTALL=$kbv_ui_install"
+  [[ -n "$konflux_kbv_bundle" ]] && echo "  CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE=$konflux_kbv_bundle"
+  [[ -n "$custom_kbv_bundle" ]] && echo "  CYPRESS_CUSTOM_KBV_BUNDLE_IMAGE=$custom_kbv_bundle"
+  [[ -n "$fbc_stage_kbv_image" ]] && echo "  CYPRESS_FBC_STAGE_KBV_IMAGE=$fbc_stage_kbv_image"
 }
 
 main "$@"


### PR DESCRIPTION
Creation of 2 claude slash commands:
`/cypress-setup` and `/cypress-run`

When running `/cypress-setup`, it validates the pre-reqs and opens a new terminal to prepare it with all cypress variables needed, such as base URL, credentials, kubeconfig etc.
Then `/cypress-run` will print to you all available commands for you to choose it and it will run in the terminal previously opened. 

This way, will make claude available to perform other things instead of running and controlling the testing execution. 