### PR TITLE
OU-1348: fix: panel actions index so they are visible on click

### DIFF
--- a/web/src/components/dashboards/perses/dashboard-page.css
+++ b/web/src/components/dashboards/perses/dashboard-page.css
@@ -1,0 +1,3 @@
+#actions-menu {
+  z-index: 100;
+}

--- a/web/src/components/dashboards/perses/dashboard-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-page.tsx
@@ -10,6 +10,7 @@ import { ProjectEmptyState } from './emptystates/ProjectEmptyState';
 import { useDashboardsData } from './hooks/useDashboardsData';
 import { ToastProvider } from './ToastProvider';
 import { ReactRouter7Adapter } from '../../../react-router-7-adapter';
+import './dashboard-page.css';
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Add a custom z index to the perses actions menu to avoid console content overlap and allow clicking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard styling to improve actions menu visibility by adjusting element layering properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->