### PR TITLE
OU-1081: allow claude-code to build-images

### DIFF
--- a/.claude/commands/build-images.md
+++ b/.claude/commands/build-images.md
@@ -1,0 +1,22 @@
+---
+name: build-images
+description: 
+parameters:
+  - tag: The tag to be placed on the created images. This will typically be a jira ticket in the format of "letters-numbers" (ie. OU-1111).
+allowed-tools: Bash(INTERACTIVE=0 TAG=* make build-image), Bash(INTERACTIVE=0 TAG=* make build-dev-mcp-image), Bash(podman image ls -f "reference=$REGISTRY_ORG/monitoring-plugin*"), Bash(podman image ls -f "reference=$REGISTRY_ORG/monitoring-console-plugin*")
+---
+
+## Context
+
+- Prefer podman when running image related commands over docker.
+- All images that have currently been built for the monitoring plugin: !`podman image ls -f "reference=$REGISTRY_ORG/monitoring-plugin*"`
+- All images that have currently been built for the monitoring console plugin: !`podman image ls -f "reference=$REGISTRY_ORG/monitoring-plugin*"`
+- Scripting used: @Makefile @scripts/build-image.sh
+
+## Your task
+
+Determine an appropriate non-duplicate image tag to use. If the current git branch is a jira issue then you should use that as the base. If the tag is not already used then use it directly. If it has already been used, then add an additional index to the tag and increment one past the highest existing value. For example, if tags [OU-1111, OU-1111-2, and OU-1111-3] already exist then the the non-duplicate tag should be OU-1111-4. Do not attempt to use the same tag and override the previous build.
+
+Run the `make build-image` and `make build-dev-mcp-image` commands with the INTERACTIVE=0 and TAG env variables set.
+
+If the image fails to build, show the error to the user and offer to debug

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -8,16 +8,19 @@ TAG="${TAG:-v1.0.0}"
 REGISTRY_ORG="${REGISTRY_ORG:-openshift-observability-ui}"
 DOCKER_FILE_NAME="${DOCKER_FILE_NAME:-Dockerfile.dev}"
 REPO="${REPO:-monitoring-plugin}"
+INTERACTIVE="${INTERACTIVE:-1}"
 
 # Define ANSI color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 ENDCOLOR='\033[0m'
 
-# Prompt user for TAG
-read -p "$(echo -e "${RED}Enter a value for TAG [${TAG}]: ${ENDCOLOR}")" USER_TAG
-if [ -n "$USER_TAG" ]; then
-    TAG="$USER_TAG"
+if [[ $INTERACTIVE == 1 ]]; then
+    # Prompt user for TAG
+    read -p "$(echo -e "${RED}Enter a value for TAG [${TAG}]: ${ENDCOLOR}")" USER_TAG
+    if [ -n "$USER_TAG" ]; then
+        TAG="$USER_TAG"
+    fi
 fi
 
 if [[ -x "$(command -v podman)" && $PREFER_PODMAN == 1 ]]; then
@@ -41,10 +44,12 @@ echo_vars() {
 }
 echo_vars
 
-# Prompt use it check env vars before proceeding to build
-read -r -p "Are the environmental variables correct [y/N] " response
-if [[ "${response:0:1}" =~ ^([nN])$ ]]; then
-    exit 0
+if [[ $INTERACTIVE == 1 ]]; then
+    # Prompt use it check env vars before proceeding to build
+    read -r -p "Are the environmental variables correct [y/N] " response
+    if [[ "${response:0:1}" =~ ^([nN])$ ]]; then
+        exit 0
+    fi
 fi
 
 # Build


### PR DESCRIPTION
This PR looks to enable claude to build the two images that our repository uses. It takes in a tag value or can check the git branch name to see if a user is working on a jira ticket and use that automatically. It will avoid overriding an existing tag, as often our projects will use the `IfNotPresent` ImagePullPolicy which won't repull an image if the tag is the same.

Since claude code doesn't execute commands in a terminal the `read` api is unavailable so I have added an INTERACTIVE variable to the `build-image.sh` script which will prevent running the interactive parts when it is set to a value other than 1.