### PR TITLE
[release-4.18] OCPBUGS-83374:  fix: re encode params when redirecting from graph to query-browser

### DIFF
--- a/web/src/components/alerting.tsx
+++ b/web/src/components/alerting.tsx
@@ -761,7 +761,13 @@ const PollerPages = () => {
 const PrometheusUIRedirect = () => {
   const params = getAllQueryArguments();
   // leaving perspective redirect to future work
-  return <Redirect to={`/monitoring/query-browser?query0=${params['g0.expr'] || ''}`} />;
+  return (
+    <Redirect
+      to={`/monitoring/query-browser?query0=${
+        params['g0.expr'] ? encodeURIComponent(params['g0.expr']) : ''
+      }`}
+    />
+  );
 };
 
 const MonitoringUI = () => {


### PR DESCRIPTION
Manual cherry pick of: https://github.com/openshift/monitoring-plugin/pull/874

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-83374