### PR TITLE
OU-1213: Add 403 permission denied mocking and access denied test

### DIFF
--- a/docs/incident_detection/resources/htpasswd-secret.yaml
+++ b/docs/incident_detection/resources/htpasswd-secret.yaml
@@ -1,0 +1,19 @@
+# HTPasswd Secret for creating a test user
+# 
+# Before applying, generate the htpasswd file:
+#   htpasswd -c -B -b users.htpasswd testuser password123
+#
+# Then base64 encode it:
+#   base64 -w0 users.htpasswd
+#
+# Replace the data.htpasswd value below with your encoded content
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: htpass-secret
+  namespace: openshift-config
+type: Opaque
+data:
+  # base64 encoded: testuser:$2y$05$fBn5ChTgiV0A/6HEfoNKleU3CLVIWuV2816XVIsmmhwAz.fBpDObe
+  htpasswd: dGVzdHVzZXI6JDJ5JDA1JGZCbjVDaFRnaVYwQS82SEVmb05LbGVVM0NMVklXdVYyODE2WFZJc21taHdBei5mQnBET2JlCg==

--- a/docs/incident_detection/resources/limited-permissions-user.yaml
+++ b/docs/incident_detection/resources/limited-permissions-user.yaml
@@ -1,0 +1,31 @@
+# Namespace and RoleBinding for testing limited permissions
+#
+# This creates a namespace with cluster-monitoring enabled and grants
+# the testuser only monitoring-rules-view access (no full monitoring access)
+#
+# The user will receive 403 Forbidden when accessing:
+# - /api/prometheus/api/v1/rules
+# - /api/alertmanager/api/v2/silences  
+# - /api/prometheus/api/v1/query_range
+# - /api/prometheus/api/v1/query
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-a
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: testuser-monitoring-view
+  namespace: namespace-a
+subjects:
+- kind: User
+  name: testuser
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: monitoring-rules-view
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/incident_detection/resources/oauth-htpasswd.yaml
+++ b/docs/incident_detection/resources/oauth-htpasswd.yaml
@@ -1,0 +1,17 @@
+# OAuth configuration to use HTPasswd identity provider
+#
+# This configures OpenShift to authenticate users from the htpass-secret
+# Apply htpasswd-secret.yaml first before applying this
+
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: my_htpasswd_provider
+    mappingMethod: claim
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret

--- a/docs/incident_detection/tests/3.api_calls_data_loading_flows.md
+++ b/docs/incident_detection/tests/3.api_calls_data_loading_flows.md
@@ -1,6 +1,6 @@
 ## 3. CRITICAL: Data Loading – API Call Bugs
 
-**Automation Status**: PARTIALLY AUTOMATED (Sections 3.1 and 3.2)
+**Automation Status**: PARTIALLY AUTOMATED (Sections 3.1, 3.2, and 3.5)
 
 ### Prerequisites: Test Data Setup for Data Loading Tests
 
@@ -91,4 +91,14 @@ start,end,alertname,namespace,severity,silenced,labels
 - [ ] Component lists combined for same group_id
 - [ ] Watchdog alerts filtered out
 
+### 3.5 Permission Denied Handling
+**BUG**: Page should gracefully handle 403 Forbidden responses from API endpoints.  
+**Automation Status**: AUTOMATED in `03.reg_api_calls.cy.ts`
+- Uses mock: `cy.mockPermissionDenied({ rules: true, silences: true, prometheus: true })`
+- Manual replication: Apply resources from [`docs/incident_detection/resources/`](../resources/)
+
+- [ ] **403 Forbidden Response**: Create user with limited permissions (testuser/password123)
+  - Apply: `htpasswd-secret.yaml`, `oauth-htpasswd.yaml`, `limited-permissions-user.yaml`
+  - Login as testuser, navigate to Observe → Incidents
+  - Expected: `<EmptyState data-test="access-denied">` with "Restricted access" text
 


### PR DESCRIPTION
Add cy.mockPermissionDenied() command to simulate 403 Forbidden responses from rules, silences, and Prometheus query endpoints. Add regression test verifying the Incidents page displays the access denied empty state.