### PR TITLE
OU-1347: fix: avoid throwing error to fallback to global datasource

### DIFF
--- a/web/src/components/dashboards/perses/datasource-api.ts
+++ b/web/src/components/dashboards/perses/datasource-api.ts
@@ -58,7 +58,7 @@ export class OcpDatasourceApi implements DatasourceApi {
       selector.name,
     ).then((list) => {
       if (!Array.isArray(list) || list.length === 0) {
-        throw new Error(this.t('No matching datasource found'));
+        return undefined;
       }
       const datasource = list[0];
       return datasource;


### PR DESCRIPTION
Return undefined rather than throwing an error to allow for global or default datasource fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing datasources—now returns gracefully instead of throwing an error when the datasource list is unavailable or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->