### PR TITLE
OBSINTA-853: Cypress Incidents Remove Flaky Tag

### DIFF
--- a/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
@@ -33,7 +33,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Time-Based Alert Resolution (E2E with Firing Alerts)', { tags: ['@incidents', '@slow', '@flaky'] }, () => {
+describe('Regression: Time-Based Alert Resolution (E2E with Firing Alerts)', { tags: ['@incidents', '@slow'] }, () => {
   let currentAlertName: string;
 
   before(() => {

--- a/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
@@ -26,7 +26,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Silences Not Applied Correctly', { tags: ['@incidents', '@flaky'] }, () => {
+describe('Regression: Silences Not Applied Correctly', { tags: ['@incidents'] }, () => {
 
   before(() => {
     cy.beforeBlockCOO(MCP, MP);

--- a/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
+++ b/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
@@ -30,7 +30,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Redux State Management', { tags: ['@incidents', '@incidents-redux', '@flaky'] }, () => {
+describe('Regression: Redux State Management', { tags: ['@incidents', '@incidents-redux'] }, () => {
 
   before(() => {
     cy.beforeBlockCOO(MCP, MP);


### PR DESCRIPTION
Flaky tests appeared to be passing reliable on the presubmit run, so this PR removes the flaky tag to be able to observe their behaviour in the nightly tests.