### PR TITLE
OU-1213: IncidentPage add error state

### DIFF
--- a/web/src/components/Incidents/IncidentsPage.tsx
+++ b/web/src/components/Incidents/IncidentsPage.tsx
@@ -23,6 +23,7 @@ import {
   Alert,
   AlertActionCloseButton,
 } from '@patternfly/react-core';
+import { AccessDenied } from '../console/console-shared/src/components/empty-state/AccessDenied';
 import { IncidentsTable } from './IncidentsTable';
 import {
   getIncidentsTimeRanges,
@@ -80,6 +81,7 @@ const IncidentsPage = () => {
   const { theme } = usePatternFlyTheme();
   // loading states
   const [incidentsAreLoading, setIncidentsAreLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | null>(null);
   // days span is where we store the value for creating time ranges for
   // fetch incidents/alerts based on the length of time ranges
   // when days filter changes we set a new days span -> calculate new time range and fetch new data
@@ -269,6 +271,9 @@ const IncidentsPage = () => {
         .catch((err) => {
           // eslint-disable-next-line no-console
           console.log(err);
+
+          dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
+          setLoadError(err);
         });
     })();
   }, [incidentForAlertProcessing]);
@@ -277,6 +282,7 @@ const IncidentsPage = () => {
     if (!isInitialized) return;
 
     setIncidentsAreLoading(true);
+    setLoadError(null);
 
     // Set refresh time before making queries
     const currentTime = getCurrentTime();
@@ -328,6 +334,10 @@ const IncidentsPage = () => {
       .catch((err) => {
         // eslint-disable-next-line no-console
         console.log(err);
+
+        setIncidentsAreLoading(false);
+        dispatch(setAlertsAreLoading({ alertsAreLoading: false }));
+        setLoadError(err);
       });
   }, [isInitialized, incidentsActiveFilters.days, selectedGroupId]);
 
