### PR TITLE
OU-1217: perses customizable dashboards with perses global datasources for tempo and loki

### DIFF
--- a/web/cypress/e2e/perses/05.coo_tempo_loki_admin.cy.ts
+++ b/web/cypress/e2e/perses/05.coo_tempo_loki_admin.cy.ts
@@ -1,0 +1,98 @@
+import { runCOOCreateImportPersesTests } from '../../support/perses/05.coo_create_import_perses_admin.cy';
+import { nav } from '../../views/nav';
+
+// Set constants for the operators that need to be installed for tests.
+const MCP = {
+  namespace: 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'monitoring',
+  },
+};
+
+const MP = {
+  namespace: 'openshift-monitoring',
+  operatorName: 'Cluster Monitoring Operator',
+};
+
+const OTEL = {
+  namespace: 'openshift-opentelemetry-operator',
+  packageName: 'opentelemetry-product',
+  operatorName: 'Red Hat build of OpenTelemetry',
+};
+
+const TEMPO = {
+  namespace: 'openshift-tempo-operator',
+  packageName: 'tempo-product',
+  operatorName: 'Tempo Operator',
+};
+
+const LOKI = {
+  namespace: 'openshift-operators-redhat',
+  packageName: 'loki-operator',
+  operatorName: 'Loki Operator',
+};
+
+const CLO = {
+  namespace: 'openshift-logging',
+  packageName: 'cluster-logging',
+  operatorName: 'Logging Operator',
+};
+
+describe(
+  'COO - Dashboards (Perses) - Perses Global Datasources with Tempo and Loki',
+  { tags: ['@perses', '@dashboards'] },
+  () => {
+    before(() => {
+      cy.beforeBlockTempo(TEMPO);
+      cy.beforeBlockOtel(OTEL);
+      cy.configureBase();
+      cy.configureTracingApps();
+
+      cy.beforeBlockLoki(LOKI);
+      cy.beforeBlockLogging(CLO);
+      cy.configureLoggingLoki();
+
+      cy.cleanupDistributeTracingUIPlugin();
+      cy.cleanupLoggingUIPlugin();
+      cy.cleanupExtraDashboards();
+
+      cy.beforeBlockCOO(MCP, MP, { dashboards: true, troubleshootingPanel: false });
+      cy.cleanupPersesTestDashboardsBeforeTests();
+      cy.setupPersesRBACandExtraDashboards();
+      cy.installDistributeTracingUIPlugin();
+      cy.installLoggingUIPlugin();
+      cy.waitForDistributeTracingUIPluginReady();
+      cy.waitForLoggingUIPluginReady();
+
+      cy.createTempoLokiThanosPersesGlobalDatasource();
+    });
+
+    beforeEach(() => {
+      nav.sidenav.clickNavLink(['Observe', 'Dashboards (Perses)']);
+      cy.wait(5000);
+      cy.changeNamespace('All Projects');
+    });
+
+    after(() => {
+      cy.cleanupTempoLokiThanosPersesGlobalDatasource();
+      cy.cleanupLoggingUIPlugin();
+      cy.cleanupDistributeTracingUIPlugin();
+      cy.cleanupExtraDashboards();
+      cy.cleanupCOO(MCP, MP, { dashboards: true, troubleshootingPanel: false });
+      cy.cleanupLoggingLoki();
+      cy.cleanupLogging(CLO);
+      cy.cleanupLoki(LOKI);
+      cy.cleanupTracingApps();
+      cy.cleanupBase();
+      cy.cleanupOtel(OTEL);
+      cy.cleanupTempo(TEMPO);
+    });
+
+    runCOOCreateImportPersesTests({
+      name: 'Administrator',
+    });
+  },
+);

