### PR TITLE
COO-1562: update acm alerting UI test case

### DIFF
--- a/web/cypress/e2e/coo/02.acm_alerting_ui.cy.ts
+++ b/web/cypress/e2e/coo/02.acm_alerting_ui.cy.ts
@@ -1,6 +1,7 @@
 // 02.acm_alerting_ui.cy.ts
 // E2E test for validating ACM Alerting UI integration with Cluster Observability Operator (COO)
 import '../../support/commands/auth-commands';
+import { commonPages } from '../../views/common';
 import { nav } from '../../views/nav';
 import { acmAlertingPage } from '../../views/acm-alerting-page';
 
@@ -25,9 +26,11 @@ describe('ACM Alerting UI', { tags: ['@coo', '@alerts'] }, () => {
   });
 
   it('Navigate to Fleet Management > local-cluster > Observe > Alerting', () => {
-    // wait for console page loading completed
-    cy.visit('/');
-    cy.get('body', { timeout: 60000 }).should('contain.text', 'Administrator');
+    // check monitoring-plugin UI is not been affected
+    nav.sidenav.clickNavLink(['Observe', 'Alerting']);
+    commonPages.titleShouldHaveText('Alerting')
+    nav.sidenav.clickNavLink(['Observe', 'Metrics']);
+    commonPages.titleShouldHaveText('Metrics');
     // switch to Fleet Management page
     cy.switchPerspective('Fleet Management');
     // close pop-up window
@@ -42,14 +45,11 @@ describe('ACM Alerting UI', { tags: ['@coo', '@alerts'] }, () => {
       });
     // click side menu -> Observe -> Alerting
     nav.sidenav.clickNavLink(['Observe', 'Alerting']);
-    // Wait for alert tab content to become visible
-    cy.get('section#alerts-tab-content', { timeout: 60000 })
-      .should('be.visible');
     // confirm Alerting page loading completed
     acmAlertingPage.shouldBeLoaded();
-    // check three test alerts exist
+    // check test alerts exist
     expectedAlerts.forEach((alert) => {
-      cy.contains('a[data-test-id="alert-resource-link"]', alert, { timeout: 60000 })
+      cy.contains('a[data-test-id="alert-resource-link"]', alert, { timeout: 120000 })
         .should('be.visible');
     });
     cy.log('Verified all expected alerts are visible on the Alerting page');

--- a/web/cypress/support/commands/operator-commands.ts
+++ b/web/cypress/support/commands/operator-commands.ts
@@ -893,15 +893,12 @@ Cypress.Commands.add('beforeBlock', (MP: { namespace: string, operatorName: stri
 
 Cypress.Commands.add('beforeBlockACM', (MCP, MP) => {
   cy.beforeBlockCOO(MCP, MP);
-  cy.log('=== [Setup] Installing ACM Operator & MCO ===');
+  cy.log('=== [Setup] Installing ACM test resources ===');
   cy.exec('bash ./cypress/fixtures/coo/acm-install.sh', {
     env: { KUBECONFIG: Cypress.env('KUBECONFIG_PATH'), },
     failOnNonZeroExit: false,
     timeout: 1200000, // long time script
   });
-  cy.exec(`oc apply -f ./cypress/fixtures/coo/acm-uiplugin.yaml --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`);
-  // add example alerts for test
-  cy.exec(`oc apply -f ./cypress/fixtures/coo/acm-alerrule-test.yaml --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`);
   cy.log('ACM environment setup completed');
 });
 


### PR DESCRIPTION
The test case `02.acm_alerting_ui.cy` will be run via the CI job in the future; the job `refs` include the relevant steps for ACM installation. Therefore, assertions were added in the Cypress test.