### PR TITLE
OU-1040: docs(tests) [Incidents] Add test case documentation 

### DIFF
--- a/docs/incident_detection/tests/2.ui_display_flows.md
+++ b/docs/incident_detection/tests/2.ui_display_flows.md
@@ -109,6 +109,74 @@ start,end,alertname,namespace,severity,silenced,labels
   - Check the "last updated date" field
   - Verify that the format changes without the need to reload the page
 
+### 2.3.2 Incident Bar Trimming on Time Filter Change
+**BUG**: When "Last N Days" is shorter than an incident's duration, the bar should be visually trimmed to show only the portion within the selected time window.  
+**Automation Status**: NOT AUTOMATED
+
+**Background**:
+- Incorrect behavior: Changing time filter "squashes" the X-axis to the right while still showing the full incident bar
+- Correct behavior: Incident bar is trimmed/clipped to only display the portion that falls within the selected time range
+
+- [ ] **Bar Trimming - Long Incident with Short Filter**: Create an incident spanning 15 days
+  - With "Last 15 days": Full incident bar visible with correct proportional width
+  - Set time filter to "Last 7 days"
+  - Verify the incident bar is trimmed to show only the 7-day portion (not the full 15-day bar)
+  - Verify the X-axis scale matches the 7-day window (not squashed to the right)
+  - Verify the bar starts at the left edge of the chart (since incident started before the 7-day window)
+
+- [ ] **Tooltip Accuracy After Trimming**: Hover over a trimmed incident bar
+  - Verify tooltip shows the actual absolute Start date (which may be before the visible window)
+  - Verify tooltip shows correct End date
+  - Verify the displayed duration reflects the full incident, not just the visible portion
+
+### 2.3.3 Mixed Severity Interval Boundary Times
+**Automation Status**: NOT AUTOMATED
+
+This section covers two related time display bugs in multi-severity incident tooltips.
+
+#### Issue 1: Boundary End Times Not Rounded (OU-1205)
+**BUG**: Consecutive interval end times within the same incident bar are not 5-minute rounded in tooltips.
+
+**Background**:
+- The interval calculation logic in `utils.ts` uses 1-second offsets to prevent overlapping intervals
+- Example: If timestamps are at 100, 200, 300 seconds, intervals are calculated as:
+  - Interval 1: [100, 199, 'critical']
+  - Interval 2: [200, 299, 'warning']
+- This results in end times like "23:29:59" instead of the expected rounded "23:30"
+- The fix should round the displayed tooltip text, not change the interval calculation logic
+
+- [ ] **End Times Should Be 5-Minute Rounded**: Use AlertC from test data (multi-severity incident)
+  - Hover over each severity segment within the incident bar
+  - Verify End time in tooltip shows rounded value (e.g., "23:30") not unrounded (e.g., "23:29:59")
+  - Verify all interval boundaries display at 5-minute precision in tooltips
+
+#### Issue 2: Start Times 5 Minutes Off (OU-1221)
+**BUG**: Multi-severity incident bar tooltip start times are 5 minutes off from the values shown in alert tooltips and alerts table.
+
+**Background**:
+- When hovering over a severity segment in an incident bar, the Start time shown differs from:
+  - The Start time shown in the corresponding alert tooltip
+  - The Start time shown in the alerts details table
+- This creates user confusion as the same data point shows different times in different UI elements
+
+- [ ] **Start Times Match Alert Tooltip**: Use AlertC from test data
+  - Click incident to open alerts chart
+  - Hover over an alert bar: Note the Start time in alert tooltip
+  - Hover over the corresponding severity segment in the incident bar
+  - Verify incident tooltip Start time matches alert tooltip Start time exactly
+
+- [ ] **Start Times Match Alerts Table**: 
+  - With incident selected, check alerts table Start column
+  - Hover over the corresponding severity segment in incident bar
+  - Verify incident tooltip Start time matches alerts table Start time exactly
+
+- [ ] **Consecutive Interval Boundaries Match**: Check multi-severity incident
+  - Hover over first severity segment: Note the End time
+  - Hover over next severity segment: Note the Start time
+  - Verify End time of previous segment matches Start time of next segment (no 5-minute gap)
+  - Example failure: Info ends at "10:15" but Warning starts at "10:20"
+  - Expected: Info ends at "10:15" and Warning starts at "10:15"
+
 ### 2.4 Silences labels (Not Automated)
 - Verify that information about silences is contained in the alert name 
   as `NetworkLatencyHigh (silenced)` instead of the additional `silenced=true`

