### PR TITLE
NO-JIRA: [release-4.17] simplify frontend build in Dockerfile.art

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -18,13 +18,8 @@ RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
 
 # use dependencies provided by Cachito
 ENV HUSKY=0
-RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
-    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem . \
- && cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/{.npmrc,.yarnrc,yarn.lock} web/ \
- && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
- && make install-frontend-ci \
- && make build-frontend
-
+ENV CYPRESS_INSTALL_BINARY=0
+RUN make install-frontend-ci && make build-frontend
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS go-builder
 
@@ -34,7 +29,7 @@ WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 
-RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \ 
+RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
   && make build-backend BUILD_OPTS="-tags strictfipsruntime"
 
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9


### PR DESCRIPTION
Remove Cachito gomod dependencies handling and streamline the build process to use direct make commands for frontend installation and building.

cherry pick of https://github.com/openshift/monitoring-plugin/pull/799