### PR TITLE
OBSINTA-1062: custom cluster-health-analyzer builds

### DIFF
--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -75,6 +75,7 @@ Creates `export-env.sh` that you can source later: `source export-env.sh`
 |----------|-------------|----------|
 | `CYPRESS_MP_IMAGE` | Custom Monitoring Plugin image | Testing custom MP builds |
 | `CYPRESS_MCP_CONSOLE_IMAGE` | Custom Monitoring Console Plugin image | Testing custom MCP builds |
+| `CYPRESS_CHA_IMAGE` | Custom cluster-health-analyzer image | Testing custom CHA builds |
 
 ### Operator Installation Control
 
@@ -160,7 +161,25 @@ export CYPRESS_MP_IMAGE=quay.io/myorg/monitoring-plugin:my-branch
 export CYPRESS_MCP_CONSOLE_IMAGE=quay.io/myorg/monitoring-console-plugin:my-branch
 ```
 
-### Example 4: Pre-Provisioned Cluster (Skip Installations)
+### Example 4: Testing Custom cluster-health-analyzer Build
+
+For CI jobs testing PRs to cluster-health-analyzer:
+
+```bash
+# Required variables
+export CYPRESS_BASE_URL=https://...
+export CYPRESS_LOGIN_IDP=flexy-htpasswd-provider
+export CYPRESS_LOGIN_USERS=username:password
+export CYPRESS_KUBECONFIG_PATH=~/Downloads/kubeconfig
+
+# Custom cluster-health-analyzer image built from PR
+export CYPRESS_CHA_IMAGE=quay.io/myorg/cluster-health-analyzer:pr-123
+
+# Use COO bundle (required for incidents feature testing)
+export CYPRESS_KONFLUX_COO_BUNDLE_IMAGE=quay.io/rhobs/observability-operator-bundle:latest
+```
+
+### Example 5: Pre-Provisioned Cluster (Skip Installations)
 
 ```bash
 # Required variables
@@ -173,14 +192,14 @@ export CYPRESS_KUBECONFIG_PATH=~/Downloads/kubeconfig
 export CYPRESS_SKIP_ALL_INSTALL=true
 ```
 
-### Example 5: Configurable COO Namespace
+### Example 6: Configurable COO Namespace
 
 Set the following var to specify the Cluster Observability Operator namespace. Defaults to `openshift-cluster-observability-operator` if not set. This is useful when testing with different namespace configurations (e.g., using `coo` instead of the default).
 ```bash
 export CYPRESS_COO_NAMESPACE=openshift-cluster-observability-operator
 ```
 
-### Example 6: Debug Mode
+### Example 7: Debug Mode
 
 ```bash
 # Required variables + debug

