### PR TITLE
OBSINTA-1358: add operator-sdk to Cypress test runner image

### DIFF
--- a/web/cypress/Dockerfile
+++ b/web/cypress/Dockerfile
@@ -1,6 +1,8 @@
 # This Dockerfile is used by OpenShift CI for running the Monitorung UI plugin tests
 FROM quay.io/redhat-distributed-tracing-qe/cypress-base:latest
 
+COPY --from=quay.io/operator-framework/operator-sdk:v1.42.0 /usr/local/bin/operator-sdk /usr/local/bin/operator-sdk
+
 # Copy current context and set working directory
 COPY . /tmp/monitoring-plugin
 RUN chmod -R 777 /tmp/monitoring-plugin


### PR DESCRIPTION
Adds `operator-sdk` binary to the Cypress test runner image (`web/cypress/Dockerfile`).

Fixes `operator-sdk: command not found` (exit 127) when `CYPRESS_CUSTOM_COO_BUNDLE_IMAGE` is set in CI periodic jobs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environment configuration to use a specific version of the operator SDK, improving consistency across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->