### PR TITLE
OU-1323: Refactor dashboards state to prevent desync

### DIFF
--- a/web/src/components/MetricsPage.tsx
+++ b/web/src/components/MetricsPage.tsx
@@ -1208,7 +1208,6 @@ const QueryBrowserWrapper: FC<{
   return (
     <QueryBrowser
       customDataSource={customDataSource}
-      defaultTimespan={30 * 60 * 1000}
       disabledSeries={disabledSeries}
       queries={queryStrings}
       units={units}

--- a/web/src/components/dashboards/legacy/custom-time-range-modal.tsx
+++ b/web/src/components/dashboards/legacy/custom-time-range-modal.tsx
@@ -16,12 +16,10 @@ import * as _ from 'lodash-es';
 import type { FC, MouseEventHandler } from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
-
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../store/actions';
 
 import { QueryParams } from '../../query-params';
-import { StringParam, useQueryParam } from 'use-query-params';
+import { NumberParam, useQueryParam } from 'use-query-params';
+import { TimeRangeParam } from './utils';
 
 const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
 
@@ -49,10 +47,8 @@ const CustomTimeRangeModal: FC<CustomTimeRangeModalProps> = ({
   endTime,
 }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
-  const [, setEndTimeParam] = useQueryParam(QueryParams.EndTime, StringParam);
-  const [, setTimeRangeParam] = useQueryParam(QueryParams.TimeRange, StringParam);
-
-  const dispatch = useDispatch();
+  const [, setEndTimeParam] = useQueryParam(QueryParams.EndTime, NumberParam);
+  const [, setTimeRangeParam] = useQueryParam(QueryParams.TimeRange, TimeRangeParam);
 
   // If a time is already set in Redux, default to that, otherwise default to a time range that
   // covers all of today
@@ -67,10 +63,8 @@ const CustomTimeRangeModal: FC<CustomTimeRangeModalProps> = ({
     const from = Date.parse(`${fromDate} ${fromTime}`);
     const to = Date.parse(`${toDate} ${toTime}`);
     if (_.isInteger(from) && _.isInteger(to)) {
-      dispatch(dashboardsSetEndTime(to));
-      dispatch(dashboardsSetTimespan(to - from));
-      setEndTimeParam(to.toString());
-      setTimeRangeParam((to - from).toString());
+      setEndTimeParam(to);
+      setTimeRangeParam(to - from);
       setClosed();
     }
   };

--- a/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
+++ b/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
@@ -61,7 +61,10 @@ export const DashboardSkeletonLegacy: FC<MonitoringDashboardsLegacyPageProps> = 
             )}
 
             <StackItem>
-              <LegacyDashboardsAllVariableDropdowns key={dashboardName} />
+              <LegacyDashboardsAllVariableDropdowns
+                key={dashboardName}
+                dashboardName={dashboardName}
+              />
             </StackItem>
             <StackItem>
               <Split>

--- a/web/src/components/dashboards/legacy/graph.tsx
+++ b/web/src/components/dashboards/legacy/graph.tsx
@@ -1,15 +1,12 @@
 import type { FC } from 'react';
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { NumberParam, useQueryParam } from 'use-query-params';
 
-import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../store/actions';
 import { FormatSeriesTitle, QueryBrowser } from '../../query-browser';
-import { MonitoringState } from '../../../store/store';
-import { getObserveState } from '../../hooks/usePerspective';
-import { DEFAULT_GRAPH_SAMPLES } from './utils';
+import { DEFAULT_GRAPH_SAMPLES, TimeRangeParam } from './utils';
 import { CustomDataSource } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
 import { GraphUnits } from '../../../components/metrics/units';
-import { useMonitoring } from '../../../hooks/useMonitoring';
+import { QueryParams } from '../../query-params';
 
 type Props = {
   customDataSource?: CustomDataSource;
@@ -20,7 +17,6 @@ type Props = {
   queries: string[];
   showLegend?: boolean;
   units: string;
-  onZoomHandle?: (timeRange: number, endTime: number) => void;
   onDataChange?: (data: any) => void;
 };
 
@@ -33,32 +29,24 @@ const Graph: FC<Props> = ({
   queries,
   showLegend,
   units,
-  onZoomHandle,
   onDataChange,
 }) => {
-  const dispatch = useDispatch();
-  const { plugin } = useMonitoring();
-  const endTime = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.endTime,
-  );
-  const timespan = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.timespan,
-  );
+  const [timeRange, setTimeRange] = useQueryParam(QueryParams.TimeRange, TimeRangeParam);
+  const [endTime, setEndTime] = useQueryParam(QueryParams.EndTime, NumberParam);
 
   const onZoom = useCallback(
-    (from, to) => {
-      dispatch(dashboardsSetEndTime(to));
-      dispatch(dashboardsSetTimespan(to - from));
-      onZoomHandle?.(to - from, to);
+    (from: number, to: number) => {
+      setEndTime(to);
+      setTimeRange(to - from);
     },
-    [dispatch, onZoomHandle],
+    [setEndTime, setTimeRange],
   );
 
   return (
     <QueryBrowser
       customDataSource={customDataSource}
       defaultSamples={DEFAULT_GRAPH_SAMPLES}
-      fixedEndTime={Number(endTime)}
+      fixedEndTime={endTime}
       formatSeriesTitle={formatSeriesTitle}
       hideControls
       isStack={isStack}
@@ -67,7 +55,7 @@ const Graph: FC<Props> = ({
       pollInterval={pollInterval}
       queries={queries}
       showLegend={showLegend}
-      timespan={timespan}
+      timespan={timeRange}
       units={units as GraphUnits}
       onDataChange={onDataChange}
       isPlain

--- a/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard-page.tsx
@@ -53,7 +53,11 @@ const LegacyDashboardsPage_: FC<LegacyDashboardsPageProps> = ({ urlBoard }) => {
               error={{ message: legacyDashboardsError, name: t('Error Loading Dashboards') }}
             />
           ) : (
-            <LegacyDashboard rows={legacyRows} perspective={perspective} />
+            <LegacyDashboard
+              rows={legacyRows}
+              perspective={perspective}
+              dashboardName={legacyDashboard}
+            />
           )}
         </Overview>
       </DashboardSkeletonLegacy>

--- a/web/src/components/dashboards/legacy/legacy-dashboard.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard.tsx
@@ -50,7 +50,8 @@ import { t_global_font_size_heading_h2 } from '@patternfly/react-tokens';
 import { GraphUnits } from '../../../components/metrics/units';
 import { LegacyDashboardPageTestIDs } from '../../../components/data-test';
 import { useMonitoring } from '../../../hooks/useMonitoring';
-import { StringParam, useQueryParam } from 'use-query-params';
+import { useQueryParam } from 'use-query-params';
+import { RefreshIntervalParam, TimeRangeParam } from './utils';
 
 const QueryBrowserLink = ({
   queries,
@@ -99,18 +100,13 @@ const getPanelSpan = (panel: Panel): gridSpans => {
   return 12;
 };
 
-const Card: FC<CardProps> = memo(({ panel, perspective }) => {
+const Card: FC<CardProps> = memo(({ panel, perspective, dashboardName }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { plugin } = useMonitoring();
 
-  const pollInterval = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.pollInterval,
-  );
-  const timespan = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.timespan,
-  );
   const variables = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.variables,
+    (state: MonitoringState) =>
+      getObserveState(plugin, state).dashboards.legacy[dashboardName]?.variables || {},
   );
 
   // Directly use the namespace variable to prevent desync
@@ -125,8 +121,8 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
   const [isChartLoading, setIsChartLoading] = useState<boolean>(panel.type === 'graph');
   const customDataSourceName = panel.datasource?.name;
   const [extensions, extensionsResolved] = useResolvedExtensions<DataSource>(isDataSource);
-  const [, setEndTimeParam] = useQueryParam(QueryParams.EndTime, StringParam);
-  const [, setTimeRangeParam] = useQueryParam(QueryParams.TimeRange, StringParam);
+  const [refreshInterval] = useQueryParam(QueryParams.RefreshInterval, RefreshIntervalParam);
+  const [timeRange] = useQueryParam(QueryParams.TimeRange, TimeRangeParam);
   const hasExtensions = !_.isEmpty(extensions);
 
   const formatSeriesTitle = useCallback(
@@ -250,11 +246,6 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
     });
   }, [extensions, extensionsResolved, customDataSourceName, hasExtensions]);
 
-  const handleZoom = (timeRange: number, endTime: number) => {
-    setEndTimeParam(endTime.toString());
-    setTimeRangeParam(timeRange.toString());
-  };
-
   const panelBreakpoints = useMemo(() => {
     const panelSpan = getPanelSpan(panel);
     return {
@@ -269,7 +260,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
     return (
       <>
         {_.map(panel.panels, (p) => (
-          <Card key={p.id} panel={p} perspective={perspective} />
+          <Card key={p.id} panel={p} perspective={perspective} dashboardName={dashboardName} />
         ))}
       </>
     );
@@ -284,7 +275,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
     return null;
   }
   const queries = rawQueries.map((expr) =>
-    evaluateVariableTemplate(expr, variables, timespan, namespace?.value ?? ''),
+    evaluateVariableTemplate(expr, variables, timeRange, namespace?.value ?? ''),
   );
   const isLoading =
     (_.some(queries, _.isUndefined) && dataSourceInfoLoading) || customDataSource === undefined;
@@ -337,7 +328,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
                 <>
                   {panel.type === 'grafana-piechart-panel' && (
                     <BarChart
-                      pollInterval={pollInterval}
+                      pollInterval={refreshInterval}
                       query={queries[0]}
                       customDataSource={customDataSource}
                     />
@@ -347,11 +338,10 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
                       formatSeriesTitle={formatSeriesTitle}
                       isStack={panel.stack}
                       onLoadingChange={setIsChartLoading}
-                      pollInterval={pollInterval}
+                      pollInterval={refreshInterval}
                       queries={queries}
                       showLegend={panel.legend?.show}
                       units={panel.yaxes?.[0]?.format}
-                      onZoomHandle={handleZoom}
                       customDataSource={customDataSource}
                       onDataChange={(data) => setCsvData(data)}
                     />
@@ -359,7 +349,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
                   {(panel.type === 'singlestat' || panel.type === 'gauge') && (
                     <SingleStat
                       panel={panel}
-                      pollInterval={pollInterval}
+                      pollInterval={refreshInterval}
                       query={queries[0]}
                       namespace={namespace?.value ?? ''}
                       customDataSource={customDataSource}
@@ -368,7 +358,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
                   {panel.type === 'table' && (
                     <Table
                       panel={panel}
-                      pollInterval={pollInterval}
+                      pollInterval={refreshInterval}
                       queries={queries}
                       namespace={namespace?.value ?? ''}
                       customDataSource={customDataSource}
@@ -384,7 +374,7 @@ const Card: FC<CardProps> = memo(({ panel, perspective }) => {
   );
 });
 
-const PanelsRow: FC<PanelsRowProps> = ({ row, perspective }) => {
+const PanelsRow: FC<PanelsRowProps> = ({ row, perspective, dashboardName }) => {
   const showButton = row.showTitle && !_.isEmpty(row.title);
 
   const [isExpanded, toggleIsExpanded] = useBoolean(showButton ? !row.collapse : true);
@@ -402,7 +392,12 @@ const PanelsRow: FC<PanelsRowProps> = ({ row, perspective }) => {
         <FlexItem>
           <Grid hasGutter>
             {_.map(row.panels, (panel) => (
-              <Card key={panel.id} panel={panel} perspective={perspective} />
+              <Card
+                key={panel.id}
+                panel={panel}
+                perspective={perspective}
+                dashboardName={dashboardName}
+              />
             ))}
           </Grid>
         </FlexItem>
@@ -411,11 +406,11 @@ const PanelsRow: FC<PanelsRowProps> = ({ row, perspective }) => {
   );
 };
 
-export const LegacyDashboard: FC<BoardProps> = ({ rows, perspective }) => (
+export const LegacyDashboard: FC<BoardProps> = ({ rows, perspective, dashboardName }) => (
   <Flex direction={{ default: 'column' }}>
     {rows.map((row) => (
       <FlexItem key={row.panels.map((panel) => `${panel.id}-${row.title}`).join()}>
-        <PanelsRow row={row} perspective={perspective} />
+        <PanelsRow row={row} perspective={perspective} dashboardName={dashboardName} />
       </FlexItem>
     ))}
   </Flex>
@@ -424,14 +419,17 @@ export const LegacyDashboard: FC<BoardProps> = ({ rows, perspective }) => (
 type BoardProps = {
   rows: Row[];
   perspective: Perspective;
+  dashboardName: string;
 };
 
 type CardProps = {
   panel: Panel;
   perspective: Perspective;
+  dashboardName: string;
 };
 
 type PanelsRowProps = {
   row: Row;
   perspective: Perspective;
+  dashboardName: string;
 };

--- a/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
@@ -30,7 +30,12 @@ import { dashboardsPatchVariable, dashboardsVariableOptionsLoaded } from '../../
 import { getTimeRanges, isTimeoutError, QUERY_CHUNK_SIZE } from '../../utils';
 import { getObserveState, usePerspective } from '../../hooks/usePerspective';
 import { MonitoringState } from '../../../store/store';
-import { DEFAULT_GRAPH_SAMPLES, MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from './utils';
+import {
+  DEFAULT_GRAPH_SAMPLES,
+  MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
+  TimeRangeParam,
+} from './utils';
+import { QueryParams } from '../../query-params';
 import {
   DataSource,
   isDataSource,
@@ -105,19 +110,22 @@ const LegacyDashboardsVariableOption = ({ value, isSelected, ...rest }) =>
     </SelectOption>
   );
 
-const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name }) => {
+const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({
+  id,
+  name,
+  dashboardName,
+}) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { plugin, accessCheckLoading, useMetricsTenancy } = useMonitoring();
   const { perspective } = usePerspective();
   const [namespace] = useActiveNamespace();
   const [queryParam, setQueryParam] = useQueryParam(name, StringParam);
 
-  const timespan = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.timespan,
-  );
+  const [timespan] = useQueryParam(QueryParams.TimeRange, TimeRangeParam);
 
   const variables = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.variables,
+    (state: MonitoringState) =>
+      getObserveState(plugin, state).dashboards.legacy[dashboardName]?.variables || {},
   );
   const variable = variables?.[name] as Variable;
 
@@ -193,7 +201,7 @@ const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name 
     const timeRanges = getTimeRanges(timespan);
     const newOptions = new Set<string>();
     let abortError = false;
-    dispatch(dashboardsPatchVariable(name, { isLoading: true }));
+    dispatch(dashboardsPatchVariable(dashboardName, name, { isLoading: true }));
     Promise.allSettled(
       timeRanges.map(async (timeRange) => {
         const prometheusProps = {
@@ -234,10 +242,10 @@ const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name 
         setIsError(false);
         // Options were found or no options were found but that wasn't in error
         const newOptionArray = Array.from(newOptions).sort();
-        dispatch(dashboardsVariableOptionsLoaded(name, newOptionArray));
+        dispatch(dashboardsVariableOptionsLoaded(dashboardName, name, newOptionArray));
       } else {
         // No options were found, and there were errors (timeouts or other) in fetching the data
-        dispatch(dashboardsPatchVariable(name, { isLoading: false }));
+        dispatch(dashboardsPatchVariable(dashboardName, name, { isLoading: false }));
         if (!abortError) {
           setIsError(true);
         }
@@ -246,6 +254,7 @@ const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name 
   }, [
     dispatch,
     getURL,
+    dashboardName,
     name,
     namespace,
     query,
@@ -259,23 +268,32 @@ const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name 
   useEffect(() => {
     if (variable?.value !== queryParam) {
       // Default to using the query param to allow for sharable links
-      if (queryParam) {
-        dispatch(dashboardsPatchVariable(name, { value: queryParam }));
+      if (queryParam && options?.includes(queryParam)) {
+        dispatch(dashboardsPatchVariable(dashboardName, name, { value: queryParam }));
         // set the url if it isn't set
       } else if (variable?.value && shouldSetQueryParam) {
         setQueryParam(variable?.value);
       }
     }
-  }, [name, variable?.value, queryParam, setQueryParam, dispatch, shouldSetQueryParam]);
+  }, [
+    dashboardName,
+    name,
+    variable?.value,
+    queryParam,
+    setQueryParam,
+    dispatch,
+    shouldSetQueryParam,
+    options,
+  ]);
 
   const onChange = useCallback(
     (v: string) => {
       if (v !== variable?.value && shouldSetQueryParam) {
         setQueryParam(v);
-        dispatch(dashboardsPatchVariable(name, { value: v }));
+        dispatch(dashboardsPatchVariable(dashboardName, name, { value: v }));
       }
     },
-    [dispatch, name, variable?.value, setQueryParam, shouldSetQueryParam],
+    [dispatch, dashboardName, name, variable?.value, setQueryParam, shouldSetQueryParam],
   );
 
   if (variable?.isHidden || (!isError && _.isEmpty(variable?.options))) {
@@ -328,21 +346,29 @@ const LegacyDashboardsVariableDropdown: FC<VariableDropdownProps> = ({ id, name 
 };
 
 // Expects to be inside of a Patternfly Split Component
-export const LegacyDashboardsAllVariableDropdowns: FC = () => {
+export const LegacyDashboardsAllVariableDropdowns: FC<{ dashboardName: string }> = ({
+  dashboardName,
+}) => {
   const { plugin } = useMonitoring();
 
   const variables = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.variables,
+    (state: MonitoringState) =>
+      getObserveState(plugin, state).dashboards.legacy[dashboardName]?.variables || {},
   );
 
-  if (!variables) {
+  if (!variables || Object.keys(variables).length === 0) {
     return null;
   }
 
   return (
     <Split hasGutter isWrappable>
       {Object.keys(variables).map((name: string) => (
-        <LegacyDashboardsVariableDropdown id={name} key={name} name={name} />
+        <LegacyDashboardsVariableDropdown
+          id={name}
+          key={`${dashboardName}-${name}`}
+          name={name}
+          dashboardName={dashboardName}
+        />
       ))}
     </Split>
   );
@@ -361,4 +387,5 @@ export type Variable = {
 type VariableDropdownProps = {
   id: string;
   name: string;
+  dashboardName: string;
 };

--- a/web/src/components/dashboards/legacy/time-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/time-dropdowns.tsx
@@ -1,28 +1,19 @@
 import { Stack, StackItem } from '@patternfly/react-core';
 import { SimpleSelect, SimpleSelectOption } from '@patternfly/react-templates';
-import * as _ from 'lodash-es';
 import type { FC } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 import { NumberParam, useQueryParam } from 'use-query-params';
-import {
-  dashboardsSetEndTime,
-  dashboardsSetPollInterval,
-  dashboardsSetTimespan,
-} from '../../../store/actions';
-import { MonitoringState } from '../../../store/store';
 import {
   formatPrometheusDuration,
   parsePrometheusDuration,
 } from '../../console/console-shared/src/datetime/prometheus';
-import { DEFAULT_REFRESH_INTERVAL, DropDownPollInterval } from '../../dropdown-poll-interval';
+import { DropDownPollInterval } from '../../dropdown-poll-interval';
 import { useBoolean } from '../../hooks/useBoolean';
-import { getObserveState } from '../../hooks/usePerspective';
 import { QueryParams } from '../../query-params';
 import CustomTimeRangeModal from './custom-time-range-modal';
 import { LegacyDashboardPageTestIDs } from '../../data-test';
-import { useMonitoring } from '../../../hooks/useMonitoring';
+import { RefreshIntervalParam, TimeRangeParam } from './utils';
 
 const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 const DEFAULT_TIMERANGE = '30m';
@@ -30,26 +21,13 @@ const DEFAULT_TIMERANGE = '30m';
 export const TimespanDropdown: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
-  const { plugin } = useMonitoring();
-
   const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
 
-  const timespan = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.timespan,
-  );
-  const endTime = useSelector(
-    (state: MonitoringState) => getObserveState(plugin, state).dashboards.endTime,
-  );
+  const [timeRange, setTimeRange] = useQueryParam(QueryParams.TimeRange, TimeRangeParam);
+  const [endTime, setEndTime] = useQueryParam(QueryParams.EndTime, NumberParam);
 
-  const [timeRangeFromParams, setTimeRange] = useQueryParam(QueryParams.TimeRange, NumberParam);
-  const [endTimeFromParams, setEndTime] = useQueryParam(QueryParams.EndTime, NumberParam);
+  const selectedKey = endTime ? CUSTOM_TIME_RANGE_KEY : formatPrometheusDuration(timeRange);
 
-  const selectedKey =
-    endTime || endTimeFromParams
-      ? CUSTOM_TIME_RANGE_KEY
-      : formatPrometheusDuration(_.toNumber(timeRangeFromParams) || timespan);
-
-  const dispatch = useDispatch();
   const onChange = useCallback(
     (v: string) => {
       if (v === CUSTOM_TIME_RANGE_KEY) {
@@ -57,11 +35,9 @@ export const TimespanDropdown: FC = () => {
       } else {
         setTimeRange(parsePrometheusDuration(v));
         setEndTime(undefined);
-        dispatch(dashboardsSetTimespan(parsePrometheusDuration(v)));
-        dispatch(dashboardsSetEndTime(undefined));
       }
     },
-    [setModalOpen, dispatch, setTimeRange, setEndTime],
+    [setModalOpen, setTimeRange, setEndTime],
   );
 
   const initialOptions = useMemo<SimpleSelectOption[]>(() => {
@@ -81,14 +57,14 @@ export const TimespanDropdown: FC = () => {
     ];
 
     // If selectedKey is empty, the dashboard has changed. Reset selected to default value.
-    if (selectedKey === '' || (selectedKey === DEFAULT_TIMERANGE && !timeRangeFromParams)) {
+    if (selectedKey === '' || (selectedKey === DEFAULT_TIMERANGE && !timeRange)) {
       setTimeRange(parsePrometheusDuration(DEFAULT_TIMERANGE));
       setEndTime(undefined);
     }
     return intervalOptions.map((o) => ({ ...o, selected: o.value === selectedKey }));
-  }, [selectedKey, t, timeRangeFromParams, setTimeRange, setEndTime]);
+  }, [selectedKey, t, timeRange, setTimeRange, setEndTime]);
 
-  const defaultTimerange = timespan ?? undefined;
+  const defaultTimerange = timeRange ?? undefined;
   let defaultEndTime = Number(endTime);
   if (Number.isNaN(defaultEndTime)) {
     defaultEndTime = undefined;
@@ -126,18 +102,9 @@ export const TimespanDropdown: FC = () => {
 
 export const PollIntervalDropdown: FC = () => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
-  const [selectedInterval, setSelectedInterval] = useState(DEFAULT_REFRESH_INTERVAL);
-
-  const dispatch = useDispatch();
-  const [, setRefreshInterval] = useQueryParam(QueryParams.RefreshInterval, NumberParam);
-
-  const setInterval = useCallback(
-    (v: number) => {
-      setSelectedInterval(v);
-      setRefreshInterval(v);
-      dispatch(dashboardsSetPollInterval(v));
-    },
-    [dispatch, setRefreshInterval],
+  const [refreshInterval, setRefreshInterval] = useQueryParam(
+    QueryParams.RefreshInterval,
+    RefreshIntervalParam,
   );
 
   return (
@@ -148,8 +115,8 @@ export const PollIntervalDropdown: FC = () => {
       <StackItem data-test={LegacyDashboardPageTestIDs.PollIntervalDropdown}>
         <DropDownPollInterval
           id="refresh-interval-dropdown"
-          setInterval={setInterval}
-          selectedInterval={selectedInterval}
+          setInterval={setRefreshInterval}
+          selectedInterval={refreshInterval}
           data-test={LegacyDashboardPageTestIDs.PollIntervalDropdownOptions}
         />
       </StackItem>

--- a/web/src/components/dashboards/legacy/useLegacyDashboards.ts
+++ b/web/src/components/dashboards/legacy/useLegacyDashboards.ts
@@ -1,16 +1,9 @@
 import * as _ from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useSearchParams } from 'react-router';
-import { NumberParam, useQueryParam } from 'use-query-params';
-import {
-  DashboardsClearVariables,
-  dashboardsPatchAllVariables,
-  dashboardsSetEndTime,
-  dashboardsSetPollInterval,
-  dashboardsSetTimespan,
-} from '../../../store/actions';
+import { dashboardsPatchAllVariables } from '../../../store/actions';
 import { useSafeFetch } from '../../console/utils/safe-fetch-hook';
 import { useBoolean } from '../../hooks/useBoolean';
 import { getLegacyDashboardsUrl, usePerspective } from '../../hooks/usePerspective';
@@ -18,24 +11,19 @@ import { QueryParams } from '../../query-params';
 import { ALL_NAMESPACES_KEY } from '../../utils';
 import { CombinedDashboardMetadata } from '../perses/hooks/useDashboardsData';
 import { Board } from './types';
-import {
-  MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
-  MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
-} from './utils';
+import { MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from './utils';
 import { useLegacyDashboardsProject } from './useLegacyDashboardsProject';
 
 export const useLegacyDashboards = (urlBoard: string) => {
   const { t } = useTranslation('plugin__monitoring-plugin');
   const { perspective } = usePerspective();
-  const { project } = useLegacyDashboardsProject();
+  const { project } = useLegacyDashboardsProject(urlBoard);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeFetch = useCallback(useSafeFetch(), []);
   const [unfilteredLegacyDashboards, setUnfilteredLegacyDashboards] = useState<any>([]);
   const [legacyDashboardsError, setLegacyDashboardsError] = useState<string>();
-  const [refreshInterval] = useQueryParam(QueryParams.RefreshInterval, NumberParam);
   const [legacyDashboardsLoading, , , setLegacyDashboardsLoaded] = useBoolean(true);
-  const [initialLoad, , , setInitialLoaded] = useBoolean(true);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [queryParams] = useSearchParams();
@@ -119,95 +107,61 @@ export const useLegacyDashboards = (urlBoard: string) => {
   }, [legacyDashboards, legacyDashboardsLoading]);
 
   const changeLegacyDashboard = useCallback(
-    ({
-      newBoard,
-      newProject,
-      initialLoad = false,
-    }: {
-      newBoard?: string;
-      newProject?: string;
-      initialLoad?: boolean;
-    }) => {
+    ({ newBoard, newProject }: { newBoard?: string; newProject?: string }) => {
       const dashboardProject = newProject ? newProject : project;
+      const dashboardName = newBoard ? newBoard : urlBoard;
 
-      const url = getLegacyDashboardsUrl(perspective, newBoard, dashboardProject);
+      const url = getLegacyDashboardsUrl(perspective, dashboardName, dashboardProject);
 
-      let params: URLSearchParams;
-      if (initialLoad) {
-        params = new URLSearchParams(queryParams);
-        if (perspective === 'dev') {
-          params.delete(QueryParams.Namespace);
-          params.delete(QueryParams.OpenshiftProject);
+      const params = new URLSearchParams();
+      if (perspective === 'dev') {
+        params.set(QueryParams.Dashboard, queryParams.get(QueryParams.Dashboard));
+        if (
+          !params.has(QueryParams.Dashboard) ||
+          params.get(QueryParams.Dashboard) !== dashboardName
+        ) {
+          params.set(QueryParams.Dashboard, dashboardName);
         }
       } else {
-        params = new URLSearchParams();
+        if (params.get(QueryParams.OpenshiftProject) !== ALL_NAMESPACES_KEY) {
+          params.delete(QueryParams.Namespace);
+        }
+        params.set(QueryParams.OpenshiftProject, dashboardProject);
       }
+      const srt = `${url}?${params.toString()}`;
+      navigate(srt, { replace: true });
 
-      if (newBoard !== urlBoard || newProject !== project || initialLoad) {
-        if (
-          perspective === 'dev' &&
-          (!params.has(QueryParams.Dashboard) || params.get(QueryParams.Dashboard) !== newBoard)
-        ) {
-          params.set(QueryParams.Dashboard, newBoard);
-        }
-        if (perspective !== 'dev') {
-          if (params.get(QueryParams.OpenshiftProject) !== ALL_NAMESPACES_KEY) {
-            params.delete(QueryParams.Namespace);
-          }
-          params.set(QueryParams.OpenshiftProject, dashboardProject);
-        }
-        const srt = `${url}?${params.toString()}`;
-        navigate(srt, { replace: true });
-
-        dispatch(
-          dashboardsPatchAllVariables(
-            getAllVariables(params, legacyDashboards, dashboardProject, newBoard),
-          ),
-        );
-
-        // Set time range and poll interval options to their defaults or from the query params if
-        // available
-        if (refreshInterval !== undefined) {
-          dispatch(dashboardsSetPollInterval(_.toNumber(refreshInterval)));
-        }
-        dispatch(dashboardsSetEndTime(_.toNumber(params.get(QueryParams.EndTime)) || null));
-        dispatch(
-          dashboardsSetTimespan(
-            _.toNumber(params.get(QueryParams.TimeRange)) || MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
-          ),
-        );
-      }
+      dispatch(
+        dashboardsPatchAllVariables(
+          dashboardName,
+          getAllVariables(params, legacyDashboards, dashboardProject, dashboardName),
+        ),
+      );
     },
-    [
-      perspective,
-      urlBoard,
-      dispatch,
-      navigate,
-      project,
-      refreshInterval,
-      queryParams,
-      legacyDashboards,
-    ],
+    [perspective, urlBoard, dispatch, navigate, project, queryParams, legacyDashboards],
   );
 
+  const previousProject = useRef(project);
   useEffect(() => {
+    let replacementBoard = urlBoard;
     if (
-      (!urlBoard ||
-        !legacyDashboards.some((legacyBoard) => legacyBoard.name === urlBoard) ||
-        initialLoad) &&
-      !_.isEmpty(legacyDashboards)
+      !urlBoard ||
+      (!legacyDashboards.some((legacyBoard) => legacyBoard.name === urlBoard) &&
+        !_.isEmpty(legacyDashboards))
     ) {
+      replacementBoard = legacyDashboards?.[0]?.name;
+    }
+    if (urlBoard !== replacementBoard || project !== previousProject.current) {
+      previousProject.current = project;
       changeLegacyDashboard({
-        newBoard: urlBoard || legacyDashboards?.[0]?.name,
-        initialLoad: initialLoad,
+        newBoard: replacementBoard,
         newProject: project,
       });
-      setInitialLoaded();
     }
-  }, [legacyDashboards, changeLegacyDashboard, initialLoad, setInitialLoaded, urlBoard, project]);
+  }, [legacyDashboards, changeLegacyDashboard, urlBoard, project]);
 
   useEffect(() => {
-    if (initialLoad || _.isEmpty(legacyDashboards)) {
+    if (_.isEmpty(legacyDashboards)) {
       return;
     }
 
@@ -215,18 +169,12 @@ export const useLegacyDashboards = (urlBoard: string) => {
     if (currentBoard) {
       dispatch(
         dashboardsPatchAllVariables(
+          currentBoard,
           getAllVariables(queryParams, legacyDashboards, project, currentBoard),
         ),
       );
     }
-  }, [project, legacyDashboards, urlBoard, dispatch, initialLoad, queryParams]);
-
-  // Clear variables on unmount
-  useEffect(() => {
-    return () => {
-      dispatch(DashboardsClearVariables());
-    };
-  }, [dispatch]);
+  }, [project, legacyDashboards, urlBoard, dispatch, queryParams]);
 
   return {
     legacyDashboards,

--- a/web/src/components/dashboards/legacy/useLegacyDashboards.ts
+++ b/web/src/components/dashboards/legacy/useLegacyDashboards.ts
@@ -109,7 +109,14 @@ export const useLegacyDashboards = (urlBoard: string) => {
   const changeLegacyDashboard = useCallback(
     ({ newBoard, newProject }: { newBoard?: string; newProject?: string }) => {
       const dashboardProject = newProject ? newProject : project;
-      const dashboardName = newBoard ? newBoard : urlBoard;
+      // If no new dashboard is specified use the current dashboard name unless
+      // the project is changing to "All Namespaces"
+      let dashboardName = newBoard;
+      if (!newBoard && newProject === ALL_NAMESPACES_KEY) {
+        dashboardName = undefined;
+      } else if (!newBoard) {
+        dashboardName = urlBoard;
+      }
 
       const url = getLegacyDashboardsUrl(perspective, dashboardName, dashboardProject);
 

--- a/web/src/components/dashboards/legacy/useLegacyDashboardsProject.ts
+++ b/web/src/components/dashboards/legacy/useLegacyDashboardsProject.ts
@@ -9,7 +9,7 @@ import { useMonitoring } from '../../../hooks/useMonitoring';
 import { useParams } from 'react-router';
 import { dashboardsPatchVariable } from '../../../store/actions';
 
-export const useLegacyDashboardsProject = () => {
+export const useLegacyDashboardsProject = (dashboardName?: string) => {
   const { perspective } = usePerspective();
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
   const { ns: routeNamespace } = useParams<{ ns?: string }>();
@@ -18,9 +18,11 @@ export const useLegacyDashboardsProject = () => {
     StringParam,
   );
   const { plugin } = useMonitoring();
-  const variableNamespace = useSelector(
-    (state: MonitoringState) =>
-      getObserveState(plugin, state).dashboards.variables['namespace']?.value ?? '',
+  const variableNamespace = useSelector((state: MonitoringState) =>
+    dashboardName
+      ? (getObserveState(plugin, state).dashboards.legacy[dashboardName]?.variables['namespace']
+          ?.value ?? '')
+      : '',
   );
   const dispatch = useDispatch();
 
@@ -30,9 +32,9 @@ export const useLegacyDashboardsProject = () => {
         setOpenshiftProject(activeNamespace);
       }
     } else {
-      if (variableNamespace && variableNamespace !== routeNamespace) {
+      if (dashboardName && variableNamespace && variableNamespace !== routeNamespace) {
         dispatch(
-          dashboardsPatchVariable('namespace', {
+          dashboardsPatchVariable(dashboardName, 'namespace', {
             // Dashboards space variable shouldn't use the ALL_NAMESPACES_KEY
             value: routeNamespace,
           }),
@@ -48,6 +50,7 @@ export const useLegacyDashboardsProject = () => {
     variableNamespace,
     perspective,
     routeNamespace,
+    dashboardName,
   ]);
 
   return {

--- a/web/src/components/dashboards/legacy/utils.ts
+++ b/web/src/components/dashboards/legacy/utils.ts
@@ -1,5 +1,12 @@
+import { NumberParam, withDefault } from 'use-query-params';
+
 export const MONITORING_DASHBOARDS_DEFAULT_TIMESPAN = 30 * 60 * 1000;
 
 export const MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY = 'ALL_OPTION_KEY';
 
 export const DEFAULT_GRAPH_SAMPLES = 60;
+
+const DEFAULT_REFRESH_INTERVAL = 30 * 1000;
+
+export const TimeRangeParam = withDefault(NumberParam, MONITORING_DASHBOARDS_DEFAULT_TIMESPAN);
+export const RefreshIntervalParam = withDefault(NumberParam, DEFAULT_REFRESH_INTERVAL);

--- a/web/src/store/actions.ts
+++ b/web/src/store/actions.ts
@@ -13,13 +13,9 @@ export enum ActionType {
   AlertingSetErrored = 'v2/AlertingSetErrored',
   AlertingSetSilencesErrored = 'v2/AlertingSetSilencesErrored',
   AlertingClearSelectorData = 'v2/AlertingClearSelectorData',
-  DashboardsPatchAllVariables = 'v2/dashboardsPatchAllVariables',
-  DashboardsPatchVariable = 'v2/dashboardsPatchVariable',
-  DashboardsClearVariables = 'v2/dashboardsClearVariables',
-  DashboardsSetEndTime = 'v2/dashboardsSetEndTime',
-  DashboardsSetPollInterval = 'v2/dashboardsSetPollInterval',
-  DashboardsSetTimespan = 'v2/dashboardsSetTimespan',
-  DashboardsVariableOptionsLoaded = 'v2/dashboardsVariableOptionsLoaded',
+  DashboardsPatchAllVariables = 'v3/dashboardsPatchAllVariables',
+  DashboardsPatchVariable = 'v3/dashboardsPatchVariable',
+  DashboardsVariableOptionsLoaded = 'v3/dashboardsVariableOptionsLoaded',
   DashboardsOpened = 'dashboardsPersesDashboardsOpened',
   DashboardsAddPersesPanelExternally = 'dashboardsAddPersesPanelExternally',
   DashboardsPersesPanelExternallyAdded = 'dashboardsPersesPanelExternallyAdded',
@@ -54,25 +50,17 @@ export enum ActionType {
 
 export type Perspective = 'admin' | 'dev' | 'acm' | 'virtualization-perspective';
 
-export const dashboardsPatchVariable = (key: string, patch: any) =>
-  action(ActionType.DashboardsPatchVariable, { key, patch });
+export const dashboardsPatchVariable = (dashboardName: string, key: string, patch: any) =>
+  action(ActionType.DashboardsPatchVariable, { dashboardName, key, patch });
 
-export const dashboardsPatchAllVariables = (variables: any) =>
-  action(ActionType.DashboardsPatchAllVariables, { variables });
+export const dashboardsPatchAllVariables = (dashboardName: string, variables: any) =>
+  action(ActionType.DashboardsPatchAllVariables, { dashboardName, variables });
 
-export const DashboardsClearVariables = () => action(ActionType.DashboardsClearVariables, {});
-
-export const dashboardsSetEndTime = (endTime: number) =>
-  action(ActionType.DashboardsSetEndTime, { endTime });
-
-export const dashboardsSetPollInterval = (pollInterval: number) =>
-  action(ActionType.DashboardsSetPollInterval, { pollInterval });
-
-export const dashboardsSetTimespan = (timespan: number) =>
-  action(ActionType.DashboardsSetTimespan, { timespan });
-
-export const dashboardsVariableOptionsLoaded = (key: string, newOptions: string[]) =>
-  action(ActionType.DashboardsVariableOptionsLoaded, { key, newOptions });
+export const dashboardsVariableOptionsLoaded = (
+  dashboardName: string,
+  key: string,
+  newOptions: string[],
+) => action(ActionType.DashboardsVariableOptionsLoaded, { dashboardName, key, newOptions });
 
 export const dashboardsOpened = (isOpened: boolean) =>
   action(ActionType.DashboardsOpened, { isOpened });
@@ -219,10 +207,6 @@ type Actions = {
   AlertingClearSelectorData: typeof alertingClearSelectorData;
   dashboardsPatchAllVariables: typeof dashboardsPatchAllVariables;
   dashboardsPatchVariable: typeof dashboardsPatchVariable;
-  DashboardsClearVariables: typeof DashboardsClearVariables;
-  dashboardsSetEndTime: typeof dashboardsSetEndTime;
-  dashboardsSetPollInterval: typeof dashboardsSetPollInterval;
-  dashboardsSetTimespan: typeof dashboardsSetTimespan;
   dashboardsVariableOptionsLoaded: typeof dashboardsVariableOptionsLoaded;
   dashboardsOpened: typeof dashboardsOpened;
   dashboardsPersesPanelExternallyAdded: typeof dashboardsPersesPanelExternallyAdded;

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -29,43 +29,32 @@ const monitoringReducer = produce((draft: ObserveState, action: ObserveAction): 
 
   switch (action.type) {
     case ActionType.DashboardsPatchVariable: {
-      // Don't worry about checking if they key exists, since we will just write into the slot
-      // regardless of if it does or doesn't
-      draft.dashboards.variables[action.payload.key] = {
-        ...draft.dashboards.variables[action.payload.key],
-        ...action.payload.patch,
+      const { dashboardName, key, patch } = action.payload;
+      if (!draft.dashboards.legacy[dashboardName]) {
+        draft.dashboards.legacy[dashboardName] = { variables: {} };
+      }
+      draft.dashboards.legacy[dashboardName].variables[key] = {
+        ...draft.dashboards.legacy[dashboardName].variables[key],
+        ...patch,
       };
       break;
     }
 
     case ActionType.DashboardsPatchAllVariables: {
-      draft.dashboards.variables = action.payload.variables;
-      break;
-    }
-
-    case ActionType.DashboardsClearVariables: {
-      draft.dashboards.variables = {};
-      break;
-    }
-
-    case ActionType.DashboardsSetEndTime: {
-      draft.dashboards.endTime = action.payload.endTime;
-      break;
-    }
-
-    case ActionType.DashboardsSetPollInterval: {
-      draft.dashboards.pollInterval = action.payload.pollInterval;
-      break;
-    }
-
-    case ActionType.DashboardsSetTimespan: {
-      draft.dashboards.timespan = action.payload.timespan;
+      const { dashboardName, variables } = action.payload;
+      if (!draft.dashboards.legacy[dashboardName]) {
+        draft.dashboards.legacy[dashboardName] = { variables: {} };
+      }
+      draft.dashboards.legacy[dashboardName].variables = variables;
       break;
     }
 
     case ActionType.DashboardsVariableOptionsLoaded: {
-      const { key, newOptions } = action.payload;
-      const val = draft.dashboards.variables[key];
+      const { dashboardName, key, newOptions } = action.payload;
+      if (!draft.dashboards.legacy[dashboardName]) {
+        draft.dashboards.legacy[dashboardName] = { variables: {} };
+      }
+      const val = draft.dashboards.legacy[dashboardName].variables[key];
       const patch = _.isEqual(val?.options, newOptions)
         ? { isLoading: false }
         : {
@@ -77,7 +66,10 @@ const monitoringReducer = produce((draft: ObserveState, action: ObserveAction): 
                 ? val?.value
                 : newOptions[0],
           };
-      draft.dashboards.variables[key] = { ...draft.dashboards.variables[key], ...patch };
+      draft.dashboards.legacy[dashboardName].variables[key] = {
+        ...draft.dashboards.legacy[dashboardName].variables[key],
+        ...patch,
+      };
       break;
     }
 

--- a/web/src/store/store.ts
+++ b/web/src/store/store.ts
@@ -24,10 +24,11 @@ export type RootState = {
 export type LegacyObserveState = Map<string, any>;
 export type ObserveState = {
   dashboards: {
-    endTime?: number;
-    pollInterval: number;
-    timespan: number;
-    variables: Record<string, Variable>;
+    legacy: {
+      [dashboardName: string]: {
+        variables: Record<string, Variable>;
+      };
+    };
     isOpened: boolean;
     addPersesPanelExternally: PanelDefinition | null;
   };
@@ -66,12 +67,9 @@ export type ObserveState = {
 
 export const defaultObserveState: ObserveState = {
   dashboards: {
-    endTime: null,
-    pollInterval: 30 * 1000,
-    timespan: MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
     isOpened: false,
     addPersesPanelExternally: null,
-    variables: {},
+    legacy: {},
   },
   queryBrowser: {
     pollInterval: null,


### PR DESCRIPTION
This PR looks to refactor the legacy dashboards state to prevent state desync through 2 primary methods:

- remove non-variable dashboard state from the redux store and make all usage rely wholly on the query params
- change the redux store to save variables into their own dashboard key so that the variable state isn't constantly deleted and recreated

It also introduces the usage of the withDefault from the `use-query-params` package to simplify initial loading state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Time range, end time and refresh interval now persist as numeric URL query parameters and drive chart/zoom/poll behavior; dashboard components accept a dashboard identifier so variables are scoped per-dashboard.
* **Bug Fixes**
  * Query views no longer override built-in timespan defaults; URL-driven values take precedence.
* **Chores**
  * Internal action/state wiring updated to support per-dashboard variable handling and query-param-driven timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->