### PR TITLE
OCPBUGS-79444: immutable bump

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,7 @@
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
         "i18next-parser": "^8.11.0",
-        "immutable": "3.x",
+        "immutable": "^3.8.3",
         "lodash-es": "^4.17.21",
         "murmurhash-js": "1.0.x",
         "react": "^17.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -46,7 +46,7 @@
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
     "i18next-parser": "^8.11.0",
-    "immutable": "3.x",
+    "immutable": "^3.8.3",
     "lodash-es": "^4.17.21",
     "murmurhash-js": "1.0.x",
     "react": "^17.0.1",


### PR DESCRIPTION
Bump immutable from 3.8.2 to 3.8.3 to address prototype pollution vulnerability via mergeDeep, merge, toJS, toObject (CVE-2026-29063).