### PR TITLE
OBSINTA-1063: Add incidents e2e command

### DIFF
--- a/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
+++ b/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
@@ -21,7 +21,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('BVT: Incidents - e2e', { tags: ['@smoke', '@slow', '@incidents'] }, () => {
+describe('BVT: Incidents - e2e', { tags: ['@smoke', '@slow', '@incidents', '@e2e-real'] }, () => {
   let currentAlertName: string;
 
   before(() => {

--- a/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
@@ -33,7 +33,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Time-Based Alert Resolution (E2E with Firing Alerts)', { tags: ['@incidents', '@slow'] }, () => {
+describe('Regression: Time-Based Alert Resolution (E2E with Firing Alerts)', { tags: ['@incidents', '@slow', '@e2e-real'] }, () => {
   let currentAlertName: string;
 
   before(() => {

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "test-cypress-coo-bvt": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@coo+@smoke --@demo'",
     "test-cypress-virtualization": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@virtualization --@flaky --@demo'",
     "test-cypress-incidents": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@incidents --@flaky --@demo'",
+    "test-cypress-incidents-e2e": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@incidents+@e2e-real --@flaky --@demo'",
     "test-cypress-smoke": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@smoke --@flaky --@demo'",
     "test-cypress-fast": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@smoke --@slow --@demo --@flaky'",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"


### PR DESCRIPTION
Add `test-cypress-incidents-e2e` command for running incidents e2e tests only.