### PR TITLE
OCPBUGS-77406: bump koa

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10928,6 +10928,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -18629,13 +18630,13 @@
       }
     },
     "node_modules/koa": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.1.tgz",
-      "integrity": "sha512-oDxVkRwPOHhGlxKIDiDB2h+/l05QPtefD7nSqRgDfZt8P+QVYFWjfeK8jANf5O2YXjk8egd7KntvXKYx82wOag==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.8",
-        "content-disposition": "~0.5.4",
+        "content-disposition": "~1.0.1",
         "content-type": "^1.0.5",
         "cookies": "~0.9.1",
         "delegates": "^1.0.0",
@@ -18662,6 +18663,19 @@
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
       "license": "MIT"
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/koa/node_modules/mime-db": {
       "version": "1.54.0",

--- a/web/package.json
+++ b/web/package.json
@@ -175,7 +175,8 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "axios": "1.13.5"
+    "axios": "1.13.5",
+    "koa": "^3.1.2"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
Add npm override for koa >=3.1.2 to address Host Header Injection vulnerability via ctx.hostname (CVE-2026-27959, GHSA-7gcc-r8m5-44qm). The vulnerable koa 3.0.1 was pulled transitively via @module-federation/dts-plugin.