### PR TITLE
OCPBUGS-79444: immutable bump: fix for CVE-2026-29063

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,7 @@
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
         "i18next-parser": "^8.11.0",
-        "immutable": "3.x",
+        "immutable": "^3.8.3",
         "lodash-es": "^4.17.21",
         "murmurhash-js": "1.0.x",
         "react": "^17.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -46,7 +46,7 @@
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
     "i18next-parser": "^8.11.0",
-    "immutable": "3.x",
+    "immutable": "^3.8.3",
     "lodash-es": "^4.17.21",
     "murmurhash-js": "1.0.x",
     "react": "^17.0.1",
@@ -102,7 +102,10 @@
     "ws": "^8.17.1",
     "braces": "^3.0.3",
     "cross-spawn": "^7.0.5",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "sass": {
+      "immutable": "^5.1.5"
+    }
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
To fix https://www.cve.org/CVERecord?id=CVE-2026-29063,
immutable versions must be >= 3.8.3 or >= 5.1.5