--- a/web/cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.json
+++ b/web/cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.json
@@ -1,0 +1,182 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "createdAt": "2026-04-10T21:51:00.581694831Z",
+    "name": "tempo_loki_perses_global_datasources_json_import",
+    "project": "default",
+    "updatedAt": "2026-04-10T21:52:50.555886464Z",
+    "version": 1
+  },
+  "spec": {
+    "display": {
+      "name": "Tempo Loki Perses Global Datasources - JSON Import"
+    },
+    "panels": {
+      "5afa2e46a64a423fac68f7282c6bb43b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "description": "This is a line chart test",
+            "name": "Time Series Chart"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "up"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "82e164e550e84a72b062d0a7d2cb0f3e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "description": "This is a trace table test",
+            "name": "Tempo - Trace Table"
+          },
+          "plugin": {
+            "kind": "TraceTable",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TraceQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "TempoTraceQuery",
+                  "spec": {
+                    "limit": 20,
+                    "query": "{}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "a10cea99a1aa4f80bfe4320ccf2fc8de": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "description": "This is a logs table test",
+            "name": "Loki - Logs Table"
+          },
+          "plugin": {
+            "kind": "LogsTable",
+            "spec": {
+              "allowWrap": true,
+              "enableDetails": true,
+              "showTime": true
+            }
+          },
+          "queries": [
+            {
+              "kind": "LogQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "LokiLogQuery",
+                  "spec": {
+                    "query": "{ log_type=\"application\" } | json"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "e3ed41a6d007492787bafa4dbc527610": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "description": "This is a scatter chart test",
+            "name": "Tempo - Scatter Chart"
+          },
+          "plugin": {
+            "kind": "ScatterChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TraceQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "TempoTraceQuery",
+                  "spec": {
+                    "limit": 20,
+                    "query": "{}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group Up",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/e3ed41a6d007492787bafa4dbc527610"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/82e164e550e84a72b062d0a7d2cb0f3e"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/a10cea99a1aa4f80bfe4320ccf2fc8de"
+              }
+            },
+            {
+              "x": 0,
+              "y": 18,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5afa2e46a64a423fac68f7282c6bb43b"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "variables": [],
+    "duration": "1h",
+    "refreshInterval": "30s",
+    "datasources": {}
+  }
+}

--- a/web/cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.yaml
+++ b/web/cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.yaml
@@ -1,0 +1,116 @@
+kind: Dashboard
+metadata:
+  createdAt: "2026-04-10T21:51:00.581694831Z"
+  name: tempo_loki_perses_global_datasources_yaml_import
+  project: default
+  updatedAt: "2026-04-10T21:52:50.555886464Z"
+  version: 1
+spec:
+  display:
+    name: Tempo Loki Perses Global Datasources - YAML Import
+  panels:
+    5afa2e46a64a423fac68f7282c6bb43b:
+      kind: Panel
+      spec:
+        display:
+          description: This is a line chart test
+          name: Time Series Chart
+        plugin:
+          kind: TimeSeriesChart
+          spec: {}
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: up
+    82e164e550e84a72b062d0a7d2cb0f3e:
+      kind: Panel
+      spec:
+        display:
+          description: This is a trace table test
+          name: Tempo - Trace Table
+        plugin:
+          kind: TraceTable
+          spec: {}
+        queries:
+          - kind: TraceQuery
+            spec:
+              plugin:
+                kind: TempoTraceQuery
+                spec:
+                  limit: 20
+                  query: "{}"
+    a10cea99a1aa4f80bfe4320ccf2fc8de:
+      kind: Panel
+      spec:
+        display:
+          description: This is a logs table test
+          name: Loki - Logs Table
+        plugin:
+          kind: LogsTable
+          spec:
+            allowWrap: true
+            enableDetails: true
+            showTime: true
+        queries:
+          - kind: LogQuery
+            spec:
+              plugin:
+                kind: LokiLogQuery
+                spec:
+                  query: '{ log_type="application" } | json'
+    e3ed41a6d007492787bafa4dbc527610:
+      kind: Panel
+      spec:
+        display:
+          description: This is a scatter chart test
+          name: Tempo - Scatter Chart
+        plugin:
+          kind: ScatterChart
+          spec: {}
+        queries:
+          - kind: TraceQuery
+            spec:
+              plugin:
+                kind: TempoTraceQuery
+                spec:
+                  limit: 20
+                  query: "{}"
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: Panel Group Up
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 12
+            height: 6
+            content:
+              $ref: "#/spec/panels/e3ed41a6d007492787bafa4dbc527610"
+          - x: 0
+            "y": 6
+            width: 12
+            height: 6
+            content:
+              $ref: "#/spec/panels/82e164e550e84a72b062d0a7d2cb0f3e"
+          - x: 0
+            "y": 12
+            width: 12
+            height: 6
+            content:
+              $ref: "#/spec/panels/a10cea99a1aa4f80bfe4320ccf2fc8de"
+          - x: 0
+            "y": 18
+            width: 12
+            height: 6
+            content:
+              $ref: "#/spec/panels/5afa2e46a64a423fac68f7282c6bb43b"
+  variables: []
+  duration: 1h
+  refreshInterval: 30s
+  datasources: {}

--- a/web/cypress/fixtures/coo/logging/base.yaml
+++ b/web/cypress/fixtures/coo/logging/base.yaml
@@ -1,0 +1,10 @@
+# Create the openshift-logging namespace with monitoring label.
+# All other resources (minio, chat, lokistack, CLF, netobserv) are
+# managed by kustomize via make-resources.sh.
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-logging
+  

--- a/web/cypress/fixtures/coo/logging/logging-ui-plugin.yaml
+++ b/web/cypress/fixtures/coo/logging/logging-ui-plugin.yaml
@@ -1,0 +1,12 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+    logsLimit: 50
+    timeout: 30s
+    schema: select

--- a/web/cypress/fixtures/coo/logging/make-clean-resources.sh
+++ b/web/cypress/fixtures/coo/logging/make-clean-resources.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+cd ./cypress/fixtures/coo/logging/openshift || exit 1
+
+make clean-resources

--- a/web/cypress/fixtures/coo/logging/make-resources.sh
+++ b/web/cypress/fixtures/coo/logging/make-resources.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+cd ./cypress/fixtures/coo/logging/openshift || exit 1
+
+make resources

--- a/web/cypress/fixtures/coo/logging/openshift/Makefile
+++ b/web/cypress/fixtures/coo/logging/openshift/Makefile
@@ -1,0 +1,38 @@
+# Deploy operators and resources for observability components.
+
+# Find default storage class.
+DEFAULT_SC=$(shell kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+STORAGE_CLASS?=$(or $(strip $(DEFAULT_SC)),$(error Cannot determine storage class, must set STORAGE_CLASS.))
+STORAGE_ENV=config/resources/storage.env
+
+ifneq ($(STORAGE_CLASS),$(file < $(STORAGE_ENV)))
+.PHONY: $(STORAGE_ENV)
+endif
+$(STORAGE_ENV):
+	echo "STORAGE_CLASS=$(STORAGE_CLASS)" > $@
+
+MINIO_ROLLOUT=./wait.sh rollout minio deployment/minio
+
+LOGGING_ROLLOUT=./wait.sh rollout openshift-logging \
+deployment.apps/cluster-logging-operator \
+deployment.apps/logging-loki-distributor \
+deployment.apps/logging-loki-gateway \
+deployment.apps/logging-loki-querier \
+deployment.apps/logging-loki-query-frontend \
+
+NETOBSERV_ROLLOUT=./wait.sh rollout netobserv \
+deployment.apps/loki-distributor \
+deployment.apps/loki-gateway \
+deployment.apps/loki-querier \
+deployment.apps/loki-query-frontend \
+deployment.apps/netobserv-plugin
+
+resources: $(STORAGE_ENV)
+	kubectl apply -k config/resources
+	$(MINIO_ROLLOUT)
+	$(LOGGING_ROLLOUT)
+	$(NETOBSERV_ROLLOUT)
+
+clean-resources:
+	test -f $(STORAGE_ENV) || echo STORAGE_CLASS=dummy > $(STORAGE_ENV) # Kustomize needs this file.
+	trap "rm $(STORAGE_ENV)" EXIT; kubectl delete --ignore-not-found -k config/resources

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/chat.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/chat.yaml
@@ -1,0 +1,29 @@
+# Generate application log messages.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chat
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: chat
+    test: "true"
+  name: chat-x
+  namespace: chat
+spec:
+  containers:
+  - name: chat
+    image: quay.io/libpod/alpine
+    command:
+    - sh
+    - "-c"
+    - 'i=1; while true; do echo "$(date) chat says hello - $i"; i=$((i + 1)); sleep 1; done'
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+      capabilities:
+        drop: [ALL]

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/kustomization.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - minio.yaml
+  - chat.yaml
+  - logging
+  - netobserv
+
+configMapGenerator:
+  - name: storage-env
+    envs:
+      - storage.env
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: storage-env
+      fieldPath: data.STORAGE_CLASS
+    targets:
+      - select:
+          kind: LokiStack
+        fieldPaths:
+          - spec.storageClassName
+

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/clusterlogforwarder.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/clusterlogforwarder.yaml
@@ -1,0 +1,29 @@
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: collector
+  outputs:
+    - name: default-lokistack
+      type: lokiStack
+      lokiStack:
+        target:
+          name: logging-loki
+          namespace: openshift-logging
+        authentication:
+          token:
+            from: serviceAccount
+      tls:
+        ca:
+          key: service-ca.crt
+          configMapName: openshift-service-ca.crt
+  pipelines:
+    - name: default-logstore
+      inputRefs:
+        - application
+        - infrastructure
+      outputRefs:
+        - default-lokistack

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/kustomization.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: openshift-logging
+resources:
+  - lokistack.yaml
+  - clusterlogforwarder.yaml

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/lokistack.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/logging/lokistack.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+stringData:
+  access_key_id: minio
+  access_key_secret: minio123
+  bucketnames: loki
+  endpoint: http://minio.minio.svc:9000
+type: Opaque
+---
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+spec:
+  size: 1x.demo
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: '2022-06-01'
+    secret:
+      name: minio
+      type: s3
+  storageClassName: REPLACE
+  tenants:
+    mode: openshift-logging

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/minio.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/minio.yaml
@@ -1,0 +1,88 @@
+# Deploy minio, does not require an operator.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+# Example secret, copy to client namespace.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: minio
+stringData:
+  access_key_id: minio
+  access_key_secret: minio123
+  bucketnames: loki
+  endpoint: http://minio.minio.svc:9000
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  ports:
+  - port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          mkdir -p /storage/loki && \
+          minio server /storage
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: minio
+        - name: MINIO_SECRET_KEY
+          value: minio123
+        image: quay.io/minio/minio
+        name: minio
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: /storage
+          name: storage
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: minio
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/flow_collector.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/flow_collector.yaml
@@ -1,0 +1,98 @@
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  annotations:
+    flows.netobserv.io/flowcollectorlegacy-namespace: netobserv
+    flows.netobserv.io/flpparent-namespace: netobserv
+  name: cluster
+spec:
+  kafka:
+    sasl:
+      type: Disabled
+  agent:
+    ebpf:
+      cacheActiveTimeout: 5s
+      cacheMaxFlows: 100000
+      excludeInterfaces:
+      - lo
+      kafkaBatchSize: 1048576
+      logLevel: info
+      sampling: 50
+    ipfix:
+      cacheActiveTimeout: 20s
+      cacheMaxFlows: 400
+      clusterNetworkOperator:
+        namespace: openshift-network-operator
+      ovnKubernetes:
+        containerName: ovnkube-node
+        daemonSetName: ovnkube-node
+        namespace: ovn-kubernetes
+      sampling: 400
+    type: eBPF
+  consolePlugin:
+    autoscaler:
+      maxReplicas: 3
+      status: Disabled
+    enable: true
+    imagePullPolicy: IfNotPresent
+    logLevel: info
+    portNaming:
+      enable: true
+    quickFilters:
+    - default: true
+      filter:
+        flow_layer: app
+      name: Applications
+    - filter:
+        flow_layer: infra
+      name: Infrastructure
+    - default: true
+      filter:
+        dst_kind: Pod
+        src_kind: Pod
+      name: Pods network
+    - filter:
+        dst_kind: Service
+      name: Services network
+    replicas: 1
+  deploymentModel: Direct
+  loki:
+    enable: true
+    lokiStack:
+      name: loki
+    manual:
+      authToken: Disabled
+      ingesterUrl: http://loki:3100/
+      querierUrl: http://loki:3100/
+      statusTls:
+        caCert: {}
+        userCert: {}
+      tenantID: netobserv
+    microservices:
+      ingesterUrl: http://loki-distributor:3100/
+      querierUrl: http://loki-query-frontend:3100/
+      tenantID: netobserv
+    mode: LokiStack
+    monolithic:
+      tenantID: netobserv
+      url: http://loki:3100/
+    readTimeout: 30s
+    writeBatchSize: 102400
+    writeBatchWait: 1s
+    writeTimeout: 10s
+  namespace: netobserv
+  processor:
+    imagePullPolicy: IfNotPresent
+    kafkaConsumerAutoscaler:
+      maxReplicas: 3
+      status: Disabled
+    kafkaConsumerBatchSize: 10485760
+    kafkaConsumerQueueCapacity: 1000
+    kafkaConsumerReplicas: 3
+    logLevel: info
+    logTypes: Flows
+    metrics:
+      server:
+        port: 9102
+        tls:
+          type: Disabled

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/kustomization.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: netobserv
+
+resources:
+  - namespace.yaml
+  - lokistack.yaml
+  - flow_collector.yaml

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/lokistack.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/lokistack.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+stringData:
+  access_key_id: minio
+  access_key_secret: minio123
+  bucketnames: loki
+  endpoint: http://minio.minio.svc:9000
+type: Opaque
+---
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: loki
+spec:
+  size: 1x.demo
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: '2022-06-01'
+    secret:
+      name: minio
+      type: s3
+  storageClassName: REPLACE
+  tenants:
+    mode: openshift-network

--- a/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/namespace.yaml
+++ b/web/cypress/fixtures/coo/logging/openshift/config/resources/netobserv/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: netobserv

--- a/web/cypress/fixtures/coo/logging/openshift/wait.sh
+++ b/web/cypress/fixtures/coo/logging/openshift/wait.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+declare RETRY_LIMIT=${RETRY_LIMIT:-10}
+declare RETRY_DELAY=${RETRY_DELAY:-10}
+declare -r ROLLOUT_TIMEOUT=5m
+
+# Wait for a subscription to have a CSV with phase=succeeded.
+subscription() {
+	local ns=$1
+	shift 1
+	local csv=""
+	for NAME in "$@"; do
+		wait_for_resource "subscription $NAME to be known" \
+			check_condition "AtLatestKnown" kubectl -n "$ns" get subscription/"$NAME" -o jsonpath='{.status.state}' || return 1
+		csv=$(kubectl get -n "$ns" subscription/"$NAME" -o jsonpath='{.status.currentCSV}')
+		wait_for_resource "csv $csv to be available" check_condition "Succeeded" kubectl get -n "$ns" csv/"$csv" -o jsonpath='{.status.phase}' || return 1
+		oc wait --allow-missing-template-keys=true --for=jsonpath='{.status.phase}'=Succeeded -n "$ns" csv/"$csv" || return 1
+	done
+}
+
+check_condition() {
+	local exp="$1"
+	local cond="$2"
+	shift 2
+	[[ -n $exp ]] && [[ $("$cond" "$@") == "$exp" ]] && {
+		return 0
+	}
+	return 1
+}
+
+# Wait for a specific condition in a resource.
+wait_for_resource() {
+	local msg="$1"
+	local condition="$2"
+	shift 2
+	echo "Waiting for [$RETRY_LIMIT x $RETRY_DELAY s]: $msg"
+	local -i tries=0
+	local -i ret=1
+	while [[ $tries -lt $RETRY_LIMIT ]]; do
+
+		$condition "$@" && {
+			ret=0
+			break
+		}
+		tries=$((tries + 1))
+		echo "...[$tries / $RETRY_LIMIT]: waiting for ($RETRY_DELAY s) - $msg" >&2
+		sleep "$RETRY_DELAY"
+	done
+
+	return $ret
+}
+
+# Wait for a workload to roll out.
+rollout() {
+	local ns=$1
+	shift 1
+	wait_for_resource "deployments to be created" kubectl -n "$ns" get "$@" || return 1
+	wait_for_resource "rollout to complete" kubectl -n "$ns" rollout status --watch --timeout="$ROLLOUT_TIMEOUT" "$@" || return 1
+}
+
+# Show usage.
+show_usage() {
+	echo "Usage: $0 {subscription|rollout} [NAMESPACE] [RESOURCE...]"
+}
+
+main() {
+	[[ "$#" -lt 1 ]] && {
+		show_usage
+		return 1
+	}
+	local op=$1
+	shift
+	case "$op" in
+	subscription | rollout)
+		kubectl get events -A --watch-only &
+		local bg_pid=$!
+		trap "kill $bg_pid 2>/dev/null || true" EXIT
+		"$op" "$@"
+		return $?
+		;;
+	*)
+		show_usage
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/web/cypress/fixtures/coo/traces/base.yaml
+++ b/web/cypress/fixtures/coo/traces/base.yaml
@@ -1,0 +1,388 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: openshift-tracing
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: openshift-tracing
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: openshift-tracing
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: openshift-tracing
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: openshift-tracing
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: platform
+  namespace: openshift-tracing
+spec:
+  observability:
+    metrics:
+      enableMetrics: true
+  config:
+    extensions:
+      bearertokenauth:
+        filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      jaeger:
+        protocols:
+          thrift_compact:
+            endpoint: 0.0.0.0:6831
+
+    connectors:
+      spanmetrics:
+        metrics_flush_interval: 5s # default: 1 min
+        dimensions:
+        - name: k8s.namespace.name
+
+    processors:
+      k8sattributes: {}
+
+    exporters:
+      otlp:
+        endpoint: tempo-platform-gateway.openshift-tracing.svc.cluster.local:8090
+        tls:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: platform
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        add_metric_suffixes: false
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
+
+    service:
+      extensions: [bearertokenauth]
+      pipelines:
+        traces:
+          receivers: [otlp, jaeger]
+          processors: [k8sattributes]
+          exporters: [otlp, spanmetrics]
+        metrics:
+          receivers: [spanmetrics]
+          processors: []
+          exporters: [prometheus]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-tracing-platform-collector
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+---
+# allow platform-collector to read namespaces, pods and replicasets (required for k8sattributes processor)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-tracing-platform-collector
+roleRef:
+  kind: ClusterRole
+  name: openshift-tracing-platform-collector
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: platform-collector
+  namespace: openshift-tracing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traces-writer-platform
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [platform]
+  resourceNames: [traces]
+  verbs: [create]
+---
+# allow platform-collector to write traces to the 'platform' tenant in Tempo
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traces-writer-platform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traces-writer-platform
+subjects:
+- kind: ServiceAccount
+  name: platform-collector
+  namespace: openshift-tracing
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: user
+  namespace: openshift-tracing
+spec:
+  observability:
+    metrics:
+      enableMetrics: true
+  config:
+    extensions:
+      bearertokenauth:
+        filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      jaeger:
+        protocols:
+          thrift_compact:
+            endpoint: 0.0.0.0:6831
+
+    connectors:
+      spanmetrics:
+        metrics_flush_interval: 5s # default: 1 min
+        dimensions:
+        - name: k8s.namespace.name
+
+    processors:
+      k8sattributes: {}
+
+    exporters:
+      otlp:
+        endpoint: tempo-platform-gateway.openshift-tracing.svc.cluster.local:8090
+        tls:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: user
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        add_metric_suffixes: false
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
+
+    service:
+      extensions: [bearertokenauth]
+      pipelines:
+        traces:
+          receivers: [otlp, jaeger]
+          processors: [k8sattributes]
+          exporters: [otlp, spanmetrics]
+        metrics:
+          receivers: [spanmetrics]
+          processors: []
+          exporters: [prometheus]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-tracing-user-collector
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+---
+# allow user-collector to read namespaces, pods and replicasets (required for k8sattributes processor)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-tracing-user-collector
+roleRef:
+  kind: ClusterRole
+  name: openshift-tracing-user-collector
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: user-collector
+  namespace: openshift-tracing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traces-writer-user
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [user]
+  resourceNames: [traces]
+  verbs: [create]
+---
+# allow user-collector to write traces to the 'user' tenant in Tempo
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traces-writer-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traces-writer-user
+subjects:
+- kind: ServiceAccount
+  name: user-collector
+  namespace: openshift-tracing
+---
+apiVersion: tempo.grafana.com/v1alpha1
+kind:  TempoStack
+metadata:
+  name: platform
+  namespace: openshift-tracing
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+  storageSize: 1Gi
+  tenants:
+    mode: openshift
+    authentication:
+    - tenantName: platform
+      tenantId: 1610b0c3-c509-4592-a256-a1871353dbfa
+    - tenantName: user
+      tenantId: 1610b0c3-c509-4592-a256-a1871353dbfb
+  observability:
+    tracing:
+      otlp_http_endpoint: http://platform-collector.openshift-tracing:4318
+      sampling_fraction: "1"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        monitorTab:
+          enabled: true
+          prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traces-reader-platform
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [platform]
+  resourceNames: [traces]
+  verbs: [get]
+---
+# allow any authenticated user to read traces from the 'platform' tenant in Tempo
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traces-reader-platform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traces-reader-platform
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traces-reader-user
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [user]
+  resourceNames: [traces]
+  verbs: [get]
+---
+# allow any authenticated user to read traces from the 'user' tenant in Tempo
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traces-reader-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traces-reader-user
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated

--- a/web/cypress/fixtures/coo/traces/tracing-apps.yaml
+++ b/web/cypress/fixtures/coo/traces/tracing-apps.yaml
@@ -1,0 +1,144 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-app-k6
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-app-hotrod
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-app-telemetrygen
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: hotrod
+  name: hotrod
+  namespace: tracing-app-hotrod
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hotrod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hotrod
+    spec:
+      containers:
+      - image: jaegertracing/example-hotrod:1.46
+        name: hotrod
+        args:
+        - all
+        - --otel-exporter=otlp
+        env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://user-collector.openshift-tracing:4318
+        ports:
+        - containerPort: 8080
+          name: frontend
+        - containerPort: 8081
+          name: customer
+        - containerPort: 8083
+          name: route
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100M
+          requests:
+            cpu: 100m
+            memory: 100M
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hotrod
+  namespace: tracing-app-hotrod
+spec:
+  selector:
+    app.kubernetes.io/name: hotrod
+  ports:
+  - name: frontend
+    port: 8080
+    targetPort: frontend
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hotrod
+  namespace: tracing-app-hotrod
+spec:
+  to:
+    kind: Service
+    name: hotrod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: k6-tracing
+  name: k6-tracing
+  namespace: tracing-app-k6
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k6-tracing
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k6-tracing
+    spec:
+      containers:
+      - name: k6-tracing
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
+        env:
+        - name: ENDPOINT
+          value: user-collector.openshift-tracing:4317
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: telemetrygen
+  name: telemetrygen
+  namespace: tracing-app-telemetrygen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: telemetrygen
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: telemetrygen
+    spec:
+      # in total 5 spans per second are generated, with 2/5 (40%) containing an error
+      containers:
+      # this generates 3 spans per second
+      - name: telemetrygen1
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.105.0
+        args:
+          - traces
+          - --otlp-endpoint=user-collector.openshift-tracing:4317
+          - --otlp-insecure
+          - --duration=1h
+          - --service=good_service
+          - --rate=3 # spans per second
+          - --child-spans=2
+      # this generates 2 spans per second with an error status
+      - name: telemetrygen2
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.105.0
+        args:
+          - traces
+          - --otlp-endpoint=user-collector.openshift-tracing:4317
+          - --otlp-insecure
+          - --duration=1h
+          - --service=faulty_service
+          - --rate=2 # spans per second
+          - --child-spans=1
+          - --status-code=Error

--- a/web/cypress/fixtures/coo/traces/tracing-ui-plugin.yaml
+++ b/web/cypress/fixtures/coo/traces/tracing-ui-plugin.yaml
@@ -1,0 +1,6 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: distributed-tracing
+spec:
+  type: DistributedTracing

--- a/web/cypress/fixtures/perses/perses-global-datasources.yaml
+++ b/web/cypress/fixtures/perses/perses-global-datasources.yaml
@@ -1,0 +1,79 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: thanos-querier-datasource
+spec:
+  config:
+    display:
+      name: "Thanos Querier Datasource"
+    default: true
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+            secret: thanos-querier-datasource-secret
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: file
+        certPath: /ca/service-ca.crt
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: loki-datasource
+spec:
+  config:
+    display:
+      name: "Loki Datasource (Application Logs)"
+    default: true
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            # URL structure for LokiStack with openshift-logging tenancy:
+            # https://{gateway-svc}.{ns}.svc:8080/api/logs/v1/{tenant}
+            # Perses will append /loki/api/v1/... for queries
+            url: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application
+            headers:
+              X-Scope-OrgID: application
+            # IMPORTANT: Must reference secret for TLS config
+            secret: loki-datasource-secret
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: file
+        certPath: /ca/service-ca.crt
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: tempo-platform
+spec:
+  config:
+    display:
+      name: "Tempo Datasource"
+    default: true
+    plugin:
+      kind: "TempoDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: https://tempo-platform-gateway.openshift-tracing.svc.cluster.local:8080/api/traces/v1/platform/tempo
+            headers:
+              X-Scope-OrgID: platform
+            secret: tempo-platform-secret
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: file
+        certPath: /ca/service-ca.crt

--- a/web/cypress/support/commands/auth-commands.ts
+++ b/web/cypress/support/commands/auth-commands.ts
@@ -164,6 +164,21 @@ export const operatorAuthUtils = {
     const envVars = [Cypress.env('SKIP_KBV_INSTALL'), Cypress.env('KBV_UI_INSTALL')];
     return [...baseKey, ...envVars.map((v) => v || '')];
   },
+
+  generateTracesLoggingSessionKey(
+    operatorType: string,
+    operator: { namespace: string; packageName: string },
+  ): string[] {
+    const baseKey = [
+      Cypress.env('LOGIN_IDP'),
+      Cypress.env('LOGIN_USERNAME'),
+      operatorType,
+      operator.namespace,
+      operator.packageName,
+    ];
+    const envVars = [Cypress.env('SKIP_COO_INSTALL')];
+    return [...baseKey, ...envVars.map((v) => v || '')];
+  },
 };
 
 // Core login function (used by both session and non-session versions)

--- a/web/cypress/support/commands/dashboards-commands.ts
+++ b/web/cypress/support/commands/dashboards-commands.ts
@@ -21,6 +21,7 @@ export const dashboardsUtils = {
       readyTimeoutMilliseconds,
     );
     cy.log(`Monitoring plugin pod is now running in namespace: ${MCP.namespace}`);
+    cy.checkForAlertRecursively();
   },
 
   setupDashboardsAndPlugins(MCP: { namespace: string }): void {
@@ -158,7 +159,7 @@ export const dashboardsUtils = {
       installTimeoutMilliseconds,
     );
     cy.log(`Korrel8r pod is now running in namespace: ${MCP.namespace}`);
-
+    cy.checkForAlertRecursively();
     cy.reload(true);
 
     // Dynamic plugins may take time to register after reload.

--- a/web/cypress/support/commands/perses-commands.ts
+++ b/web/cypress/support/commands/perses-commands.ts
@@ -16,6 +16,7 @@ const PERSES_TEST_DASHBOARD_NAME_PREFIXES = [
   'Dashboard to test rename',
   'Dashboard to test duplication',
   'DashboardToTestDuplication',
+  'Tempo Loki Perses Global Datasources',
 ];
 const PERSES_TEST_DASHBOARD_NAME_EXACT = [
   'Testing Perses dashboard - YAML',

--- a/web/cypress/support/commands/traces-logging-commands.ts
+++ b/web/cypress/support/commands/traces-logging-commands.ts
@@ -1,0 +1,1040 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import 'cypress-wait-until';
+import { operatorHubPage } from '../../views/operator-hub-page';
+import { nav } from '../../views/nav';
+import { operatorAuthUtils } from './auth-commands';
+
+export {};
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      beforeBlockOtel(OTEL: { namespace: string; packageName: string });
+      beforeBlockTempo(TEMPO: { namespace: string; packageName: string });
+      configureBase();
+      configureTracingApps();
+      installDistributeTracingUIPlugin();
+      waitForDistributeTracingUIPluginReady();
+
+      beforeBlockLoki(LOKI: { namespace: string; packageName: string });
+      beforeBlockLogging(CLO: { namespace: string; packageName: string });
+      configureLoggingLoki();
+      installLoggingUIPlugin();
+      waitForLoggingUIPluginReady();
+
+      cleanupOtel(OTEL: { namespace: string; packageName: string });
+      cleanupTempo(TEMPO: { namespace: string; packageName: string });
+      cleanupBase();
+      cleanupTracingApps();
+      cleanupTempoLokiThanosPersesGlobalDatasource();
+      cleanupDistributeTracingUIPlugin();
+      cleanupLoki(LOKI: { namespace: string; packageName: string });
+      cleanupLogging(CLO: { namespace: string; packageName: string });
+      cleanupLoggingLoki();
+      cleanupLoggingUIPlugin();
+      cleanupChainsawNamespaces();
+
+      createTempoLokiThanosPersesGlobalDatasource();
+    }
+  }
+}
+
+const readyTimeoutMilliseconds = Cypress.config('readyTimeoutMilliseconds') as number;
+const installTimeoutMilliseconds = Cypress.config('installTimeoutMilliseconds') as number;
+
+const useSession = String(Cypress.env('SESSION')).toLowerCase() === 'true';
+
+const DTP = {
+  namespace: Cypress.env('COO_NAMESPACE') || 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'distributed-tracing',
+  },
+};
+
+const LOGGING_PLUGIN = {
+  namespace: Cypress.env('COO_NAMESPACE') || 'openshift-cluster-observability-operator',
+  packageName: 'cluster-observability-operator',
+  operatorName: 'Cluster Observability Operator',
+  config: {
+    kind: 'UIPlugin',
+    name: 'logging',
+  },
+};
+
+const tracesUtils = {
+  installOtel(OTEL: { namespace: string; packageName: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping OpenTelemetry Operator installation.');
+      return;
+    }
+
+    cy.log('Install Red Hat build of OpenTelemetry');
+    operatorHubPage.installOperator(OTEL.packageName, 'redhat-operators');
+    cy.get('.co-clusterserviceversion-install__heading', {
+      timeout: installTimeoutMilliseconds,
+    }).should(($el) => {
+      const text = $el.text();
+      expect(text).to.satisfy(
+        (t: string) => t.includes('ready for use') || t.includes('Operator installed successfully'),
+      );
+    });
+  },
+
+  waitForOtelReady(OTEL: { namespace: string }): void {
+    cy.log('Check OpenTelemetry Operator status');
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.waitUntil(
+      () =>
+        cy
+          .exec(
+            `oc get pods -n ${OTEL.namespace} -o name --kubeconfig ${kubeconfig} ` +
+              '| grep opentelemetry',
+            { failOnNonZeroExit: false },
+          )
+          .then((result) => result.code === 0 && result.stdout.trim().length > 0),
+      {
+        timeout: readyTimeoutMilliseconds,
+        interval: 10000,
+        errorMsg: `OpenTelemetry operator pod not found in namespace ${OTEL.namespace}`,
+      },
+    );
+
+    cy.exec(
+      `oc get pods -n ${OTEL.namespace} -o name --kubeconfig ${kubeconfig} ` +
+        '| grep opentelemetry',
+    )
+      .its('stdout')
+      .then((podOutput) => {
+        const podName = podOutput.trim().split('\n')[0];
+        cy.log(`Found OpenTelemetry pod: ${podName}`);
+
+        cy.exec(
+          `oc wait --for=condition=Ready ${podName} -n ${OTEL.namespace} ` +
+            `--timeout=120s --kubeconfig ${kubeconfig}`,
+          { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: true },
+        ).then((result) => {
+          expect(result.code).to.eq(0);
+          cy.log(`OpenTelemetry operator pod is now running in namespace: ${OTEL.namespace}`);
+        });
+      });
+
+    cy.get('#page-sidebar').then(($sidebar) => {
+      const section = $sidebar.text().includes('Ecosystem') ? 'Ecosystem' : 'Operators';
+      nav.sidenav.clickNavLink([section, 'Installed Operators']);
+    });
+
+    cy.byTestID('name-filter-input').should('be.visible').type('OpenTelemetry{enter}');
+    cy.get('[data-test="status-text"]', { timeout: installTimeoutMilliseconds })
+      .eq(0)
+      .should('contain.text', 'Succeeded');
+  },
+
+  cleanupOtel(OTEL: { namespace: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping OpenTelemetry Operator cleanup.');
+      return;
+    }
+
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.log('Remove OpenTelemetry Operator');
+    cy.executeAndDelete(`oc delete namespace ${OTEL.namespace} --kubeconfig ${kubeconfig}`);
+  },
+
+  installTempo(TEMPO: { namespace: string; packageName: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Tempo Operator installation.');
+      return;
+    }
+
+    cy.log('Install Tempo Operator');
+    operatorHubPage.installOperator(TEMPO.packageName, 'redhat-operators');
+    cy.get('.co-clusterserviceversion-install__heading', {
+      timeout: installTimeoutMilliseconds,
+    }).should(($el) => {
+      const text = $el.text();
+      expect(text).to.satisfy(
+        (t: string) => t.includes('ready for use') || t.includes('Operator installed successfully'),
+      );
+    });
+  },
+
+  waitForTempoReady(TEMPO: { namespace: string }): void {
+    cy.log('Check Tempo Operator status');
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.waitUntil(
+      () =>
+        cy
+          .exec(
+            `oc get pods -n ${TEMPO.namespace} -o name --kubeconfig ${kubeconfig} ` +
+              '| grep tempo',
+            { failOnNonZeroExit: false },
+          )
+          .then((result) => result.code === 0 && result.stdout.trim().length > 0),
+      {
+        timeout: readyTimeoutMilliseconds,
+        interval: 10000,
+        errorMsg: `Tempo operator pod not found in namespace ${TEMPO.namespace}`,
+      },
+    );
+
+    cy.exec(
+      `oc get pods -n ${TEMPO.namespace} -o name --kubeconfig ${kubeconfig} ` + '| grep tempo',
+    )
+      .its('stdout')
+      .then((podOutput) => {
+        const podName = podOutput.trim().split('\n')[0];
+        cy.log(`Found Tempo pod: ${podName}`);
+
+        cy.exec(
+          `oc wait --for=condition=Ready ${podName} -n ${TEMPO.namespace} ` +
+            `--timeout=120s --kubeconfig ${kubeconfig}`,
+          { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: true },
+        ).then((result) => {
+          expect(result.code).to.eq(0);
+          cy.log(`Tempo operator pod is now running in namespace: ${TEMPO.namespace}`);
+        });
+      });
+
+    cy.get('#page-sidebar').then(($sidebar) => {
+      const section = $sidebar.text().includes('Ecosystem') ? 'Ecosystem' : 'Operators';
+      nav.sidenav.clickNavLink([section, 'Installed Operators']);
+    });
+
+    cy.byTestID('name-filter-input').should('be.visible').type('Tempo{enter}');
+    cy.get('[data-test="status-text"]', { timeout: installTimeoutMilliseconds })
+      .eq(0)
+      .should('contain.text', 'Succeeded');
+  },
+
+  cleanupTempo(TEMPO: { namespace: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Tempo Operator cleanup.');
+      return;
+    }
+
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.log('Delete Tempo Operator namespace');
+    cy.executeAndDelete(`oc delete namespace ${TEMPO.namespace} --kubeconfig ${kubeconfig}`);
+
+    cy.log('Delete Tempo Operator resource');
+    cy.exec(`oc delete operator tempo-product.${TEMPO.namespace} --kubeconfig ${kubeconfig}`, {
+      timeout: readyTimeoutMilliseconds,
+      failOnNonZeroExit: false,
+    });
+
+    cy.log('Delete Tempo CustomResourceDefinitions');
+    const tempoCRs = ['tempomonolithics.tempo.grafana.com', 'tempostacks.tempo.grafana.com'];
+    tempoCRs.forEach((cr) => {
+      cy.exec(
+        `oc get ${cr} -A -o name --kubeconfig ${kubeconfig} 2>/dev/null` +
+          ` | xargs --no-run-if-empty -I {} sh -c` +
+          ` 'oc patch {} -A --type=merge -p "{\\"metadata\\":{\\"finalizers\\":[]}}"` +
+          ` --kubeconfig ${kubeconfig} 2>/dev/null; oc delete {} -A --force --grace-period=0` +
+          ` --kubeconfig ${kubeconfig} 2>/dev/null' || true`,
+        { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: false },
+      );
+      cy.exec(
+        `oc patch crd ${cr} -p '{"metadata":{"finalizers":[]}}' ` +
+          `--type=merge --kubeconfig ${kubeconfig}`,
+        { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: false },
+      );
+      cy.exec(
+        `oc delete crd ${cr} --force --grace-period=0 ` +
+          `--wait=false --ignore-not-found --kubeconfig ${kubeconfig}`,
+        { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: false },
+      );
+    });
+  },
+
+  cleanupChainsawNamespaces(): void {
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.log('Delete Chainsaw namespaces if they exist');
+    cy.exec(
+      `for ns in $(oc get projects -o name --kubeconfig ${kubeconfig} ` +
+        '| grep "chainsaw-" | sed \'s|project.project.openshift.io/||\'); do ' +
+        // eslint-disable-next-line max-len
+        `oc get opentelemetrycollectors.opentelemetry.io,tempostacks.tempo.grafana.com,tempomonolithics.tempo.grafana.com,pvc ` +
+        `-n $ns -o name --kubeconfig ${kubeconfig} 2>/dev/null ` +
+        `| xargs --no-run-if-empty -I {} oc patch {} -n $ns --type merge ` +
+        `-p '{"metadata":{"finalizers":[]}}' --kubeconfig ${kubeconfig} 2>/dev/null || true; ` +
+        `oc delete project $ns --kubeconfig ${kubeconfig} || true; done`,
+      {
+        timeout: 300000,
+        failOnNonZeroExit: false,
+      },
+    );
+  },
+
+  installDistributeTracingUIPlugin(): void {
+    cy.log('Create Distributed Tracing UI Plugin instance.');
+    cy.exec(
+      `oc apply -f ./cypress/fixtures/coo/traces/tracing-ui-plugin.yaml --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+    );
+    cy.exec(
+      // eslint-disable-next-line max-len
+      `sleep 15 && oc wait --for=condition=Ready pods --selector=app.kubernetes.io/instance=distributed-tracing -n ${
+        DTP.namespace
+      } --timeout=60s --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+      {
+        timeout: 80000,
+        failOnNonZeroExit: true,
+      },
+    ).then((result) => {
+      expect(result.code).to.eq(0);
+      cy.log(
+        `Distributed Tracing Console plugin pod is now running in namespace: ${DTP.namespace}`,
+      );
+    });
+    // Check for web console update alert for up to 2 minutes
+    // (especially important for Hypershift clusters)
+    cy.log('Checking for web console update alert for up to 2 minutes...');
+    cy.checkForAlertRecursively();
+  },
+
+  waitForDistributeTracingUIPluginReady(): void {
+    cy.visit('/observe/traces');
+    cy.url().should('include', '/observe/traces');
+    cy.get('body').should('be.visible');
+    // Wait for the page to fully render
+    cy.wait(3000);
+  },
+
+  cleanupDistributeTracingUIPlugin(): void {
+    cy.log('Cleanup Distributed Tracing UI Plugin');
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Distributed Tracing UI Plugin cleanup.');
+      return;
+    }
+    cy.exec(
+      `oc delete ${DTP.config.kind} ${DTP.config.name} --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.log('Cleanup Distributed Tracing UI Plugin completed');
+  },
+
+  configureBase(): void {
+    cy.log('Configure Tempo');
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Tempo configuration.');
+      return;
+    }
+    const kc = Cypress.env('KUBECONFIG_PATH');
+    const savedStatePath = 'cypress/fixtures/coo/traces/.original-monitoring-config.json';
+
+    // Read and store the existing enableUserWorkload value, then patch
+    cy.exec(
+      `oc get configmap cluster-monitoring-config -n openshift-monitoring
+      -o jsonpath='{.data["config.yaml"]}' --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    ).then((result) => {
+      const configMapExists = result.code === 0;
+      const originalConfigYaml = configMapExists ? result.stdout : '';
+
+      // Save original state for cleanup restoration
+      cy.writeFile(savedStatePath, {
+        existed: configMapExists,
+        configYaml: originalConfigYaml,
+      });
+
+      if (!configMapExists) {
+        // ConfigMap doesn't exist, create it with just the needed setting
+        cy.exec(
+          `oc create configmap cluster-monitoring-config -n openshift-monitoring ` +
+            `--from-literal=config.yaml='enableUserWorkload: true' --kubeconfig ${kc}`,
+          { failOnNonZeroExit: false },
+        );
+      } else if (!originalConfigYaml.includes('enableUserWorkload: true')) {
+        // Patch existing ConfigMap to set enableUserWorkload: true
+        let newConfig: string;
+        if (originalConfigYaml.includes('enableUserWorkload')) {
+          newConfig = originalConfigYaml.replace(
+            /enableUserWorkload:.*/,
+            'enableUserWorkload: true',
+          );
+        } else {
+          newConfig = originalConfigYaml
+            ? `enableUserWorkload: true\n${originalConfigYaml}`
+            : 'enableUserWorkload: true';
+        }
+        const patch = JSON.stringify({
+          data: { 'config.yaml': newConfig },
+        });
+        cy.exec(
+          `oc patch configmap cluster-monitoring-config -n openshift-monitoring ` +
+            `--type merge -p '${patch}' --kubeconfig ${kc}`,
+          { failOnNonZeroExit: false },
+        );
+      }
+    });
+
+    // Apply the rest of base.yaml (no longer contains cluster-monitoring-config)
+    cy.exec(`oc apply -f ./cypress/fixtures/coo/traces/base.yaml --kubeconfig ${kc}`, {
+      failOnNonZeroExit: false,
+    });
+  },
+
+  cleanupBase(): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Base cleanup.');
+      return;
+    }
+    const kc = Cypress.env('KUBECONFIG_PATH');
+    const savedStatePath = 'cypress/fixtures/coo/traces/.original-monitoring-config.json';
+
+    // Restore cluster-monitoring-config if we saved its original state
+    cy.exec(`test -f ${savedStatePath}`, {
+      failOnNonZeroExit: false,
+    }).then((testResult) => {
+      if (testResult.code === 0) {
+        cy.readFile(savedStatePath).then((original: { existed: boolean; configYaml: string }) => {
+          if (!original.existed) {
+            // ConfigMap didn't exist before we created it, so delete it
+            cy.exec(
+              `oc delete configmap cluster-monitoring-config
+              -n openshift-monitoring --kubeconfig ${kc}`,
+              { failOnNonZeroExit: false },
+            );
+          } else {
+            // Restore original config.yaml value
+            const patch = JSON.stringify({
+              data: { 'config.yaml': original.configYaml },
+            });
+            cy.exec(
+              `oc patch configmap cluster-monitoring-config -n openshift-monitoring ` +
+                `--type merge -p '${patch}' --kubeconfig ${kc}`,
+              { failOnNonZeroExit: false },
+            );
+          }
+          // Clean up the saved state file
+          cy.exec(`rm -f ${savedStatePath}`, {
+            failOnNonZeroExit: false,
+          });
+        });
+      }
+    });
+
+    // Delete the rest of base.yaml resources
+    cy.exec(`oc delete -f ./cypress/fixtures/coo/traces/base.yaml --kubeconfig ${kc}`, {
+      failOnNonZeroExit: false,
+      timeout: installTimeoutMilliseconds,
+    });
+  },
+
+  configureTracingApps(): void {
+    cy.log('Configure Tracing Apps');
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Tracing Apps configuration.');
+      return;
+    }
+    cy.exec(
+      `oc apply -f ./cypress/fixtures/coo/traces/tracing-apps.yaml --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+      { failOnNonZeroExit: false },
+    );
+  },
+
+  cleanupTracingApps(): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Tracing Apps cleanup.');
+      return;
+    }
+    cy.exec(
+      `oc delete -f ./cypress/fixtures/coo/traces/tracing-apps.yaml --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+      { failOnNonZeroExit: false },
+    );
+  },
+};
+
+const loggingUtils = {
+  installLoki(LOKI: { namespace: string; packageName: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Loki Operator installation.');
+      return;
+    }
+
+    cy.log('Install Loki Operator');
+    operatorHubPage.installOperator(LOKI.packageName, 'redhat-operators');
+    cy.get('.co-clusterserviceversion-install__heading', {
+      timeout: installTimeoutMilliseconds,
+    }).should(($el) => {
+      const text = $el.text();
+      expect(text).to.satisfy(
+        (t: string) => t.includes('ready for use') || t.includes('Operator installed successfully'),
+      );
+    });
+  },
+
+  cleanupLoki(LOKI: { namespace: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Loki Operator cleanup.');
+      return;
+    }
+
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.log('Delete Loki Operator namespace');
+    cy.executeAndDelete(`oc delete namespace ${LOKI.namespace} --kubeconfig ${kubeconfig}`);
+
+    cy.log('Delete Loki Operator resource');
+    cy.executeAndDelete(
+      `oc delete operator loki-operator.${LOKI.namespace} --kubeconfig ${kubeconfig}`,
+    );
+
+    cy.log('Delete Loki CustomResourceDefinitions');
+    cy.executeAndDelete(
+      `oc delete customresourcedefinitions.apiextensions.k8s.io ` +
+        `lokistacks.loki.grafana.com --ignore-not-found --kubeconfig ${kubeconfig}`,
+    );
+
+    cy.log('Delete Loki Operator CRDs');
+    cy.executeAndDelete(
+      `oc delete crds lokistacks.loki.grafana.com --ignore-not-found --kubeconfig ${kubeconfig}`,
+    );
+  },
+
+  installLogging(CLO: { namespace: string; packageName: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Logging Operator installation.');
+      return;
+    }
+
+    cy.log('Install Logging Operator');
+    operatorHubPage.installOperator(CLO.packageName, 'redhat-operators');
+    cy.get('.co-clusterserviceversion-install__heading', {
+      timeout: installTimeoutMilliseconds,
+    }).should(($el) => {
+      const text = $el.text();
+      expect(text).to.satisfy(
+        (t: string) => t.includes('ready for use') || t.includes('Create initialization resource'),
+      );
+    });
+  },
+
+  cleanupLogging(CLO: { namespace: string }): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Logging Operator cleanup.');
+      return;
+    }
+
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.log('Delete Logging Operator namespace');
+    cy.executeAndDelete(`oc delete namespace ${CLO.namespace} --kubeconfig ${kubeconfig}`);
+
+    cy.log('Delete Logging Operator resource');
+    cy.executeAndDelete(
+      `oc delete operator cluster-logging.${CLO.namespace} --kubeconfig ${kubeconfig}`,
+    );
+
+    cy.log('Delete Logging CustomResourceDefinitions');
+    cy.executeAndDelete(
+      `oc delete customresourcedefinitions.apiextensions.k8s.io ` +
+        `logging.openshift.io --ignore-not-found --kubeconfig ${kubeconfig}`,
+    );
+
+    cy.log('Delete Logging Operator CRDs');
+    cy.executeAndDelete(
+      `oc delete crds logging.openshift.io --ignore-not-found --kubeconfig ${kubeconfig}`,
+    );
+  },
+
+  waitForLokiReady(LOKI: { namespace: string }): void {
+    cy.log('Check Loki Operator status');
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.waitUntil(
+      () =>
+        cy
+          .exec(
+            `oc get pods -n ${LOKI.namespace} -o name --kubeconfig ${kubeconfig} ` + '| grep loki',
+            { failOnNonZeroExit: false },
+          )
+          .then((result) => result.code === 0 && result.stdout.trim().length > 0),
+      {
+        timeout: readyTimeoutMilliseconds,
+        interval: 10000,
+        errorMsg: `Loki operator pod not found in namespace ${LOKI.namespace}`,
+      },
+    );
+
+    cy.exec(`oc get pods -n ${LOKI.namespace} -o name --kubeconfig ${kubeconfig} ` + '| grep loki')
+      .its('stdout')
+      .then((podOutput) => {
+        const podName = podOutput.trim().split('\n')[0];
+        cy.log(`Found Loki pod: ${podName}`);
+
+        cy.exec(
+          `oc wait --for=condition=Ready ${podName} -n ${LOKI.namespace} ` +
+            `--timeout=120s --kubeconfig ${kubeconfig}`,
+          { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: true },
+        ).then((result) => {
+          expect(result.code).to.eq(0);
+          cy.log(`Loki operator pod is now running in namespace: ${LOKI.namespace}`);
+        });
+      });
+
+    cy.get('#page-sidebar').then(($sidebar) => {
+      const section = $sidebar.text().includes('Ecosystem') ? 'Ecosystem' : 'Operators';
+      nav.sidenav.clickNavLink([section, 'Installed Operators']);
+    });
+
+    cy.byTestID('name-filter-input').should('be.visible').type('Loki{enter}');
+    cy.get('[data-test="status-text"]', { timeout: installTimeoutMilliseconds })
+      .eq(0)
+      .should('contain.text', 'Succeeded');
+  },
+
+  waitForLoggingReady(CLO: { namespace: string }): void {
+    cy.log('Check Logging Operator status');
+    const kubeconfig = Cypress.env('KUBECONFIG_PATH');
+
+    cy.waitUntil(
+      () =>
+        cy
+          .exec(
+            `oc get pods -n ${CLO.namespace} -o name --kubeconfig ${kubeconfig} ` +
+              '| grep logging',
+            { failOnNonZeroExit: false },
+          )
+          .then((result) => result.code === 0 && result.stdout.trim().length > 0),
+      {
+        timeout: readyTimeoutMilliseconds,
+        interval: 10000,
+        errorMsg: `Logging operator pod not found in namespace ${CLO.namespace}`,
+      },
+    );
+
+    cy.exec(
+      `oc get pods -n ${CLO.namespace} -o name --kubeconfig ${kubeconfig} ` + '| grep logging',
+    )
+      .its('stdout')
+      .then((podOutput) => {
+        const podName = podOutput.trim().split('\n')[0];
+        cy.log(`Found Logging pod: ${podName}`);
+
+        cy.exec(
+          `oc wait --for=condition=Ready ${podName} -n ${CLO.namespace} ` +
+            `--timeout=120s --kubeconfig ${kubeconfig}`,
+          { timeout: readyTimeoutMilliseconds, failOnNonZeroExit: true },
+        ).then((result) => {
+          expect(result.code).to.eq(0);
+          cy.log(`Logging operator pod is now running in namespace: ${CLO.namespace}`);
+        });
+      });
+
+    cy.get('#page-sidebar').then(($sidebar) => {
+      const section = $sidebar.text().includes('Ecosystem') ? 'Ecosystem' : 'Operators';
+      nav.sidenav.clickNavLink([section, 'Installed Operators']);
+    });
+
+    cy.byTestID('name-filter-input').should('be.visible').type('Logging{enter}');
+    cy.get('[data-test="status-text"]', { timeout: installTimeoutMilliseconds })
+      .eq(0)
+      .should('contain.text', 'Succeeded');
+  },
+
+  installLoggingUIPlugin(): void {
+    cy.log('Install Logging UI Plugin');
+    cy.exec(
+      `oc apply -f ./cypress/fixtures/coo/logging/logging-ui-plugin.yaml --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+    );
+    cy.log('Install Logging UI Plugin completed');
+
+    cy.exec(
+      // eslint-disable-next-line max-len
+      `sleep 15 && oc wait --for=condition=Ready pods --selector=app.kubernetes.io/instance=logging -n ${
+        LOGGING_PLUGIN.namespace
+      } --timeout=60s --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+      {
+        timeout: 80000,
+        failOnNonZeroExit: true,
+      },
+    ).then((result) => {
+      expect(result.code).to.eq(0);
+      cy.log(`Logging UI Plugin pod is now running in namespace: ${LOGGING_PLUGIN.namespace}`);
+    });
+    // Check for web console update alert for up to 2 minutes
+    // (especially important for Hypershift clusters)
+    cy.log('Checking for web console update alert for up to 2 minutes...');
+    cy.checkForAlertRecursively();
+    cy.log('Logging UI Plugin installed successfully');
+  },
+
+  waitForLoggingUIPluginReady(): void {
+    cy.visit('/monitoring/logs');
+    cy.url().should('include', '/monitoring/logs');
+    cy.get('body').should('be.visible');
+    // Wait for the page to fully render
+    cy.wait(3000);
+  },
+
+  cleanupLoggingUIPlugin(): void {
+    cy.log('Cleanup Logging UI Plugin');
+    cy.exec(
+      `oc delete ${LOGGING_PLUGIN.config.kind} ${
+        LOGGING_PLUGIN.config.name
+      } --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.log('Cleanup Logging UI Plugin completed');
+  },
+
+  configureLoggingLoki(): void {
+    cy.log('Configure Logging Loki');
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Logging Loki configuration.');
+      return;
+    }
+    const kc = Cypress.env('KUBECONFIG_PATH');
+    cy.exec(`oc apply -f ./cypress/fixtures/coo/logging/base.yaml --kubeconfig ${kc}`, {
+      failOnNonZeroExit: false,
+    });
+    cy.exec(`oc project openshift-logging --kubeconfig ${kc}`);
+    cy.exec(`oc create sa collector -n openshift-logging --kubeconfig ${kc}`, {
+      failOnNonZeroExit: false,
+    });
+    cy.exec(
+      `oc adm policy add-cluster-role-to-user logging-collector-logs-writer ` +
+        `-z collector --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.exec(
+      `oc adm policy add-cluster-role-to-user collect-application-logs ` +
+        `-z collector --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.exec(
+      `oc adm policy add-cluster-role-to-user collect-audit-logs ` +
+        `-z collector --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.exec(
+      `oc adm policy add-cluster-role-to-user collect-infrastructure-logs ` +
+        `-z collector --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+
+    cy.exec(`./cypress/fixtures/coo/logging/make-resources.sh`, {
+      env: {
+        KUBECONFIG: Cypress.env('KUBECONFIG_PATH'),
+      },
+      timeout: installTimeoutMilliseconds,
+      failOnNonZeroExit: false,
+    });
+
+    cy.log('Configure Logging Loki completed');
+  },
+
+  cleanupLoggingLoki(): void {
+    cy.log('Cleanup Logging Loki');
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log('SKIP_COO_INSTALL is set. Skipping Logging Loki cleanup.');
+      return;
+    }
+    cy.exec(
+      `oc delete -f ./cypress/fixtures/coo/logging/base.yaml --kubeconfig ${Cypress.env(
+        'KUBECONFIG_PATH',
+      )}`,
+      { failOnNonZeroExit: false },
+    );
+    cy.exec(`./cypress/fixtures/coo/logging/make-clean-resources.sh`, {
+      env: {
+        KUBECONFIG: Cypress.env('KUBECONFIG_PATH'),
+      },
+      timeout: installTimeoutMilliseconds,
+      failOnNonZeroExit: false,
+    });
+    cy.log('Cleanup Logging Loki completed');
+  },
+};
+
+const persesUtils = {
+  createTempoLokiThanosPersesGlobalDatasource(): void {
+    cy.log('Create Tempo Loki Thanos Perses Global Datasource');
+    const kc = Cypress.env('KUBECONFIG_PATH');
+    cy.exec(
+      `oc apply -f ./cypress/fixtures/perses/perses-global-datasources.yaml --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+  },
+
+  cleanupTempoLokiThanosPersesGlobalDatasource(): void {
+    if (Cypress.env('SKIP_COO_INSTALL')) {
+      cy.log(
+        'SKIP_COO_INSTALL is set. Skipping Tempo Loki Thanos Perses Global Datasource cleanup.',
+      );
+      return;
+    }
+    const kc = Cypress.env('KUBECONFIG_PATH');
+    cy.exec(
+      `oc delete -f ./cypress/fixtures/perses/perses-global-datasources.yaml --kubeconfig ${kc}`,
+      { failOnNonZeroExit: false },
+    );
+  },
+};
+
+// ── Cypress commands ───────────────────────────────────────────────
+
+Cypress.Commands.add('beforeBlockOtel', (OTEL: { namespace: string; packageName: string }) => {
+  if (useSession) {
+    const sessionKey = operatorAuthUtils.generateTracesLoggingSessionKey('otel', OTEL);
+    cy.session(
+      sessionKey,
+      () => {
+        cy.log('Before block OpenTelemetry (session)');
+        cy.cleanupOtel(OTEL);
+        operatorAuthUtils.loginAndAuthNoSession();
+        tracesUtils.installOtel(OTEL);
+        tracesUtils.waitForOtelReady(OTEL);
+        cy.log('Before block OpenTelemetry (session) completed');
+      },
+      {
+        cacheAcrossSpecs: true,
+        validate() {
+          cy.validateLogin();
+        },
+      },
+    );
+  } else {
+    cy.log('Before block OpenTelemetry (no session)');
+    cy.cleanupOtel(OTEL);
+    operatorAuthUtils.loginAndAuth();
+    tracesUtils.installOtel(OTEL);
+    tracesUtils.waitForOtelReady(OTEL);
+    cy.log('Before block OpenTelemetry (no session) completed');
+  }
+});
+
+Cypress.Commands.add('beforeBlockTempo', (TEMPO: { namespace: string; packageName: string }) => {
+  if (useSession) {
+    const sessionKey = operatorAuthUtils.generateTracesLoggingSessionKey('tempo', TEMPO);
+    cy.session(
+      sessionKey,
+      () => {
+        cy.log('Before block Tempo (session)');
+        cy.cleanupTempoLokiThanosPersesGlobalDatasource();
+        cy.cleanupBase();
+        cy.cleanupTracingApps();
+        cy.cleanupTempo(TEMPO);
+        tracesUtils.cleanupChainsawNamespaces();
+        operatorAuthUtils.loginAndAuthNoSession();
+        tracesUtils.installTempo(TEMPO);
+        tracesUtils.waitForTempoReady(TEMPO);
+        cy.log('Before block Tempo (session) completed');
+      },
+      {
+        cacheAcrossSpecs: true,
+        validate() {
+          cy.validateLogin();
+        },
+      },
+    );
+  } else {
+    cy.log('Before block Tempo (no session)');
+    cy.cleanupTempoLokiThanosPersesGlobalDatasource();
+    cy.cleanupBase();
+    cy.cleanupTracingApps();
+    cy.cleanupTempo(TEMPO);
+    tracesUtils.cleanupChainsawNamespaces();
+    operatorAuthUtils.loginAndAuth();
+    tracesUtils.installTempo(TEMPO);
+    tracesUtils.waitForTempoReady(TEMPO);
+    cy.log('Before block Tempo (no session) completed');
+  }
+});
+
+Cypress.Commands.add('beforeBlockLoki', (LOKI: { namespace: string; packageName: string }) => {
+  if (useSession) {
+    const sessionKey = operatorAuthUtils.generateTracesLoggingSessionKey('loki', LOKI);
+    cy.session(
+      sessionKey,
+      () => {
+        cy.log('Before block Loki (session)');
+        cy.cleanupLoggingLoki();
+        cy.cleanupLoki(LOKI);
+        operatorAuthUtils.loginAndAuthNoSession();
+        loggingUtils.installLoki(LOKI);
+        loggingUtils.waitForLokiReady(LOKI);
+        cy.log('Before block Loki (session) completed');
+      },
+      {
+        cacheAcrossSpecs: true,
+        validate() {
+          cy.validateLogin();
+        },
+      },
+    );
+  } else {
+    cy.log('Before block Loki (no session)');
+    cy.cleanupLoggingLoki();
+    cy.cleanupLoki(LOKI);
+    operatorAuthUtils.loginAndAuth();
+    loggingUtils.installLoki(LOKI);
+    loggingUtils.waitForLokiReady(LOKI);
+    cy.log('Before block Loki (no session) completed');
+  }
+});
+
+Cypress.Commands.add('beforeBlockLogging', (CLO: { namespace: string; packageName: string }) => {
+  if (useSession) {
+    const sessionKey = operatorAuthUtils.generateTracesLoggingSessionKey('logging', CLO);
+    cy.session(
+      sessionKey,
+      () => {
+        cy.log('Before block Logging (session)');
+        cy.cleanupLogging(CLO);
+        cy.cleanupLoggingLoki();
+        operatorAuthUtils.loginAndAuthNoSession();
+        loggingUtils.installLogging(CLO);
+        loggingUtils.waitForLoggingReady(CLO);
+        cy.log('Before block Logging (session) completed');
+      },
+      {
+        cacheAcrossSpecs: true,
+        validate() {
+          cy.validateLogin();
+        },
+      },
+    );
+  } else {
+    cy.log('Before block Logging (no session)');
+    cy.cleanupLogging(CLO);
+    cy.cleanupLoggingLoki();
+    operatorAuthUtils.loginAndAuth();
+    loggingUtils.installLogging(CLO);
+    loggingUtils.waitForLoggingReady(CLO);
+    cy.log('Before block Logging (no session) completed');
+  }
+});
+
+Cypress.Commands.add('cleanupOtel', (OTEL: { namespace: string; packageName: string }) => {
+  cy.log('Cleanup OpenTelemetry');
+  tracesUtils.cleanupOtel(OTEL);
+  cy.log('Cleanup OpenTelemetry completed');
+});
+
+Cypress.Commands.add('cleanupTempo', (TEMPO: { namespace: string; packageName: string }) => {
+  cy.log('Cleanup Tempo');
+  tracesUtils.cleanupTempo(TEMPO);
+  cy.log('Cleanup Tempo completed');
+});
+
+Cypress.Commands.add('cleanupLoki', (LOKI: { namespace: string; packageName: string }) => {
+  cy.log('Cleanup Loki');
+  loggingUtils.cleanupLoki(LOKI);
+  cy.log('Cleanup Loki completed');
+});
+
+Cypress.Commands.add('cleanupLogging', (CLO: { namespace: string; packageName: string }) => {
+  cy.log('Cleanup Logging Operator');
+  loggingUtils.cleanupLogging(CLO);
+  cy.log('Cleanup Logging Operator completed');
+});
+
+Cypress.Commands.add('cleanupChainsawNamespaces', () => {
+  cy.log('Cleanup Chainsaw namespaces');
+  tracesUtils.cleanupChainsawNamespaces();
+  cy.log('Cleanup Chainsaw namespaces completed');
+});
+
+Cypress.Commands.add('configureBase', () => {
+  cy.log('Configure Base');
+  tracesUtils.configureBase();
+  cy.log('Configure Base completed');
+});
+
+Cypress.Commands.add('cleanupBase', () => {
+  cy.log('Cleanup Base');
+  tracesUtils.cleanupBase();
+  cy.log('Cleanup Base completed');
+});
+
+Cypress.Commands.add('configureTracingApps', () => {
+  cy.log('Configure Tracing Apps');
+  tracesUtils.configureTracingApps();
+  cy.log('Configure Tracing Apps completed');
+});
+
+Cypress.Commands.add('cleanupTracingApps', () => {
+  cy.log('Cleanup Tracing Apps');
+  tracesUtils.cleanupTracingApps();
+  cy.log('Cleanup Tracing Apps completed');
+});
+
+Cypress.Commands.add('installDistributeTracingUIPlugin', () => {
+  cy.log('Install Distributed Tracing UI Plugin');
+  tracesUtils.installDistributeTracingUIPlugin();
+  cy.log('Install Distributed Tracing UI Plugin completed');
+});
+
+Cypress.Commands.add('installLoggingUIPlugin', () => {
+  cy.log('Install Logging UI Plugin');
+  loggingUtils.installLoggingUIPlugin();
+  cy.log('Install Logging UI Plugin completed');
+});
+
+Cypress.Commands.add('configureLoggingLoki', () => {
+  cy.log('Configure Logging Loki');
+  loggingUtils.configureLoggingLoki();
+  cy.log('Configure Logging Loki completed');
+});
+
+Cypress.Commands.add('cleanupLoggingLoki', () => {
+  cy.log('Cleanup Logging Loki');
+  loggingUtils.cleanupLoggingLoki();
+  cy.log('Cleanup Logging Loki completed');
+});
+
+Cypress.Commands.add('cleanupDistributeTracingUIPlugin', () => {
+  cy.log('Cleanup Distributed Tracing UI Plugin');
+  tracesUtils.cleanupDistributeTracingUIPlugin();
+  cy.log('Cleanup Distributed Tracing UI Plugin completed');
+});
+
+Cypress.Commands.add('cleanupLoggingUIPlugin', () => {
+  cy.log('Cleanup Logging UI Plugin');
+  loggingUtils.cleanupLoggingUIPlugin();
+  cy.log('Cleanup Logging UI Plugin completed');
+});
+
+Cypress.Commands.add('waitForDistributeTracingUIPluginReady', () => {
+  cy.log('WaitFor Distributed Tracing UI Plugin Ready');
+  tracesUtils.waitForDistributeTracingUIPluginReady();
+  cy.log('WaitFor Distributed Tracing UI Plugin Ready completed');
+});
+
+Cypress.Commands.add('waitForLoggingUIPluginReady', () => {
+  cy.log('WaitFor Logging UI Plugin Ready');
+  loggingUtils.waitForLoggingUIPluginReady();
+  cy.log('WaitFor Logging UI Plugin Ready completed');
+});
+
+Cypress.Commands.add('createTempoLokiThanosPersesGlobalDatasource', () => {
+  cy.log('Create Tempo Loki Thanos Perses Global Datasource');
+  persesUtils.createTempoLokiThanosPersesGlobalDatasource();
+  cy.log('Create Tempo Loki Thanos Perses Global Datasource completed');
+});
+
+Cypress.Commands.add('cleanupTempoLokiThanosPersesGlobalDatasource', () => {
+  cy.log('Cleanup Tempo Loki Thanos Perses Global Datasource');
+  persesUtils.cleanupTempoLokiThanosPersesGlobalDatasource();
+  cy.log('Cleanup Tempo Loki Thanos Perses Global Datasource completed');
+});

--- a/web/cypress/support/commands/utility-commands.ts
+++ b/web/cypress/support/commands/utility-commands.ts
@@ -14,6 +14,7 @@ declare global {
       aboutModal(): Chainable<Element>;
       podImage(pod: string, namespace: string): Chainable<Element>;
       assertNamespace(namespace: string, exists: boolean): Chainable<Element>;
+      checkForAlertRecursively(attemptsLeft?: number): Chainable<Element>;
     }
   }
 }