--- a/web/cypress/configure-env.sh
+++ b/web/cypress/configure-env.sh
@@ -175,6 +175,7 @@ print_current_config() {
   print_var "CYPRESS_KONFLUX_COO_BUNDLE_IMAGE" "${CYPRESS_KONFLUX_COO_BUNDLE_IMAGE-}"
   print_var "CYPRESS_CUSTOM_COO_BUNDLE_IMAGE" "${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}"
   print_var "CYPRESS_MCP_CONSOLE_IMAGE" "${CYPRESS_MCP_CONSOLE_IMAGE-}"
+  print_var "CYPRESS_CHA_IMAGE" "${CYPRESS_CHA_IMAGE-}"
   print_var "CYPRESS_TIMEZONE" "${CYPRESS_TIMEZONE-}"
   print_var "CYPRESS_MOCK_NEW_METRICS" "${CYPRESS_MOCK_NEW_METRICS-}"
   print_var "CYPRESS_SESSION" "${CYPRESS_SESSION-}"
@@ -226,6 +227,7 @@ main() {
   local def_konflux_bundle=${CYPRESS_KONFLUX_COO_BUNDLE_IMAGE-}
   local def_custom_coo_bundle=${CYPRESS_CUSTOM_COO_BUNDLE_IMAGE-}
   local def_mcp_console_image=${CYPRESS_MCP_CONSOLE_IMAGE-}
+  local def_cha_image=${CYPRESS_CHA_IMAGE-}
   local def_timezone=${CYPRESS_TIMEZONE-}
   local def_mock_new_metrics=${CYPRESS_MOCK_NEW_METRICS-}
   local def_session=${CYPRESS_SESSION-}
@@ -434,6 +436,9 @@ main() {
   local mcp_console_image
   mcp_console_image=$(ask "Monitoring Console Plugin UI image (CYPRESS_MCP_CONSOLE_IMAGE)" "$def_mcp_console_image")
 
+  local cha_image
+  cha_image=$(ask "Cluster Health Analyzer image (CYPRESS_CHA_IMAGE)" "$def_cha_image")
+
   local timezone
   timezone=$(ask "Cluster timezone (CYPRESS_TIMEZONE)" "${def_timezone:-UTC}")
 
@@ -500,6 +505,9 @@ main() {
   if [[ -n "$mcp_console_image" ]]; then
     export_lines+=("export CYPRESS_MCP_CONSOLE_IMAGE='$(printf %s "$mcp_console_image" | escape_for_single_quotes)'" )
   fi
+  if [[ -n "$cha_image" ]]; then
+    export_lines+=("export CYPRESS_CHA_IMAGE='$(printf %s "$cha_image" | escape_for_single_quotes)'" )
+  fi
   if [[ -n "$timezone" ]]; then
     export_lines+=("export CYPRESS_TIMEZONE='$(printf %s "$timezone" | escape_for_single_quotes)'" )
   fi
@@ -553,6 +561,7 @@ main() {
   [[ -n "$konflux_bundle" ]] && echo "  CYPRESS_KONFLUX_COO_BUNDLE_IMAGE=$konflux_bundle"
   [[ -n "$custom_coo_bundle" ]] && echo "  CYPRESS_CUSTOM_COO_BUNDLE_IMAGE=$custom_coo_bundle"
   [[ -n "$mcp_console_image" ]] && echo "  CYPRESS_MCP_CONSOLE_IMAGE=$mcp_console_image"
+  [[ -n "$cha_image" ]] && echo "  CYPRESS_CHA_IMAGE=$cha_image"
   [[ -n "$timezone" ]] && echo "  CYPRESS_TIMEZONE=$timezone"
   echo "  CYPRESS_MOCK_NEW_METRICS=$mock_new_metrics"
   echo "  CYPRESS_SESSION=$session"

--- a/web/cypress/fixtures/coo/update-cha-image.sh
+++ b/web/cypress/fixtures/coo/update-cha-image.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Script to patch the cluster-health-analyzer image in COO CSV
+# Used by Cypress tests to test custom CHA builds
+
+echo "--------------------------------"
+echo "CHA_IMAGE: ${CHA_IMAGE}"
+echo "--------------------------------"
+
+# Generate a random filename
+RANDOM_FILE="/tmp/coo_cha_csv_$(date +%s%N).yaml"
+
+COO_CSV_NAME=$(oc get csv --kubeconfig "${KUBECONFIG}" --namespace="${MCP_NAMESPACE}" | grep "cluster-observability-operator" | awk '{print $1}')
+
+if [ -z "${COO_CSV_NAME}" ]; then
+    echo "Error: Could not find cluster-observability-operator CSV in namespace ${MCP_NAMESPACE}"
+    exit 1
+fi
+
+echo "Found COO CSV: ${COO_CSV_NAME}"
+
+oc get csv "${COO_CSV_NAME}" -n "${MCP_NAMESPACE}" -o yaml > "${RANDOM_FILE}" --kubeconfig "${KUBECONFIG}"
+
+# Patch the CSV file env vars for cluster-health-analyzer
+# Handle both US and UK spellings (analyser/analyzer) for compatibility
+sed -i "s#value: .*cluster-health-analy[sz]er.*#value: ${CHA_IMAGE}#g" "${RANDOM_FILE}"
+
+# Patch the CSV file related images
+sed -i "s#^\([[:space:]]*- image:\).*cluster-health-analy[sz]er.*#\1 ${CHA_IMAGE}#g" "${RANDOM_FILE}"
+
+# Apply the patched CSV resource file
+oc replace -f "${RANDOM_FILE}" --kubeconfig "${KUBECONFIG}"
+
+# Wait for the operator to reconcile the change
+sleep 25
+
+# Wait for health-analyzer pod to be ready with the new image
+OUTPUT=$(oc wait --for=condition=ready pods -l app.kubernetes.io/instance=health-analyzer -n "${MCP_NAMESPACE}" --timeout=120s --kubeconfig "${KUBECONFIG}")
+echo "${OUTPUT}"
+
+echo "--------------------------------"
+echo "Health-analyzer pod status:"
+echo "--------------------------------"
+oc get pods -l app.kubernetes.io/instance=health-analyzer -n "${MCP_NAMESPACE}" -o wide --kubeconfig "${KUBECONFIG}"
+echo "--------------------------------"
+

--- a/web/cypress/fixtures/export.sh
+++ b/web/cypress/fixtures/export.sh
@@ -36,6 +36,9 @@ export CYPRESS_FBC_STAGE_COO_IMAGE=<COO FBC image>
 # Set the following var to use custom Monitoring Console Plugin UI plugin image. The image will be patched in Cluster Observability Operator CSV.
 export CYPRESS_MCP_CONSOLE_IMAGE=<Monitoring Console Plugin image>
 
+# Set the following var to use custom cluster-health-analyzer image. The image will be patched in Cluster Observability Operator CSV.
+export CYPRESS_CHA_IMAGE=<cluster-health-analyzer image>
+
 # Set the following var to specify the cluster timezone for incident timeline calculations. Defaults to UTC if not specified.
 export CYPRESS_TIMEZONE=<timezone>
 


### PR DESCRIPTION
Add support for patching custom cluster-health-analyzer images in COO CSV, enabling CI jobs on cluster-health-analyzer PRs to run the monitoring-plugin test suite against custom builds.

- Add update-cha-image.sh script to patch CHA image in COO CSV
- Refactor setupMonitoringConsolePlugin into generic patchCOOCSVImage function
- Add CHA_IMAGE to session key for proper cache invalidation
- Update configure-env.sh with interactive CHA_IMAGE configuration
- Document CYPRESS_CHA_IMAGE usage in README.md