### PR TITLE
OCPBUGS-79456: immutable bump

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -67,7 +67,7 @@
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
         "immer": "^10.1.3",
-        "immutable": "3.x",
+        "immutable": "^3.8.3",
         "js-yaml": "^4.1.0",
         "lodash-es": "^4.17.21",
         "lru-cache": "^6.0.0",
@@ -15547,9 +15547,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/web/package.json
+++ b/web/package.json
@@ -103,7 +103,7 @@
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
     "immer": "^10.1.3",
-    "immutable": "3.x",
+    "immutable": "^3.8.3",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "lru-cache": "^6.0.0",


### PR DESCRIPTION
Bump immutable from 3.8.2 to 3.8.3 to address prototype pollution vulnerability via mergeDeep, merge, toJS, toObject (CVE-2026-29063).