@@ -249,6 +250,28 @@ Cypress.Commands.add('assertNamespace', (namespace: string, exists: boolean) => 
         .scrollIntoView()
         .should('be.visible')
         .click({ force: true });
+    }
+  });
+});
+
+Cypress.Commands.add('checkForAlertRecursively', (attemptsLeft = 24) => {
+  cy.get('body', { timeout: 10000 }).then(($body) => {
+    if (
+      $body.find('.pf-v5-c-alert, .pf-v6-c-alert').length > 0 &&
+      $body.text().includes('Web console update is available')
+    ) {
+      cy.log('Web console update alert found');
+      cy.get('.pf-v5-c-alert, .pf-v6-c-alert')
+        .contains('Web console update is available')
+        .should('exist');
+    } else if (attemptsLeft > 0) {
+      cy.log(
+        `Alert not found, checking again in 5 seconds... (${attemptsLeft} attempts remaining)`,
+      );
+      cy.wait(5000);
+      cy.checkForAlertRecursively(attemptsLeft - 1);
+    } else {
+      cy.log('No web console update alert found after 2 minutes, continuing...');
     }
   });
 });

--- a/web/cypress/support/index.ts
+++ b/web/cypress/support/index.ts
@@ -12,6 +12,7 @@ import './commands/utility-commands';
 import './incidents_prometheus_query_mocks';
 import './commands/virtualization-commands';
 import './commands/perses-commands';
