### PR TITLE
Testing Only

### DIFF
--- a/web/cypress/e2e/monitoring/00.bvt_admin.cy.ts
+++ b/web/cypress/e2e/monitoring/00.bvt_admin.cy.ts
@@ -1,5 +1,6 @@
 import { nav } from '../../views/nav';
 import { alerts } from '../../fixtures/monitoring/alert';
+import { guidedTour } from '../../views/tour';
 import { runBVTMonitoringTests } from '../../support/monitoring/00.bvt_monitoring.cy';
 import { commonPages } from '../../views/common';
 import { overviewPage } from '../../views/overview-page';
@@ -16,6 +17,9 @@ describe('BVT: Monitoring', { tags: ['@smoke', '@monitoring'] }, () => {
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');
     cy.changeNamespace("All Projects");

--- a/web/cypress/e2e/monitoring/00.bvt_dev.cy.ts
+++ b/web/cypress/e2e/monitoring/00.bvt_dev.cy.ts
@@ -1,7 +1,9 @@
 import { nav } from '../../views/nav';
 import { alerts } from '../../fixtures/monitoring/alert';
+import { guidedTour } from '../../views/tour';
 import { runBVTMonitoringTestsNamespace } from '../../support/monitoring/00.bvt_monitoring_namespace.cy';
 import { commonPages } from '../../views/common';
+import { overviewPage } from '../../views/overview-page';
 // Set constants for the operators that need to be installed for tests.
 const MP = {
   namespace: 'openshift-monitoring',
@@ -15,6 +17,9 @@ describe('BVT: Monitoring - Namespaced', { tags: ['@monitoring-dev', '@smoke-dev
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     alerts.getWatchdogAlert();
     nav.sidenav.clickNavLink(['Observe', 'Alerting']);
     commonPages.titleShouldHaveText('Alerting');

--- a/web/cypress/e2e/monitoring/regression/01.reg_alerts_admin.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/01.reg_alerts_admin.cy.ts
@@ -2,6 +2,7 @@ import { alerts } from '../../../fixtures/monitoring/alert';
 import { runAllRegressionAlertsTests } from '../../../support/monitoring/01.reg_alerts.cy';
 import { commonPages } from '../../../views/common';
 import { nav } from '../../../views/nav';
+import { guidedTour } from '../../../views/tour';
 
 const MP = {
   namespace: 'openshift-monitoring',
@@ -16,6 +17,9 @@ describe('Regression: Monitoring - Alerts (Administrator)', { tags: ['@monitorin
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     alerts.getWatchdogAlert();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');

--- a/web/cypress/e2e/monitoring/regression/01.reg_alerts_dev.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/01.reg_alerts_dev.cy.ts
@@ -2,6 +2,7 @@ import { alerts } from '../../../fixtures/monitoring/alert';
 import { runAllRegressionAlertsTestsNamespace } from '../../../support/monitoring/04.reg_alerts_namespace.cy';
 import { commonPages } from '../../../views/common';
 import { nav } from '../../../views/nav';
+import { guidedTour } from '../../../views/tour';
 
 const MP = {
   namespace: 'openshift-monitoring',
@@ -15,6 +16,9 @@ describe('Regression: Monitoring - Alerts Namespaced (Administrator)', { tags: [
     });
 
     beforeEach(() => {
+      cy.visit('/');
+      guidedTour.close();
+      cy.validateLogin();
       alerts.getWatchdogAlert();
       nav.sidenav.clickNavLink(['Observe', 'Alerting']);
       commonPages.titleShouldHaveText('Alerting');

--- a/web/cypress/e2e/monitoring/regression/02.reg_metrics_admin_1.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/02.reg_metrics_admin_1.cy.ts
@@ -2,6 +2,7 @@ import { runAllRegressionMetricsTests1 } from '../../../support/monitoring/02.re
 import { runAllRegressionMetricsTestsNamespace1 } from '../../../support/monitoring/05.reg_metrics_namespace_1.cy';
 import { commonPages } from '../../../views/common';
 import { nav } from '../../../views/nav';
+import { guidedTour } from '../../../views/tour';
 
 const MP = {
   namespace: 'openshift-monitoring',
@@ -16,6 +17,9 @@ describe('Regression: Monitoring - Metrics (Administrator)', { tags: ['@monitori
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');
     cy.changeNamespace("All Projects");
@@ -36,6 +40,9 @@ describe('Regression: Monitoring - Metrics Namespaced (Administrator)', { tags: 
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');
     cy.changeNamespace(MP.namespace);

--- a/web/cypress/e2e/monitoring/regression/02.reg_metrics_admin_2.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/02.reg_metrics_admin_2.cy.ts
@@ -2,6 +2,7 @@ import { runAllRegressionMetricsTests2 } from '../../../support/monitoring/02.re
 import { runAllRegressionMetricsTestsNamespace2 } from '../../../support/monitoring/05.reg_metrics_namespace_2.cy';
 import { commonPages } from '../../../views/common';
 import { nav } from '../../../views/nav';
+import { guidedTour } from '../../../views/tour';
 
 const MP = {
   namespace: 'openshift-monitoring',
@@ -16,6 +17,9 @@ describe('Regression: Monitoring - Metrics (Administrator)', { tags: ['@monitori
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');
     cy.changeNamespace("All Projects");
@@ -36,6 +40,9 @@ describe('Regression: Monitoring - Metrics Namespaced (Administrator)', { tags: 
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
     commonPages.titleShouldHaveText('Metrics');
     cy.changeNamespace(MP.namespace);

--- a/web/cypress/e2e/monitoring/regression/03.reg_legacy_dashboards_admin.cy.ts
+++ b/web/cypress/e2e/monitoring/regression/03.reg_legacy_dashboards_admin.cy.ts
@@ -2,6 +2,7 @@ import { runAllRegressionLegacyDashboardsTests } from '../../../support/monitori
 import { runAllRegressionLegacyDashboardsTestsNamespace } from '../../../support/monitoring/06.reg_legacy_dashboards_namespace.cy';
 import { commonPages } from '../../../views/common';
 import { nav } from '../../../views/nav';
+import { guidedTour } from '../../../views/tour';
 
 const MP = {
   namespace: 'openshift-monitoring',
@@ -16,6 +17,9 @@ describe('Regression: Monitoring - Legacy Dashboards (Administrator)', { tags: [
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     //when running only this file, beforeBlock changes the namespace to openshift-monitoring
     //so we need to change it back to All Projects before landing to Dashboards page in order to have API Performance dashboard loaded by default
     nav.sidenav.clickNavLink(['Observe', 'Metrics']);
@@ -41,6 +45,9 @@ describe('Regression: Monitoring - Legacy Dashboards Namespaced (Administrator)'
   });
 
   beforeEach(() => {
+    cy.visit('/');
+    guidedTour.close();
+    cy.validateLogin();
     nav.sidenav.clickNavLink(['Observe', 'Dashboards']);
     commonPages.titleShouldHaveText('Dashboards');
     cy.changeNamespace(MP.namespace);

--- a/web/cypress/fixtures/monitoring/constants.ts
+++ b/web/cypress/fixtures/monitoring/constants.ts
@@ -98,7 +98,6 @@ export enum MetricsPagePredefinedQueries {
 export enum MetricsPageQueryInput {
   EXPRESSION_PRESS_SHIFT_ENTER_FOR_NEWLINES = 'Expression (press Shift+Enter for newlines)',
   INSERT_EXAMPLE_QUERY = 'sort_desc(sum(sum_over_time(ALERTS{alertstate="firing"}[24h])) by (alertname))',
-  INSERT_EXAMPLE_QUERY_NAMESPACE = 'sort_desc(sum(sum_over_time(ALERTS{alertstate="firing", namespace="openshift-monitoring"}[24h])) by (alertname))',
   VECTOR_QUERY='vector(1)',
   CPU_USAGE = 'OpenShift_Metrics_QueryTable_sum(node_namespace_pod_container_container_cpu_usage_seconds_total_sum_irate) by (pod).csv',
   MEMORY_USAGE = 'OpenShift_Metrics_QueryTable_sum(container_memory_working_set_bytes{container!=__}) by (pod).csv',

--- a/web/cypress/support/commands/auth-commands.ts
+++ b/web/cypress/support/commands/auth-commands.ts
@@ -81,11 +81,9 @@ declare global {
   }
 
   Cypress.Commands.add('validateLogin', () => {
-    cy.log('validateLogin');
     cy.visit('/');
     cy.wait(2000);
     cy.byTestID("username", {timeout: 120000}).should('be.visible');
-    cy.wait(10000);
     guidedTour.close();
   });
 
@@ -129,7 +127,6 @@ declare global {
       }
     });
     nav.sidenav.switcher.changePerspectiveTo(perspective);
-    cy.validateLogin();
   });
 
   // To avoid influence from upstream login change

--- a/web/cypress/support/commands/utility-commands.ts
+++ b/web/cypress/support/commands/utility-commands.ts
@@ -116,8 +116,6 @@ Cypress.Commands.add('waitUntilWithCustomTimeout', (
 
   Cypress.Commands.add('podImage', (pod: string, namespace: string) => {
     cy.log('Get pod image');
-    cy.switchPerspective('Core platform');
-    cy.wait(5000);
     cy.clickNavLink(['Workloads', 'Pods']);
     cy.changeNamespace(namespace);
     cy.byTestID('page-heading').contains('Pods').should('be.visible');

--- a/web/cypress/support/monitoring/02.reg_metrics_1.cy.ts
+++ b/web/cypress/support/monitoring/02.reg_metrics_1.cy.ts
@@ -193,6 +193,7 @@ export function testMetricsRegression1(perspective: PerspectiveConfig) {
   //https://issues.redhat.com/browse/OU-974 - [Metrics] - Units - undefined showing in Y axis and tooltip
   it(`${perspective.name} perspective - Metrics > Units`, () => {
     cy.log('5.1 Preparation to test Units dropdown');
+    cy.visit('/monitoring/query-browser');
     metricsPage.clickInsertExampleQuery();
     metricsPage.unitsDropdownAssertion();
 

--- a/web/cypress/support/monitoring/02.reg_metrics_2.cy.ts
+++ b/web/cypress/support/monitoring/02.reg_metrics_2.cy.ts
@@ -15,7 +15,6 @@ export function testMetricsRegression2(perspective: PerspectiveConfig) {
 
   it(`${perspective.name} perspective - Metrics > Add Query - Run Queries - Kebab icon`, () => {
     cy.log('6.1 Preparation to test Add Query button');
-    metricsPage.clickActionsDeleteAllQueries();
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).should('have.length', 1);
     metricsPage.clickInsertExampleQuery();
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);

--- a/web/cypress/support/monitoring/05.reg_metrics_namespace_1.cy.ts
+++ b/web/cypress/support/monitoring/05.reg_metrics_namespace_1.cy.ts
@@ -132,7 +132,7 @@ export function testMetricsRegressionNamespace1(perspective: PerspectiveConfig) 
     cy.log('4.1 Insert Example Query');
     metricsPage.clickInsertExampleQuery();
     metricsPage.shouldBeLoadedWithGraph();
-    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     metricsPage.graphAxisXAssertion(GraphTimespan.THIRTY_MINUTES);
 
     cy.log('4.2 Graph Timespan Dropdown');
@@ -193,6 +193,7 @@ export function testMetricsRegressionNamespace1(perspective: PerspectiveConfig) 
   //https://issues.redhat.com/browse/OU-974 - [Metrics] - Units - undefined showing in Y axis and tooltip
   it(`${perspective.name} perspective - Metrics > Units`, () => {
     cy.log('5.1 Preparation to test Units dropdown');
+    cy.visit('/monitoring/query-browser');
     metricsPage.clickInsertExampleQuery();
     metricsPage.unitsDropdownAssertion();
 

--- a/web/cypress/support/monitoring/05.reg_metrics_namespace_2.cy.ts
+++ b/web/cypress/support/monitoring/05.reg_metrics_namespace_2.cy.ts
@@ -18,7 +18,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     metricsPage.shouldBeLoaded();
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).should('have.length', 1);
     metricsPage.clickInsertExampleQuery();
-    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
 
     cy.log('6.2 Only one query added, resulting in 2 rows');
     metricsPage.clickActionsAddQuery();
@@ -26,7 +26,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).find('button').eq(0).should('have.attr', 'aria-expanded', 'true');
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).find('button').eq(1).should('have.attr', 'aria-expanded', 'true');
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.EXPRESSION_PRESS_SHIFT_ENTER_FOR_NEWLINES);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
  
     cy.log('6.3 Preparation to test Run Queries button');
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('be.visible').clear();
@@ -51,7 +51,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     metricsPage.expandCollapseRowAssertion(false, 0, true, true);
     metricsPage.expandCollapseRowAssertion(true, 1, true, true);
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.VECTOR_QUERY);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricGraph).scrollIntoView().should('be.visible');
     metricsPage.clickKebabDropdown(0);
     cy.get(Classes.MenuItemDisabled).contains(MetricsPageQueryKebabDropdown.HIDE_ALL_SERIES).should('be.visible');
@@ -64,7 +64,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     metricsPage.expandCollapseRowAssertion(true, 0, true, true);
     metricsPage.expandCollapseRowAssertion(true, 1, true, true);
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.VECTOR_QUERY);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricGraph).scrollIntoView().should('be.visible');
     metricsPage.clickKebabDropdown(0);
     cy.byTestID(DataTestIDs.MetricsPageHideShowAllSeriesDropdownItem).contains(MetricsPageQueryKebabDropdown.HIDE_ALL_SERIES).should('be.visible');
@@ -90,7 +90,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     cy.byTestID(DataTestIDs.MetricsPageExportCsvDropdownItem).should('not.exist');
     metricsPage.clickKebabDropdown(1);
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.VECTOR_QUERY);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricGraph).should('not.exist');
     cy.byTestID(DataTestIDs.MetricsPageNoQueryEnteredTitle).should('be.visible');
     cy.byTestID(DataTestIDs.MetricsPageNoQueryEntered).should('be.visible');
@@ -115,7 +115,7 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     cy.byTestID(DataTestIDs.MetricsPageExportCsvDropdownItem).contains(MetricsPageQueryKebabDropdown.EXPORT_AS_CSV).should('be.visible');
     metricsPage.clickKebabDropdown(1);
     cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.VECTOR_QUERY);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricGraph).scrollIntoView().should('be.visible');
 
     cy.log('6.10 Kebab icon - Hide all series');
@@ -188,14 +188,14 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     cy.byTestID(DataTestIDs.MetricsPageDeleteQueryDropdownItem).contains(MetricsPageQueryKebabDropdown.DELETE_QUERY).should('be.visible').click();
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).should('have.length', 1);
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).find('button').eq(0).should('have.attr', 'aria-expanded', 'true');
-    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricsPageSelectAllUnselectAllButton).should('have.length', 1);
 
     cy.log('6.17 Kebab icon - Duplicate query');
     metricsPage.clickKebabDropdown(0);
     cy.byTestID(DataTestIDs.MetricsPageDuplicateQueryDropdownItem).contains(MetricsPageQueryKebabDropdown.DUPLICATE_QUERY).should('be.visible').click();
-    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
-    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY_NAMESPACE);
+    cy.get(Classes.MetricsPageQueryInput).eq(0).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
+    cy.get(Classes.MetricsPageQueryInput).eq(1).should('contain', MetricsPageQueryInput.INSERT_EXAMPLE_QUERY);
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).should('have.length', 2);
     metricsPage.expandCollapseRowAssertion(true, 1, true, true);
     cy.byTestID(DataTestIDs.MetricsPageExpandCollapseRowButton).find('button').eq(0).should('have.attr', 'aria-expanded', 'true');
@@ -284,7 +284,8 @@ export function testMetricsRegressionNamespace2(perspective: PerspectiveConfig) 
     cy.byOUIAID(DataTestIDs.MetricsGraphAlertDanger).should('be.visible');
   });
 
-  it(`${perspective.name} perspective - Metrics > Empty state`, () => {
+  //TODO remove skip when OU-1118 get answered/fixed
+  it.skip(`${perspective.name} perspective - Metrics > Empty state`, () => {
     cy.log('11.1 Insert example query - Empty state');
     cy.changeNamespace("default");
     metricsPage.clickInsertExampleQuery();

--- a/web/cypress/support/monitoring/06.reg_legacy_dashboards_namespace.cy.ts
+++ b/web/cypress/support/monitoring/06.reg_legacy_dashboards_namespace.cy.ts
@@ -1,13 +1,12 @@
 import { nav } from '../../views/nav';
 import { legacyDashboardsPage } from '../../views/legacy-dashboards';
-import { KUBERNETES_COMPUTE_RESOURCES_NAMESPACE_PODS_PANELS, LegacyDashboardsDashboardDropdownNamespace, MetricsPageQueryInputByNamespace, WatchdogAlert } from '../../fixtures/monitoring/constants';
+import { KUBERNETES_COMPUTE_RESOURCES_NAMESPACE_PODS_PANELS, LegacyDashboardsDashboardDropdownNamespace, MetricsPageQueryInput, MetricsPageQueryInputByNamespace, WatchdogAlert } from '../../fixtures/monitoring/constants';
 import { Classes, LegacyDashboardPageTestIDs, DataTestIDs } from '../../../src/components/data-test';
 import { metricsPage } from '../../views/metrics';
 import { alertingRuleDetailsPage } from '../../views/alerting-rule-details-page';
 import { alerts } from '../../fixtures/monitoring/alert';
 import { listPage } from '../../views/list-page';
 import { commonPages } from '../../views/common';
-import { guidedTour } from '../../views/tour';
 
 export interface PerspectiveConfig {
   name: string;
@@ -54,7 +53,6 @@ export function testLegacyDashboardsRegressionNamespace(perspective: Perspective
 
     cy.log('2.2 Empty state');
     cy.changeNamespace('default');
-    legacyDashboardsPage.shouldBeLoaded();
     cy.byTestID(DataTestIDs.MetricGraphNoDatapointsFound).eq(0).scrollIntoView().should('be.visible');
     legacyDashboardsPage.clickKebabDropdown(0);
     cy.byTestID(LegacyDashboardPageTestIDs.ExportAsCsv).should('be.visible');
@@ -64,13 +62,6 @@ export function testLegacyDashboardsRegressionNamespace(perspective: Perspective
 
   it(`${perspective.name} perspective - Dashboards (legacy) - No kebab dropdown`, () => {
     cy.log('3.1 Single Stat - No kebab dropdown');
-    cy.visit('/');
-    guidedTour.close();
-    cy.validateLogin();
-    nav.sidenav.clickNavLink(['Observe', 'Dashboards']);
-    commonPages.titleShouldHaveText('Dashboards');
-    cy.changeNamespace('openshift-monitoring');
-    legacyDashboardsPage.shouldBeLoaded();
     cy.byLegacyTestID('chart-1').find('[data-test="'+DataTestIDs.KebabDropdownButton+'"]').should('not.exist');
 
     cy.log('3.2 Table - No kebab dropdown');

--- a/web/cypress/views/common.ts
+++ b/web/cypress/views/common.ts
@@ -7,7 +7,7 @@ export const commonPages = {
   projectDropdownShouldExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('exist'),
   titleShouldHaveText: (title: string) => {
     cy.log('commonPages.titleShouldHaveText - ' + `${title}`);
-    cy.bySemanticElement('h1', title).scrollIntoView().should('be.visible');
+    cy.bySemanticElement('h1', title).should('be.visible');
   },
 
   linkShouldExist: (linkName: string) => {

--- a/web/cypress/views/legacy-dashboards.ts
+++ b/web/cypress/views/legacy-dashboards.ts
@@ -10,14 +10,14 @@ export const legacyDashboardsPage = {
     commonPages.titleShouldHaveText(MonitoringPageTitles.DASHBOARDS);
     cy.byTestID(LegacyDashboardPageTestIDs.TimeRangeDropdown).contains(LegacyDashboardsTimeRange.LAST_30_MINUTES).should('be.visible');
     cy.byTestID(LegacyDashboardPageTestIDs.PollIntervalDropdown).contains(MonitoringRefreshInterval.THIRTY_SECONDS).should('be.visible');
-    
-    cy.byLegacyTestID('namespace-bar-dropdown').find('span').invoke('text').then((text) => {
-      if (text === 'Project: All Projects') {
-        cy.byTestID(LegacyDashboardPageTestIDs.DashboardDropdown).find('input').should('have.value', LegacyDashboardsDashboardDropdown.API_PERFORMANCE[0]).and('be.visible');
-      } else {
-        cy.byTestID(LegacyDashboardPageTestIDs.DashboardDropdown).find('input').should('have.value', LegacyDashboardsDashboardDropdownNamespace.K8S_COMPUTE_RESOURCES_NAMESPACE_PODS[0]).and('be.visible');
-      }
-    });
+    //TODO: Uncomment when OU-949 gets merged
+    // cy.byLegacyTestID('namespace-bar-dropdown').find('span').invoke('text').then((text) => {
+    //   if (text === 'Project: All Projects') {
+    //     cy.byTestID(LegacyDashboardPageTestIDs.DashboardDropdown).find('input').should('have.value', LegacyDashboardsDashboardDropdown.API_PERFORMANCE[0]).and('be.visible');
+    //   } else {
+    //     cy.byTestID(LegacyDashboardPageTestIDs.DashboardDropdown).find('input').should('have.value', LegacyDashboardsDashboardDropdownNamespace.K8S_COMPUTE_RESOURCES_NAMESPACE_PODS[0]).and('be.visible');
+    //   }
+    // });
   },
 
   clickTimeRangeDropdown: (timeRange: LegacyDashboardsTimeRange) => {

--- a/web/cypress/views/metrics.ts
+++ b/web/cypress/views/metrics.ts
@@ -361,7 +361,7 @@ export const metricsPage = {
   graphCardInlineInfoAssertion: (visible: boolean) => {
     cy.log('metricsPage.graphCardInlineInfoAssertion');
     if (visible) {
-      cy.get(Classes.GraphCardInlineInfo).scrollIntoView().should('be.visible');
+      cy.get(Classes.GraphCardInlineInfo).should('be.visible');
     } else {
       cy.get(Classes.GraphCardInlineInfo).should('not.exist');
     }

--- a/web/cypress/views/nav.ts
+++ b/web/cypress/views/nav.ts
@@ -7,15 +7,11 @@ export const nav = {
     },
     switcher: {
       changePerspectiveTo: (perspective: string) => {
-        cy.get('body').then((body) => {
-          if (body.find('#perspective-switcher-toggle').length > 0) {
-            cy.log('Switch perspective - ' + `${perspective}`);
-            cy.byLegacyTestID('perspective-switcher-toggle').scrollIntoView().should('be.visible').click({force: true});
-            cy.byLegacyTestID('perspective-switcher-menu-option').contains(perspective).should('be.visible');
-            cy.byLegacyTestID('perspective-switcher-menu-option').contains(perspective).should('be.visible').click({force: true});
-          }
-        });
-
+      cy.log('Switch perspective - ' + `${perspective}`);
+      cy.byLegacyTestID('perspective-switcher-toggle').scrollIntoView().should('be.visible');
+      cy.byLegacyTestID('perspective-switcher-toggle').scrollIntoView().should('be.visible').click({force: true});
+      cy.byLegacyTestID('perspective-switcher-menu-option').contains(perspective).should('be.visible');
+      cy.byLegacyTestID('perspective-switcher-menu-option').contains(perspective).should('be.visible').click({force: true});
       },
       shouldHaveText: (perspective: string) => {
         cy.log('Should have text - ' + `${perspective}`);

--- a/web/cypress/views/tour.ts
+++ b/web/cypress/views/tour.ts
@@ -1,36 +1,13 @@
 export const guidedTour = {
     close: () => {
-      const modalSelector = 'button[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]'
-      cy.log('close guided tour');
       cy.get('body').then(($body) => {
-        //Core platform modal
         if ($body.find(`[data-test="guided-tour-modal"]`).length > 0) {
-          cy.log('Core platform modal detected, attempting to close...');
           cy.byTestID('tour-step-footer-secondary').contains('Skip tour').click();
-        } 
-        //Kubevirt modal
-        else if ($body.find(`[aria-label="Welcome modal"]`).length > 0) {
-          cy.log('Kubevirt modal detected, attempting to close...');
-          cy.get('[aria-label="Close"]').should('be.visible').click();
-        } 
-        //ACM Onboarding modal
-        else if ($body.find(modalSelector).length > 0) {
-          cy.log('Onboarding modal detected, attempting to close...');
-          cy.get(modalSelector, { timeout: 20000 })
-            .should('be.visible')
-            .should('not.be.disabled')
-            .click({ force: true });
-    
-          cy.get(modalSelector, { timeout: 10000 })
-            .should('not.exist')
-            .then(() => cy.log('Modal successfully closed'));
         }
-
       });
     },
 
     closeKubevirtTour: () => {
-      cy.log('close Kubevirt tour');
       cy.get('body').then(($body) => {
         if ($body.find(`[aria-label="Welcome modal"]`).length > 0) {
           cy.get('[aria-label="Close"]').should('be.visible').click();


### PR DESCRIPTION
Reverts openshift/monitoring-plugin#687

We are looking for the source of failures in OCP conformance testing.  I doubt this is it but 

https://github.com/openshift/monitoring-plugin/pull/684 is in https://amd64.ocp.releases.ci.openshift.org/releasestream/4.21.0-0.nightly/release/4.21.0-0.nightly-2025-12-18-020818 where we see the issue and https://github.com/openshift/monitoring-plugin/pull/687 has come into https://amd64.ocp.releases.ci.openshift.org/releasestream/4.21.0-0.nightly/release/4.21.0-0.nightly-2025-12-18-020818

Can't easily test the https://github.com/openshift/monitoring-plugin/pull/684 due to conflicts so testing in 4.21.

Will close once we verify the issue still exits