### PR TITLE
OCPBUGS-85605: register ACM perspective routes for alerting pages

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -316,6 +316,66 @@
     "type": "console.page/route",
     "properties": {
       "exact": false,
+      "path": "/multicloud/monitoring",
+      "component": {
+        "$codeRef": "AlertingPage.MpCmoAlertingPage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": "/multicloud/monitoring/silences/~new",
+      "component": {
+        "$codeRef": "SilenceCreatePage.MpCmoCreateSilencePage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": "/multicloud/monitoring/silences/:id",
+      "component": {
+        "$codeRef": "SilencesDetailsPage.MpCmoSilencesDetailsPage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": "/multicloud/monitoring/silences/:id/edit",
+      "component": {
+        "$codeRef": "SilenceEditPage.MpCmoSilenceEditPage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": ["/multicloud/monitoring/alertrules/:id"],
+      "component": {
+        "$codeRef": "AlertRulesDetailsPage.MpCmoAlertRulesDetailsPage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": ["/multicloud/monitoring/alerts/:ruleID"],
+      "component": {
+        "$codeRef": "AlertsDetailsPage.MpCmoAlertsDetailsPage"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
       "path": "/dev-monitoring/ns/:ns/alerts/:ruleID",
       "component": {
         "$codeRef": "AlertsDetailsPage.MpCmoAlertsDetailsPage"


### PR DESCRIPTION
The monitoring plugin generates URLs under /multicloud/monitoring/ for the ACM (Fleet Management) perspective but had no matching route entries in console-extensions.json, causing 404 errors when clicking breadcrumbs on alert detail pages.

## Summary
  - Adds 6 `console.page/route` entries for the ACM perspective under
    `/multicloud/monitoring/`, mirroring the existing admin (`/monitoring/`)
    and virt (`/virt-monitoring/`) route patterns
  - Fixes 404 when clicking breadcrumbs (e.g., "Alerts", "Alerting rules")
    on alert/silence detail pages in the Fleet Management perspective

  ## Root Cause
  The URL generation functions in `usePerspective.tsx` produce paths like
  `/multicloud/monitoring/alerts` for the ACM perspective, but no routes
  were registered for that prefix in `console-extensions.json`.

  ## Routes Added
  | Path | Component |
  |------|-----------|
  | `/multicloud/monitoring` | AlertingPage |
  | `/multicloud/monitoring/alerts/:ruleID` | AlertsDetailsPage |
  | `/multicloud/monitoring/alertrules/:id` | AlertRulesDetailsPage |
  | `/multicloud/monitoring/silences/~new` | SilenceCreatePage |
  | `/multicloud/monitoring/silences/:id` | SilencesDetailsPage |
  | `/multicloud/monitoring/silences/:id/edit` | SilenceEditPage |

  ## Verification
  - Admin perspective: breadcrumb navigation confirmed working (no regression)
  - Fleet Management (ACM) perspective: alert rules detail breadcrumb
    navigates back to alerts list; alerts, silences, and alerting rules
    pages all load correctly at `/multicloud/monitoring/*`

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-85605
Related: https://redhat.atlassian.net/browse/DFBUGS-6890

Assisted by Claude code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new multicloud monitoring pages now accessible through the console, including alerting dashboard, alert rules details, silence management (create/view/edit modes), and individual alert details views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->