### PR TITLE
OBSINTA-853: [Cypress] Operator and Monitoring Plugin Setup Commands Fixes

### DIFF
--- a/web/cypress/support/commands/auth-commands.ts
+++ b/web/cypress/support/commands/auth-commands.ts
@@ -81,6 +81,7 @@ declare global {
   }
 
   Cypress.Commands.add('validateLogin', () => {
+    cy.visit('/');
     cy.wait(2000);
     cy.byTestID("username", {timeout: 120000}).should('be.visible');
     guidedTour.close();


### PR DESCRIPTION
**Add 'cy.visit('/') needed for the correct flow of session reconstruction.**
This targets the case where the tests run locally and session is reloaded, without the redirect the tests did not load any openshift page and the `cy.byTestID("username", {timeout: 120000}).should('be.visible');` condition was failing.

**Fix failure on MCP delete when no resource exists yet.** 
Issue appearing in current [nightly incident job runs.](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-monitoring-plugin-main-periodics-e2e-incidents/1998618942423175168#1:build-log.txt%3A36) (e.g. line 480)

[This CI job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/70614/rehearse-70614-periodic-ci-rhobs-observability-operator-main-amd64-ocp-4.19-gcp-coo-stage/1998741327382056960) executed the tests and the setup was working within the rehearse of release pipeline.