### PR TITLE
OBSINTA-853:  Incident tests CI: Incorrect MP namespace + Race Condition in Closing Guide Tour 

### DIFF
--- a/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
+++ b/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
@@ -17,7 +17,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -22,7 +22,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
+++ b/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
@@ -22,7 +22,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/regression/01.reg_filtering.cy.ts
+++ b/web/cypress/e2e/incidents/regression/01.reg_filtering.cy.ts
@@ -21,7 +21,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/regression/02.reg_ui_charts_comprehensive.cy.ts
+++ b/web/cypress/e2e/incidents/regression/02.reg_ui_charts_comprehensive.cy.ts
@@ -80,7 +80,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
@@ -22,7 +22,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
+++ b/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
@@ -26,7 +26,7 @@ const MCP = {
 };
 
 const MP = {
-  namespace: Cypress.env('COO_NAMESPACE'),
+  namespace: 'openshift-monitoring',
   operatorName: 'Cluster Monitoring Operator',
 };
 

--- a/web/cypress/support/commands/operator-commands.ts
+++ b/web/cypress/support/commands/operator-commands.ts
@@ -206,7 +206,6 @@ const operatorUtils = {
           cy.log(`Monitoring plugin pod is now running in namespace: ${MP.namespace}`);
           cy.reload(true);
         });
-      // });
 
     } else {
       cy.log('MP_IMAGE is NOT set. Skipping patching the image in CMO operator CSV.');

--- a/web/cypress/views/tour.ts
+++ b/web/cypress/views/tour.ts
@@ -25,7 +25,8 @@ export const guidedTour = {
             .should('not.exist')
             .then(() => cy.log('Modal successfully closed'));
         }
-
+        // Prevents navigating away from the page before the tour is closed
+        cy.wait(2000);
       });
     },
 
@@ -35,6 +36,8 @@ export const guidedTour = {
         if ($body.find(`[aria-label="Welcome modal"]`).length > 0) {
           cy.get('[aria-label="Close"]').should('be.visible').click();
         }
+        // Prevents navigating away from the page before the tour is closed
+        cy.wait(2000);
       });
     },
   };


### PR DESCRIPTION
Addressing recent Incident Detection periodics pipeline fails.

The current implementation was using the COO namespace in place of `monitoring-plugin` for incident tests,

Additionally adds wait after the initial welcome pop-up removal to target a race condition when cypress navigated to a new page before popup closing finished, leading to it rerendering again.