### PR TITLE
OCPBUGS-79448: immutable bump: fix for CVE-2026-29063

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,7 @@
         "fuzzysearch": "1.0.x",
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
-        "immutable": "3.x",
+        "immutable": "^3.8.3",
         "lodash-es": "^4.17.21",
         "murmurhash-js": "1.0.x",
         "react": "^17.0.1",
@@ -8761,9 +8761,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12644,9 +12644,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,7 @@
     "fuzzysearch": "1.0.x",
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
-    "immutable": "3.x",
+    "immutable": "^3.8.3",
     "lodash-es": "^4.17.21",
     "murmurhash-js": "1.0.x",
     "react": "^17.0.1",
@@ -121,7 +121,10 @@
     "path-to-regexp": "^1.9.0",
     "cross-spawn": "^7.0.5",
     "qs": "^6.14.1",
-    "http-errors": "2.0.1"
+    "http-errors": "2.0.1",
+    "sass": {
+      "immutable": "^4.3.7"
+    }
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
To fix CVE-2026-29063, 
1. bump node_modules/immutable from version 3.8.2 to version 3.8.3
2. bump node_modules/sass/node_modules/immutable from version 4.2.2 to version 4.3.8
