### PR TITLE
COO-1776: fix: throw error for unsupported dashboard level datasources

### DIFF
--- a/web/src/components/dashboards/perses/datasource-api.ts
+++ b/web/src/components/dashboards/perses/datasource-api.ts
@@ -39,7 +39,9 @@ export class OcpDatasourceApi implements DatasourceApi {
       name,
     )}`;
     if (dashboard) {
-      url = `dashboards/${encodeURIComponent(dashboard)}/${url}`;
+      throw new Error(
+        'Dashboard level datasources are not supported in OpenShift, please use a project or global level datasource',
+      );
     }
     if (project) {
       url = `projects/${encodeURIComponent(project)}/${url}`;
@@ -77,7 +79,7 @@ export class OcpDatasourceApi implements DatasourceApi {
     ).then((list) => {
       if (!Array.isArray(list) || list.length === 0) {
         // eslint-disable-next-line no-console
-        console.warn('No matching local datasource found');
+        console.warn('No matching global datasource found');
         return undefined;
       }
       const datasource = list[0];


### PR DESCRIPTION
<img width="1750" height="946" alt="Screenshot 2026-05-18 at 14 09 42" src="https://github.com/user-attachments/assets/35ee4894-fce5-4ad5-bc2e-c9d2a1c0b45b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard-level datasources are no longer allowed in OpenShift environments; attempting to use one now shows a clear error message instructing users to configure a project- or global-level datasource instead.
  * Updated console warning text to correctly indicate when no matching global datasource is found, reducing confusion during datasource lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->