--- a/docs/incident_detection/tests/3.api_calls_data_loading_flows.md
+++ b/docs/incident_detection/tests/3.api_calls_data_loading_flows.md
@@ -84,8 +84,41 @@ start,end,alertname,namespace,severity,silenced,labels
   - Verify the latest query end time param is within the last 5 minutes
 
 
-  ### 3.4 Data Integrity
-  **NEW, NOT AUTOMATED, TODO COO 1.4**
+### 3.4 15-Day Data Loading with "Last N Days" Filtering
+**FEATURE**: UI always loads 15 days of data (one query_range call per day), then filters client-side based on "Last N Days" selection.  
+**Automation Status**: NOT AUTOMATED
+
+**Background**:
+- Before: Data was downloaded only for "Last N Days", causing Start dates to be relative to N days
+- After: Start displays an absolute date, even when "Last N Days" is shorter than the incident's actual start
+- Limit: Start is capped at max 15 days (the maximum supported range)
+
+**Fix Implementation**:
+The absolute start date of an incident/alert is always displayed, regardless of the selected "Last N Days" filter.
+
+Solution uses a new API call:
+- Absolute timestamps are retrieved by performing an **instant query** call to Prometheus
+- For incidents: `min_over_time(timestamp(cluster_health_components_map{}))`
+- For alerts: `min_over_time(timestamp(ALERTS{}))`
+- This returns the timestamp of the first datapoint for that metric
+- The result is saved into Redux store and matched to related incident/alert to update the Start date displayed in the tooltip
+
+**Manual Testing Data**:
+Use `docs/incident_detection/simulate_scenarios/long-incident-15-days.csv` which creates a 15-day spanning incident for testing absolute start date display.
+
+- [ ] **Absolute Start Date Display**: Use `long-incident-15-days.csv` (creates 15-day incident)
+  - Set time filter to "Last 7 days"
+  - Verify incident Start date shows the absolute date (15 days ago), NOT a date relative to 7 days
+  - Verify the incident bar in the chart is trimmed to show only the portion within the 7-day window
+  - Verify tooltip shows the actual absolute start time
+
+- [ ] **API Call Pattern Verification**: Monitor network requests on initial page load
+  - Verify 15 query_range calls are made on initial page load (one per day)
+  - Verify instant query calls for `min_over_time(timestamp(cluster_health_components_map{}))` and `min_over_time(timestamp(ALERTS{}))`
+  - Verify the time ranges cover the full 15-day window regardless of "Last N Days" selection
+
+### 3.5 Data Integrity
+**NEW, NOT AUTOMATED, TODO COO 1.4**
 - [ ] Incident grouping by `group_id` works correctly
 - [ ] Values deduplicated across multiple time range queries
 - [ ] Component lists combined for same group_id


### PR DESCRIPTION
    docs(tests): add test cases for incident loading and related tooltip time display issues
    
    - Add test case for boundary end times not rounded to 5 minutes (OU-1205)
      Interval calculation uses 1-second offsets causing unrounded times like
      "23:29:59" instead of "23:30" in multi-severity incident tooltips
    
    - Add test case for start times mismatch between UI elements (OU-1221)
      Multi-severity incident tooltip start times are 5 minutes off from
      alert tooltip and alerts table values
    
    - Document absolute start date fix implementation using new API call
      (OU-1040)
      Uses min_over_time(timestamp()) instant queries to retrieve actual
      start timestamps regardless of "Last N Days" filter selection