### PR TITLE
OU-1307: don't fight console to setActiveNamespace

### DIFF
--- a/web/src/components/dashboards/legacy/useLegacyDashboardsProject.ts
+++ b/web/src/components/dashboards/legacy/useLegacyDashboardsProject.ts
@@ -30,9 +30,6 @@ export const useLegacyDashboardsProject = () => {
         setOpenshiftProject(activeNamespace);
       }
     } else {
-      if (routeNamespace && activeNamespace !== routeNamespace) {
-        setActiveNamespace(routeNamespace);
-      }
       if (variableNamespace && variableNamespace !== routeNamespace) {
         dispatch(
           dashboardsPatchVariable('namespace', {

--- a/web/src/components/hooks/useMonitoringNamespace.ts
+++ b/web/src/components/hooks/useMonitoringNamespace.ts
@@ -1,7 +1,5 @@
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
-import { useEffect } from 'react';
 import { useParams } from 'react-router';
-import { useMonitoring } from '../../hooks/useMonitoring';
 
 /**
  * Utility hook to synchronize the namespace route in the URL with the activeNamespace
@@ -12,13 +10,6 @@ import { useMonitoring } from '../../hooks/useMonitoring';
 export const useMonitoringNamespace = () => {
   const { ns: routeNamespace } = useParams<{ ns?: string }>();
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
-  const { displayNamespaceSelector } = useMonitoring();
-
-  useEffect(() => {
-    if (routeNamespace && activeNamespace !== routeNamespace) {
-      setActiveNamespace(routeNamespace);
-    }
-  }, [routeNamespace, activeNamespace, setActiveNamespace, displayNamespaceSelector]);
 
   return {
     namespace: routeNamespace || activeNamespace,


### PR DESCRIPTION
The 4.22 console already changes the namespace based on the route parameter and the route parameter based on the namespace. This leads to a loop of us setting it and the console changing it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified namespace synchronization logic in dashboard and monitoring components. Internal handling of namespace routing has been streamlined to reduce redundant state updates while maintaining core namespace resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->