### PR TITLE
OCPBUGS-79460: immutable bump: fix for CVE-2026-29063 [4.21]

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -67,7 +67,7 @@
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
         "immer": "^10.1.3",
-        "immutable": "3.x",
+        "immutable": "^3.8.3",
         "js-yaml": "^4.1.0",
         "lodash-es": "^4.17.21",
         "lru-cache": "^6.0.0",
@@ -16071,9 +16071,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23313,9 +23313,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -103,7 +103,7 @@
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
     "immer": "^10.1.3",
-    "immutable": "3.x",
+    "immutable": "^3.8.3",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "lru-cache": "^6.0.0",
@@ -174,7 +174,10 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "axios": "1.15.0"
+    "axios": "1.15.0",
+    "sass": {
+      "immutable": "^5.1.5"
+    }
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
Fix CVE-2026-29063 (Prototype Pollution in the immutable npm package) by updating the dependency to patched versions.

Changes:

Bumped immutable in dependencies from 3.x to ^3.8.3 (the minimum patched version for the 3.x range)
Added overrides.sass.immutable: ^5.1.5 to force sass's transitive dependency on immutable to the patched 5.x version
Updated package-lock.json accordingly — both immutable@3.8.3 (direct) and immutable@5.1.5 (scoped under node_modules/sass) are now at their respective patched versions
CVE details:

CVE-2026-29063 — Prototype Pollution via mergeDeep(), mergeDeepWith(), merge(), Map.toJS(), Map.toObject()
Affected: < 3.8.3, >= 4.0.0-rc.1 < 4.3.8, >= 5.0.0-beta.1 < 5.1.5
Fixed: 3.8.3, 4.3.8, 5.1.5