### PR TITLE
OU-1122: reuse existing handler to set alerts table data

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -131,9 +131,6 @@ const IncidentsPage = () => {
     (state: MonitoringState) => state.plugins.mcp.incidentsData.incidentsActiveFilters,
   );
 
-  const alertsData = useSelector(
-    (state: MonitoringState) => state.plugins.mcp.incidentsData?.alertsData,
-  );
   const alertsAreLoading = useSelector(
     (state: MonitoringState) => state.plugins.mcp.incidentsData?.alertsAreLoading,
   );
@@ -239,15 +236,23 @@ const IncidentsPage = () => {
       )
         .then((results) => {
           const prometheusResults = results.flat();
+          const alerts = convertToAlerts(
+            prometheusResults,
+            incidentForAlertProcessing,
+            currentTime,
+          );
           dispatch(
             setAlertsData({
-              alertsData: convertToAlerts(
-                prometheusResults,
-                incidentForAlertProcessing,
-                currentTime,
-              ),
+              alertsData: alerts,
             }),
           );
+          if (rules && alerts) {
+            dispatch(
+              setAlertsTableData({
+                alertsTableData: groupAlertsForTable(alerts, rules),
+              }),
+            );
+          }
           if (!isEmpty(filteredData)) {
             dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
           } else {
@@ -260,16 +265,6 @@ const IncidentsPage = () => {
         });
     })();
   }, [incidentForAlertProcessing]);
-
-  useEffect(() => {
-    if (rules && alertsData) {
-      dispatch(
-        setAlertsTableData({
-          alertsTableData: groupAlertsForTable(alertsData, rules),
-        }),
-      );
-    }
-  }, [alertsData, rules]);
 
   useEffect(() => {
     if (!isInitialized) return;


### PR DESCRIPTION
This change is not to call `groupAlertsForTable(alerts, rules)` every 15s (because of the polling defined in the `useAlerts` hook), but call it only when user clicks on particular incident. 