### PR TITLE
OU-1039: add info alert to the Incident page

### DIFF
--- a/web/locales/en/plugin__monitoring-plugin.json
+++ b/web/locales/en/plugin__monitoring-plugin.json
@@ -303,5 +303,6 @@
   "No metrics targets found": "No metrics targets found",
   "Error loading latest targets data": "Error loading latest targets data",
   "Search by endpoint or namespace...": "Search by endpoint or namespace...",
-  "Text": "Text"
+  "Text": "Text",
+  "Incident data is updated every few minutes. What you see may be up to 5 minutes old. Refresh the page to view updated information.":"Incident data is updated every few minutes. What you see may be up to 5 minutes old. Refresh the page to view updated information."
 }


### PR DESCRIPTION
This is to display a temporary (5min) alert for the incident page. It looks like:

<img width="1590" height="416" alt="Snímek obrazovky z 2026-01-27 13-05-06" src="https://github.com/user-attachments/assets/0f369dc2-b1a9-457a-81e5-c416637684df" />