@@ -399,7 +409,9 @@ const IncidentsPage = () => {
   return (
     <>
       <DocumentTitle>{title}</DocumentTitle>
-      {alertsAreLoading && incidentsAreLoading ? (
+      {loadError ? (
+        <AccessDenied message={loadError.message} />
+      ) : alertsAreLoading && incidentsAreLoading ? (
         <Bullseye>
           <Spinner
             aria-label="incidents-chart-spinner"
@@ -407,255 +419,261 @@ const IncidentsPage = () => {
           />
         </Bullseye>
       ) : (
-        <PageSection hasBodyWrapper={false} className="incidents-page-main-section">
-          {showDataDelayAlert && (
-            <Alert
-              variant="info"
-              title="Data delay"
-              className="pf-v6-u-mb-md"
-              actionClose={
-                <AlertActionCloseButton
-                  aria-label="Close data delay alert"
-                  onClose={() => {
-                    setShowDataDelayAlert(false);
-                    localStorage.setItem(INCIDENTS_DATA_ALERT_DISPLAYED, 'true');
-                  }}
-                />
-              }
-            >
-              {t(
-                'Incident data is updated every few minutes. What you see may be up to 5 minutes old. Refresh the page to view updated information.',
-              )}
-            </Alert>
-          )}
-          <Toolbar
-            id="toolbar-with-filter"
-            data-test={DataTestIDs.IncidentsPage.Toolbar}
-            collapseListedFiltersBreakpoint="xl"
-            clearFiltersButtonText={t('Clear all filters')}
-            clearAllFilters={() => {
-              closeDropDownFilters();
-              dispatch(
-                setIncidentsActiveFilters({
-                  incidentsActiveFilters: {
-                    ...incidentsActiveFilters,
-                    severity: [],
-                    state: [],
-                    groupId: [],
-                  },
-                }),
-              );
-              dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
-            }}
-          >
-            <ToolbarContent>
-              <ToolbarGroup>
-                <ToolbarItem>
-                  <Select
-                    aria-label={t('Filter type selection')}
-                    data-test={DataTestIDs.IncidentsPage.FiltersSelect}
-                    isOpen={filterTypeExpanded.filterType}
-                    role="menu"
-                    selected={incidentPageFilterTypeSelected}
-                    onOpenChange={(isOpen) =>
-                      setFiltersExpanded((prev) => ({ ...prev, filterType: isOpen }))
-                    }
-                    onSelect={(event, selection) => {
-                      dispatch(setIncidentPageFilterType({ incidentPageFilterType: selection }));
-                      setFilterTypeExpanded((prev) => ({ ...prev, filterType: false }));
+        !loadError && (
+          <PageSection hasBodyWrapper={false} className="incidents-page-main-section">
+            {showDataDelayAlert && (
+              <Alert
+                variant="info"
+                title="Data delay"
+                className="pf-v6-u-mb-md"
+                actionClose={
+                  <AlertActionCloseButton
+                    aria-label="Close data delay alert"
+                    onClose={() => {
+                      setShowDataDelayAlert(false);
+                      localStorage.setItem(INCIDENTS_DATA_ALERT_DISPLAYED, 'true');
                     }}
-                    shouldFocusToggleOnSelect
+                  />
+                }
+              >
+                {t(
+                  'Incident data is updated every few minutes. What you see may be up to 5 minutes old. Refresh the page to view updated information.',
+                )}
+              </Alert>
+            )}
+            <Toolbar
+              id="toolbar-with-filter"
+              data-test={DataTestIDs.IncidentsPage.Toolbar}
+              collapseListedFiltersBreakpoint="xl"
+              clearFiltersButtonText={t('Clear all filters')}
+              clearAllFilters={() => {
+                closeDropDownFilters();
+                dispatch(
+                  setIncidentsActiveFilters({
+                    incidentsActiveFilters: {
+                      ...incidentsActiveFilters,
+                      severity: [],
+                      state: [],
+                      groupId: [],
+                    },
+                  }),
+                );
+                dispatch(setAlertsAreLoading({ alertsAreLoading: true }));
+              }}
+            >
+              <ToolbarContent>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <Select
+                      aria-label={t('Filter type selection')}
+                      data-test={DataTestIDs.IncidentsPage.FiltersSelect}
+                      isOpen={filterTypeExpanded.filterType}
+                      role="menu"
+                      selected={incidentPageFilterTypeSelected}
+                      onOpenChange={(isOpen) =>
+                        setFiltersExpanded((prev) => ({ ...prev, filterType: isOpen }))
+                      }
+                      onSelect={(event, selection) => {
+                        dispatch(setIncidentPageFilterType({ incidentPageFilterType: selection }));
+                        setFilterTypeExpanded((prev) => ({ ...prev, filterType: false }));
+                      }}
+                      shouldFocusToggleOnSelect
+                      toggle={(toggleRef) => (
+                        <MenuToggle
+                          ref={toggleRef}
+                          onClick={(ev) => onFilterToggle(ev, 'filterType', setFilterTypeExpanded)}
+                          isExpanded={filterTypeExpanded.filterType}
+                          icon={<FilterIcon />}
+                          data-test={DataTestIDs.IncidentsPage.FiltersSelectToggle}
+                        >
+                          {t(incidentPageFilterTypeSelected)}
+                        </MenuToggle>
+                      )}
+                      style={{ width: '145px' }}
+                    >
+                      <SelectList data-test={DataTestIDs.IncidentsPage.FiltersSelectList}>
+                        <SelectOption
+                          value="Severity"
+                          isSelected={incidentPageFilterTypeSelected?.includes('Severity')}
+                          data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-severity`}
+                        >
+                          {t('Severity')}
+                        </SelectOption>
+                        <SelectOption
+                          value="State"
+                          isSelected={incidentPageFilterTypeSelected?.includes('State')}
+                          data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-state`}
+                        >
+                          {t('State')}
+                        </SelectOption>
+                        <SelectOption
+                          value="Incident ID"
+                          isSelected={incidentPageFilterTypeSelected?.includes('Incident ID')}
+                          data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-incident-id`}
+                        >
+                          {t('Incident ID')}
+                        </SelectOption>
+                      </SelectList>
+                    </Select>
+                  </ToolbarItem>
+                  <ToolbarItem
+                    className={incidentPageFilterTypeSelected !== 'Severity' ? 'pf-m-hidden' : ''}
+                  >
+                    <IncidentFilterToolbarItem
+                      categoryName="Severity"
+                      toggleLabel={t('Severity filters')}
+                      options={severityOptions}
+                      incidentsActiveFilters={incidentsActiveFilters}
+                      onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
+                      onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
+                      incidentFilterIsExpanded={filtersExpanded.severity}
+                      onIncidentFiltersSelect={onIncidentFiltersSelect}
+                      setIncidentIsExpanded={(isExpanded) =>
+                        setFiltersExpanded((prev) => ({ ...prev, severity: isExpanded }))
+                      }
+                      onIncidentFilterToggle={(ev) =>
+                        onFilterToggle(ev, 'severity', setFiltersExpanded)
+                      }
+                      dispatch={dispatch}
+                      showToolbarItem={incidentPageFilterTypeSelected?.includes('Severity')}
+                    />
+                  </ToolbarItem>
+                  <ToolbarItem
+                    className={incidentPageFilterTypeSelected !== 'State' ? 'pf-m-hidden' : ''}
+                  >
+                    <IncidentFilterToolbarItem
+                      categoryName="State"
+                      toggleLabel={t('State filters')}
+                      options={stateOptions}
+                      incidentsActiveFilters={incidentsActiveFilters}
+                      onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
+                      onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
+                      incidentFilterIsExpanded={filtersExpanded.state}
+                      onIncidentFiltersSelect={onIncidentFiltersSelect}
+                      setIncidentIsExpanded={(isExpanded) =>
+                        setFiltersExpanded((prev) => ({ ...prev, state: isExpanded }))
+                      }
+                      onIncidentFilterToggle={(ev) =>
+                        onFilterToggle(ev, 'state', setFiltersExpanded)
+                      }
+                      dispatch={dispatch}
+                      showToolbarItem={incidentPageFilterTypeSelected?.includes('State')}
+                    />
+                  </ToolbarItem>
+                  <ToolbarItem
+                    className={
+                      incidentPageFilterTypeSelected !== 'Incident ID' ? 'pf-m-hidden' : ''
+                    }
+                  >
+                    <IncidentFilterToolbarItem
+                      categoryName="Incident ID"
+                      toggleLabel={t('Incident ID filters')}
+                      options={incidentIdFilterOptions}
+                      incidentsActiveFilters={incidentsActiveFilters}
+                      onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
+                      onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
+                      incidentFilterIsExpanded={filtersExpanded.groupId}
+                      onIncidentFiltersSelect={onIncidentFiltersSelect}
+                      setIncidentIsExpanded={(isExpanded) =>
+                        setFiltersExpanded((prev) => ({ ...prev, groupId: isExpanded }))
+                      }
+                      onIncidentFilterToggle={(ev) =>
+                        onFilterToggle(ev, 'groupId', setFiltersExpanded)
+                      }
+                      dispatch={dispatch}
+                      showToolbarItem={incidentPageFilterTypeSelected?.includes('Incident ID')}
+                    />
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarItem align={{ default: 'alignEnd' }}>
+                  <Select
+                    id="time-range-select"
+                    data-test={DataTestIDs.IncidentsPage.DaysSelect}
+                    isOpen={daysFilterIsExpanded}
+                    selected={incidentsActiveFilters.days[0]}
+                    onSelect={onSelect}
+                    onOpenChange={(isOpen) => setDaysFilterIsExpanded(isOpen)}
                     toggle={(toggleRef) => (
                       <MenuToggle
                         ref={toggleRef}
-                        onClick={(ev) => onFilterToggle(ev, 'filterType', setFilterTypeExpanded)}
-                        isExpanded={filterTypeExpanded.filterType}
-                        icon={<FilterIcon />}
-                        data-test={DataTestIDs.IncidentsPage.FiltersSelectToggle}
+                        onClick={onToggleClick}
+                        isExpanded={daysFilterIsExpanded}
+                        data-test={DataTestIDs.IncidentsPage.DaysSelectToggle}
                       >
-                        {t(incidentPageFilterTypeSelected)}
+                        {t(`Last ${incidentsActiveFilters.days[0]}`)}
                       </MenuToggle>
                     )}
-                    style={{ width: '145px' }}
+                    shouldFocusToggleOnSelect
                   >
-                    <SelectList data-test={DataTestIDs.IncidentsPage.FiltersSelectList}>
+                    <SelectList data-test={DataTestIDs.IncidentsPage.DaysSelectList}>
                       <SelectOption
-                        value="Severity"
-                        isSelected={incidentPageFilterTypeSelected?.includes('Severity')}
-                        data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-severity`}
+                        value="1 day"
+                        data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-1-day`}
                       >
-                        {t('Severity')}
+                        {t('Last 1 day')}
                       </SelectOption>
                       <SelectOption
-                        value="State"
-                        isSelected={incidentPageFilterTypeSelected?.includes('State')}
-                        data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-state`}
+                        value="3 days"
+                        data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-3-days`}
                       >
-                        {t('State')}
+                        {t('Last 3 days')}
                       </SelectOption>
                       <SelectOption
-                        value="Incident ID"
-                        isSelected={incidentPageFilterTypeSelected?.includes('Incident ID')}
-                        data-test={`${DataTestIDs.IncidentsPage.FiltersSelectOption}-incident-id`}
+                        value="7 days"
+                        data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-7-days`}
                       >
-                        {t('Incident ID')}
+                        {t('Last 7 days')}
+                      </SelectOption>
+                      <SelectOption
+                        value="15 days"
+                        data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-15-days`}
+                      >
+                        {t('Last 15 days')}
                       </SelectOption>
                     </SelectList>
                   </Select>
                 </ToolbarItem>
-                <ToolbarItem
-                  className={incidentPageFilterTypeSelected !== 'Severity' ? 'pf-m-hidden' : ''}
-                >
-                  <IncidentFilterToolbarItem
-                    categoryName="Severity"
-                    toggleLabel={t('Severity filters')}
-                    options={severityOptions}
-                    incidentsActiveFilters={incidentsActiveFilters}
-                    onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
-                    onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
-                    incidentFilterIsExpanded={filtersExpanded.severity}
-                    onIncidentFiltersSelect={onIncidentFiltersSelect}
-                    setIncidentIsExpanded={(isExpanded) =>
-                      setFiltersExpanded((prev) => ({ ...prev, severity: isExpanded }))
-                    }
-                    onIncidentFilterToggle={(ev) =>
-                      onFilterToggle(ev, 'severity', setFiltersExpanded)
-                    }
-                    dispatch={dispatch}
-                    showToolbarItem={incidentPageFilterTypeSelected?.includes('Severity')}
-                  />
-                </ToolbarItem>
-                <ToolbarItem
-                  className={incidentPageFilterTypeSelected !== 'State' ? 'pf-m-hidden' : ''}
-                >
-                  <IncidentFilterToolbarItem
-                    categoryName="State"
-                    toggleLabel={t('State filters')}
-                    options={stateOptions}
-                    incidentsActiveFilters={incidentsActiveFilters}
-                    onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
-                    onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
-                    incidentFilterIsExpanded={filtersExpanded.state}
-                    onIncidentFiltersSelect={onIncidentFiltersSelect}
-                    setIncidentIsExpanded={(isExpanded) =>
-                      setFiltersExpanded((prev) => ({ ...prev, state: isExpanded }))
-                    }
-                    onIncidentFilterToggle={(ev) => onFilterToggle(ev, 'state', setFiltersExpanded)}
-                    dispatch={dispatch}
-                    showToolbarItem={incidentPageFilterTypeSelected?.includes('State')}
-                  />
-                </ToolbarItem>
-                <ToolbarItem
-                  className={incidentPageFilterTypeSelected !== 'Incident ID' ? 'pf-m-hidden' : ''}
-                >
-                  <IncidentFilterToolbarItem
-                    categoryName="Incident ID"
-                    toggleLabel={t('Incident ID filters')}
-                    options={incidentIdFilterOptions}
-                    incidentsActiveFilters={incidentsActiveFilters}
-                    onDeleteIncidentFilterChip={onDeleteIncidentFilterChip}
-                    onDeleteGroupIncidentFilterChip={onDeleteGroupIncidentFilterChip}
-                    incidentFilterIsExpanded={filtersExpanded.groupId}
-                    onIncidentFiltersSelect={onIncidentFiltersSelect}
-                    setIncidentIsExpanded={(isExpanded) =>
-                      setFiltersExpanded((prev) => ({ ...prev, groupId: isExpanded }))
-                    }
-                    onIncidentFilterToggle={(ev) =>
-                      onFilterToggle(ev, 'groupId', setFiltersExpanded)
-                    }
-                    dispatch={dispatch}
-                    showToolbarItem={incidentPageFilterTypeSelected?.includes('Incident ID')}
-                  />
-                </ToolbarItem>
-              </ToolbarGroup>
-              <ToolbarItem align={{ default: 'alignEnd' }}>
-                <Select
-                  id="time-range-select"
-                  data-test={DataTestIDs.IncidentsPage.DaysSelect}
-                  isOpen={daysFilterIsExpanded}
-                  selected={incidentsActiveFilters.days[0]}
-                  onSelect={onSelect}
-                  onOpenChange={(isOpen) => setDaysFilterIsExpanded(isOpen)}
-                  toggle={(toggleRef) => (
-                    <MenuToggle
-                      ref={toggleRef}
-                      onClick={onToggleClick}
-                      isExpanded={daysFilterIsExpanded}
-                      data-test={DataTestIDs.IncidentsPage.DaysSelectToggle}
+              </ToolbarContent>
+            </Toolbar>
+            <Stack hasGutter>
+              <StackItem>
+                <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                  <FlexItem>
+                    <Button
+                      variant="link"
+                      icon={hideCharts ? <CompressArrowsAltIcon /> : <CompressIcon />}
+                      onClick={() => setHideCharts(!hideCharts)}
+                      data-test={DataTestIDs.IncidentsPage.ToggleChartsButton}
                     >
-                      {t(`Last ${incidentsActiveFilters.days[0]}`)}
-                    </MenuToggle>
-                  )}
-                  shouldFocusToggleOnSelect
-                >
-                  <SelectList data-test={DataTestIDs.IncidentsPage.DaysSelectList}>
-                    <SelectOption
-                      value="1 day"
-                      data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-1-day`}
-                    >
-                      {t('Last 1 day')}
-                    </SelectOption>
-                    <SelectOption
-                      value="3 days"
-                      data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-3-days`}
-                    >
-                      {t('Last 3 days')}
-                    </SelectOption>
-                    <SelectOption
-                      value="7 days"
-                      data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-7-days`}
-                    >
-                      {t('Last 7 days')}
-                    </SelectOption>
-                    <SelectOption
-                      value="15 days"
-                      data-test={`${DataTestIDs.IncidentsPage.DaysSelectOption}-15-days`}
-                    >
-                      {t('Last 15 days')}
-                    </SelectOption>
-                  </SelectList>
-                </Select>
-              </ToolbarItem>
-            </ToolbarContent>
-          </Toolbar>
-          <Stack hasGutter>
-            <StackItem>
-              <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
-                <FlexItem>
-                  <Button
-                    variant="link"
-                    icon={hideCharts ? <CompressArrowsAltIcon /> : <CompressIcon />}
-                    onClick={() => setHideCharts(!hideCharts)}
-                    data-test={DataTestIDs.IncidentsPage.ToggleChartsButton}
-                  >
-                    <span>{hideCharts ? t('Show graph') : t('Hide graph')}</span>
-                  </Button>
-                </FlexItem>
-              </Flex>
-            </StackItem>
-            {!hideCharts && (
-              <>
-                <StackItem>
-                  <IncidentsChart
-                    incidentsData={filteredData}
-                    chartDays={timeRanges.length}
-                    theme={theme}
-                    selectedGroupId={selectedGroupId}
-                    onIncidentClick={handleIncidentChartClick}
-                    currentTime={incidentsLastRefreshTime}
-                    lastRefreshTime={incidentsLastRefreshTime}
-                  />
-                </StackItem>
-                <StackItem>
-                  <AlertsChart theme={theme} />
-                </StackItem>
-              </>
-            )}
-            <StackItem>
-              <IncidentsTable />
-            </StackItem>
-          </Stack>
-        </PageSection>
+                      <span>{hideCharts ? t('Show graph') : t('Hide graph')}</span>
+                    </Button>
+                  </FlexItem>
+                </Flex>
+              </StackItem>
+              {!hideCharts && (
+                <>
+                  <StackItem>
+                    <IncidentsChart
+                      incidentsData={filteredData}
+                      chartDays={timeRanges.length}
+                      theme={theme}
+                      selectedGroupId={selectedGroupId}
+                      onIncidentClick={handleIncidentChartClick}
+                      currentTime={incidentsLastRefreshTime}
+                      lastRefreshTime={incidentsLastRefreshTime}
+                    />
+                  </StackItem>
+                  <StackItem>
+                    <AlertsChart theme={theme} />
+                  </StackItem>
+                </>
+              )}
+              <StackItem>
+                <IncidentsTable />
+              </StackItem>
+            </Stack>
+          </PageSection>
+        )
       )}
     </>
   );


### PR DESCRIPTION
This is adding use of `AccessDenied` to the IncidentPage when user doesn't have sufficient permissions. 

Previously it displayed only spinning spinner. 

When this fix is applied, it looks like:
<img width="1639" height="828" alt="Snímek obrazovky z 2026-02-02 09-43-37" src="https://github.com/user-attachments/assets/4410471e-4a83-4cfc-adef-5934ea904d37" />