+import './commands/traces-logging-commands';
 
 export const checkErrors = () =>
   cy.window().then((win) => {
@@ -31,7 +32,8 @@ Cypress.on('uncaught:exception', (err) => {
     message.includes('Bad Gateway') ||
     message.includes(`Cannot read properties of null (reading 'default')`) ||
     message.includes(`(intermediate value) is not a function`) ||
-    message.includes(`Cannot read properties of null (reading '0')`)
+    message.includes(`Cannot read properties of null (reading '0')`) ||
+    message.includes(`load_plugin_entry`)
   ) {
     // eslint-disable-next-line no-console
     console.warn('Ignored frontend exception:', err.message);

--- a/web/cypress/support/perses/05.coo_create_import_perses_admin.cy.ts
+++ b/web/cypress/support/perses/05.coo_create_import_perses_admin.cy.ts
@@ -1,0 +1,156 @@
+import { listPersesDashboardsPage } from '../../views/perses-dashboards-list-dashboards';
+import { persesDashboardsPage } from '../../views/perses-dashboards';
+import { persesDashboardsAddListPanelType } from '../../fixtures/perses/constants';
+import { persesCreateDashboardsPage } from '../../views/perses-dashboards-create-dashboard';
+import { persesDashboardsPanelGroup } from '../../views/perses-dashboards-panelgroup';
+import { persesDashboardsPanel } from '../../views/perses-dashboards-panel';
+import { persesImportDashboardsPage } from '../../views/perses-dashboards-import-dashboard';
+
+export interface PerspectiveConfig {
+  name: string;
+  beforeEach?: () => void;
+}
+
+export function runCOOCreateImportPersesTests(perspective: PerspectiveConfig) {
+  testCOOCreateImportPerses(perspective);
+}
+
+export function testCOOCreateImportPerses(perspective: PerspectiveConfig) {
+  it(
+    `1.${perspective.name} perspective - Create Dashboard with Tempo and Loki Global Datasources ` +
+      `and variables`,
+    () => {
+      let dashboardName = 'Tempo Loki Perses Global Datasources ';
+      const randomSuffix = Math.random().toString(5);
+      dashboardName += randomSuffix;
+      cy.log(`1.1. use sidebar nav to go to Observe > Dashboards (Perses)`);
+      listPersesDashboardsPage.shouldBeLoaded();
+
+      cy.log(`1.2. Click on Create button`);
+      listPersesDashboardsPage.clickCreateButton();
+      persesCreateDashboardsPage.createDashboardShouldBeLoaded();
+
+      cy.log(`1.3. Create Dashboard`);
+      persesCreateDashboardsPage.selectProject('default');
+      persesCreateDashboardsPage.enterDashboardName(dashboardName);
+      persesCreateDashboardsPage.createDashboardDialogCreateButton();
+      persesDashboardsPage.shouldBeLoadedEditionMode(dashboardName);
+      persesDashboardsPage.shouldBeLoadedEditionModeFromCreateDashboard();
+
+      // cy.log(`1.4. Turn off Auto Refresh`);
+      // persesDashboardsPage.clickRefreshIntervalDropdown(persesDashboardsRefreshInterval.OFF);
+
+      cy.log(`1.5. Add Panel Group`);
+      persesDashboardsPage.clickEditActionButton('AddGroup');
+      persesDashboardsPanelGroup.addPanelGroup('Panel Group Up', 'Open', '');
+
+      cy.log(`1.6. Add Panel - Tempo Scatter Chart`);
+      persesDashboardsPage.clickEditActionButton('AddPanel');
+      persesDashboardsPanel.addPanelShouldBeLoaded();
+      persesDashboardsPanel.addPanel(
+        'Tempo - Scatter Chart',
+        'Panel Group Up',
+        persesDashboardsAddListPanelType.SCATTER_CHART,
+        'This is a scatter chart test',
+        '{}',
+      );
+
+      cy.log(`1.7. Add Panel - Tempo Trace Table`);
+      persesDashboardsPage.clickEditActionButton('AddPanel');
+      persesDashboardsPanel.addPanelShouldBeLoaded();
+      persesDashboardsPanel.addPanel(
+        'Tempo - Trace Table',
+        'Panel Group Up',
+        persesDashboardsAddListPanelType.TRACE_TABLE,
+        'This is a trace table test',
+        '{}',
+      );
+
+      cy.log(`1.8. Add Panel - Loki Logs Table`);
+      persesDashboardsPage.clickEditActionButton('AddPanel');
+      persesDashboardsPanel.addPanelShouldBeLoaded();
+      persesDashboardsPanel.addPanel(
+        'Loki - Logs Table',
+        'Panel Group Up',
+        persesDashboardsAddListPanelType.LOGS_TABLE,
+        'This is a logs table test',
+        '{ log_type="application" } | json',
+      );
+
+      cy.log(`1.9. Add Panel - Time Series Chart`);
+      persesDashboardsPage.clickEditActionButton('AddPanel');
+      persesDashboardsPanel.addPanelShouldBeLoaded();
+      persesDashboardsPanel.addPanel(
+        'Time Series Chart',
+        'Panel Group Up',
+        persesDashboardsAddListPanelType.TIME_SERIES_CHART,
+        'This is a line chart test',
+        'up',
+      );
+      persesDashboardsPage.clickEditActionButton('Save');
+      persesDashboardsPage.assertScatterChartPanel();
+      persesDashboardsPage.assertTraceTablePanel();
+      persesDashboardsPage.assertLogsTablePanel();
+    },
+  );
+
+  it(`2. ${perspective.name} perspective - Import Dashboard - Perses dashboard - JSON file`, () => {
+    cy.log(`2.1 use sidebar nav to go to Observe > Dashboards (Perses)`);
+    listPersesDashboardsPage.shouldBeLoaded();
+
+    cy.log(`2.2 Click on Import button`);
+    listPersesDashboardsPage.clickImportButton();
+    persesImportDashboardsPage.importDashboardShouldBeLoaded();
+
+    cy.log(`2.3 Upload Perses dashboard JSON file`);
+    persesImportDashboardsPage.uploadFile(
+      './cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.json',
+    );
+    persesImportDashboardsPage.assertPersesDashboardDetected();
+
+    cy.log(`2.4 Select a project`);
+    persesImportDashboardsPage.selectProject('default');
+
+    cy.log(`2.5 Import dashboard`);
+    persesImportDashboardsPage.clickImportFileButton();
+    persesDashboardsPage.closeAlert();
+
+    cy.log(`2.6 Assert dashboard is imported`);
+    persesDashboardsPage.shouldBeLoadedEditionMode(
+      'Tempo Loki Perses Global Datasources - JSON Import',
+    );
+    persesDashboardsPage.assertScatterChartPanel();
+    persesDashboardsPage.assertTraceTablePanel();
+    persesDashboardsPage.assertLogsTablePanel();
+  });
+
+  it(`3. ${perspective.name} perspective - Import Dashboard - Perses dashboard - YAML file`, () => {
+    cy.log(`3.1 use sidebar nav to go to Observe > Dashboards (Perses)`);
+    listPersesDashboardsPage.shouldBeLoaded();
+
+    cy.log(`3.2 Click on Import button`);
+    listPersesDashboardsPage.clickImportButton();
+    persesImportDashboardsPage.importDashboardShouldBeLoaded();
+
+    cy.log(`3.3 Upload Perses dashboard YAML file`);
+    persesImportDashboardsPage.uploadFile(
+      './cypress/fixtures/coo/coo140_perses/import/tempo_loki_thanos.yaml',
+    );
+    persesImportDashboardsPage.assertPersesDashboardDetected();
+
+    cy.log(`3.4 Select a project`);
+    persesImportDashboardsPage.selectProject('default');
+
+    cy.log(`3.5 Import dashboard`);
+    persesImportDashboardsPage.clickImportFileButton();
+    persesDashboardsPage.closeAlert();
+
+    cy.log(`3.6 Assert dashboard is imported`);
+    persesDashboardsPage.shouldBeLoadedEditionMode(
+      'Tempo Loki Perses Global Datasources - YAML Import',
+    );
+    persesDashboardsPage.assertScatterChartPanel();
+    persesDashboardsPage.assertTraceTablePanel();
+    persesDashboardsPage.assertLogsTablePanel();
+  });
+}

--- a/web/cypress/views/common.ts
+++ b/web/cypress/views/common.ts
@@ -6,9 +6,8 @@ export const commonPages = {
     cy.byLegacyTestID('namespace-bar-dropdown').should('not.exist'),
   projectDropdownShouldExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('exist'),
   titleShouldHaveText: (title: string) => {
-    cy.wait(15000);
     cy.log('commonPages.titleShouldHaveText - ' + `${title}`);
-    cy.bySemanticElement('h1', title).scrollIntoView().should('be.visible');
+    cy.waitUntil(() => cy.bySemanticElement('h1', title).should('be.visible'), { timeout: 60000 });
   },
 
   titleModalShouldHaveText: (title: string) => {

--- a/web/cypress/views/perses-dashboards-panel.ts
+++ b/web/cypress/views/perses-dashboards-panel.ts
@@ -111,7 +111,9 @@ export const persesDashboardsPanel = {
     legend?: string,
   ) => {
     cy.log('persesDashboardsPanel.addPanel');
-    cy.wait(2000);
+    cy.waitUntil(() => cy.get('#' + IDs.persesDashboardAddPanelForm).should('be.visible'), {
+      timeout: 60000,
+    });
     cy.get('input[name="' + editPersesDashboardsAddPanel.inputName + '"]')
       .clear()
       .type(name);
@@ -121,18 +123,16 @@ export const persesDashboardsPanel = {
         .type(description);
     }
     persesDashboardsPanel.clickDropdownAndSelectOption('Group', group);
-
-    cy.wait(1000);
     persesDashboardsPanel.clickDropdownAndSelectOption('Type', type);
 
     switch (type) {
       //BAR_GAUGE_HEAT_HISTOGRAM_PIE_STAT_STATUS_TABLE_TIMESERIES
-      case persesDashboardsAddListPanelType.BAR_CHART:
       // case persesDashboardsAddListPanelType.HEATMAP_CHART:
       // case persesDashboardsAddListPanelType.HISTOGRAM_CHART:
       // case persesDashboardsAddListPanelType.PIE_CHART:
       // case persesDashboardsAddListPanelType.STAT_CHART:
       // falls through
+      case persesDashboardsAddListPanelType.BAR_CHART:
       case persesDashboardsAddListPanelType.STATUS_HISTORY_CHART:
       case persesDashboardsAddListPanelType.TABLE:
       case persesDashboardsAddListPanelType.TIME_SERIES_CHART:
@@ -153,6 +153,36 @@ export const persesDashboardsPanel = {
           cy.get('label').contains('Legend').next('div').find('input').click().type(legend);
         }
         break;
+      case persesDashboardsAddListPanelType.SCATTER_CHART:
+      case persesDashboardsAddListPanelType.TRACE_TABLE:
+      case persesDashboardsAddListPanelType.TRACING_GANTT_CHART:
+        cy.wait(2000);
+        persesDashboardsPanel.clickDropdownAndSelectOption(
+          'Query Type',
+          persesDashboardsAddPanelAddQueryType.SCATTER_TRACE_TRACINGGANTT.TEMPO_TRACE_QUERY,
+        );
+
+        cy.get('button').contains('Show query').click();
+        cy.wait(2000);
+        if (query !== undefined && query !== '') {
+          persesDashboardsPanel.enterTraceQLExpression(query);
+        } else {
+          persesDashboardsPanel.enterTraceQLExpression('{}');
+        }
+        break;
+      case persesDashboardsAddListPanelType.LOGS_TABLE:
+        cy.wait(2000);
+        persesDashboardsPanel.clickDropdownAndSelectOption(
+          'Query Type',
+          persesDashboardsAddPanelAddQueryType.LOGS_TABLE.LOKI_LOG_QUERY,
+        );
+        cy.wait(2000);
+        if (query !== undefined && query !== '') {
+          persesDashboardsPanel.enterLogQLQuery(query);
+        } else {
+          persesDashboardsPanel.enterLogQLQuery('{ log_type="application" } | json');
+        }
+        break;
     }
     cy.get('#' + IDs.persesDashboardAddPanelForm)
       .parent('div')
@@ -162,6 +192,39 @@ export const persesDashboardsPanel = {
       .contains('Add')
       .should('be.visible')
       .click();
+  },
+
+  // CM6 needs direct DOM manipulation so the query value is captured
+  // in the editor's internal state via its MutationObserver.
+  // Using .type() fails because CM6 replaces the .cm-line element
+  // after clearing, leaving Cypress typing into a detached node.
+  enterCM6Expression: (label: 'TraceQL Expression' | 'LogQL Query', expression: string) => {
+    cy.log(`persesDashboardsPanel.enterCM6Expression (${label})`);
+    cy.contains('label', label)
+      .parent()
+      .find('[role="textbox"] .cm-line')
+      .should('be.visible')
+      .then(($el) => {
+        $el[0].textContent = expression;
+        $el[0].dispatchEvent(new Event('input', { bubbles: true }));
+        $el[0].dispatchEvent(new Event('blur', { bubbles: true }));
+      });
+    cy.wait(3000);
+    cy.contains('label', label).parent().find('[role="textbox"] .cm-line').click();
+    cy.wait(3000);
+    cy.bySemanticElement('button', 'Run Query')
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+    cy.wait(3000);
+  },
+
+  enterTraceQLExpression: (expression: string) => {
+    persesDashboardsPanel.enterCM6Expression('TraceQL Expression', expression);
+  },
+
+  enterLogQLQuery: (expression: string) => {
+    persesDashboardsPanel.enterCM6Expression('LogQL Query', expression);
   },
 
   enterPromQLQuery: (query: string | 'up' | 'haproxy_up') => {

--- a/web/cypress/views/perses-dashboards.ts
+++ b/web/cypress/views/perses-dashboards.ts
@@ -87,7 +87,6 @@ export const persesDashboardsPage = {
 
   shouldBeLoadedEditionMode: (dashboardName: string) => {
     cy.log('persesDashboardsPage.shouldBeLoadedEditionMode');
-    cy.wait(10000);
     commonPages.titleShouldHaveText(MonitoringPageTitles.DASHBOARDS);
     cy.byOUIAID(listPersesDashboardsOUIAIDs.PageHeaderSubtitle)
       .scrollIntoView()
@@ -127,16 +126,19 @@ export const persesDashboardsPage = {
 
   shouldBeLoadedEditionModeFromCreateDashboard: () => {
     cy.log('persesDashboardsPage.shouldBeLoadedEditionModeFromCreateDashboard');
-    cy.wait(10000);
-    cy.get('h2')
-      .contains(persesDashboardsEmptyDashboard.TITLE)
-      .scrollIntoView()
-      .should('be.visible');
+    cy.waitUntil(
+      () =>
+        cy
+          .get('h2')
+          .contains(persesDashboardsEmptyDashboard.TITLE)
+          .scrollIntoView()
+          .should('be.visible'),
+      { timeout: 60000 },
+    );
     cy.get('p')
       .contains(persesDashboardsEmptyDashboard.DESCRIPTION)
       .scrollIntoView()
       .should('be.visible');
-
     cy.get('h2')
       .siblings('div')
       .find('[aria-label="Add panel"]')
@@ -651,10 +653,7 @@ export const persesDashboardsPage = {
     cy.log('persesDashboardsPage.clickSaveDashboardButton');
     cy.wait(2000);
     cy.get('body').then((body) => {
-      if (
-        body.find('[data-testid="CloseIcon"]').length > 0 &&
-        body.find('[data-testid="CloseIcon"]').is(':visible')
-      ) {
+      if (body.find('button:contains("Save Changes"):visible').length > 0) {
         cy.bySemanticElement('button', 'Save Changes')
           .scrollIntoView()
           .should('be.visible')
@@ -812,5 +811,20 @@ export const persesDashboardsPage = {
           .click({ force: true });
       }
     });
+  },
+
+  assertLogsTablePanel: () => {
+    cy.log('persesDashboardsPage.assertLogsTablePanel');
+    cy.byDataTestID(persesMUIDataTestIDs.logsTableContainer).should('exist');
+  },
+
+  assertScatterChartPanel: () => {
+    cy.log('persesDashboardsPage.assertScatterChartPanel');
+    cy.byDataTestID(persesMUIDataTestIDs.scatterChartPanel_ScatterPlot).should('exist');
+  },
+
+  assertTraceTablePanel: () => {
+    cy.log('persesDashboardsPage.assertTraceTablePanel');
+    cy.byAriaLabel(persesAriaLabels.traceTablePanel_TraceTable).should('exist');
   },
 };

--- a/web/src/components/data-test.ts
+++ b/web/src/components/data-test.ts
@@ -277,6 +277,7 @@ export const persesAriaLabels = {
   dashboardActionsMenu: 'Dashboard actions',
   importDashboardProjectInputButton: 'Typeahead menu toggle',
   importDashboardDuplicatedDashboardError: 'Danger alert:document already exists',
+  traceTablePanel_TraceTable: 'Trace name column menu',
 };
 
 //data-testid from MUI components
@@ -294,6 +295,8 @@ export const persesMUIDataTestIDs = {
   editDashboardEditVariableDatasourceEditButton: 'PencilIcon',
   editDashboardEditVariableDatasourceDeleteButton: 'TrashCanIcon',
   addPanelGroupFormName: 'panel-group-editor-name',
+  logsTableContainer: 'log-row-container-0',
+  scatterChartPanel_ScatterPlot: 'ScatterChartPanel_ScatterPlot',
 };
 
 export const persesDashboardDataTestIDs = {


### PR DESCRIPTION
This PR includes [OU-1217](https://redhat.atlassian.net/browse/OU-1217), [OU-1218](https://redhat.atlassian.net/browse/OU-1218) and [OU-1219](https://redhat.atlassian.net/browse/OU-1219) tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tempo/Loki/Thanos global datasources for Perses and UI plugins for tracing/logging
  * New Perses panel types: Trace Table, Logs Table, Scatter Chart; improved create/import flows

* **Tests**
  * End-to-end Cypress tests covering Perses dashboards with tracing and logging integration
  * New test fixtures and orchestration commands to install, configure, and clean tracing/logging stacks

* **Stability**
  * Improved UI readiness checks and alert handling to reduce flaky dashboard test timing issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->