### PR TITLE
OU-1399: pass ISO string to Timestamp component for valid date rendering

### DIFF
--- a/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
@@ -45,13 +45,17 @@ const IncidentsDetailsRowTable = ({ alerts }: IncidentsDetailsRowTableProps) => 
                 <SeverityBadge severity={alertDetails.severity} />
               </Td>
               <Td dataLabel="expanded-details-firingstart">
-                <Timestamp timestamp={String(alertDetails.alertsStartFiring * 1000)} />
+                <Timestamp
+                  timestamp={new Date(alertDetails.alertsStartFiring * 1000).toISOString()}
+                />
               </Td>
               <Td dataLabel="expanded-details-firingend">
                 {!alertDetails.resolved ? (
                   '---'
                 ) : (
-                  <Timestamp timestamp={String(alertDetails.alertsEndFiring * 1000)} />
+                  <Timestamp
+                    timestamp={new Date(alertDetails.alertsEndFiring * 1000).toISOString()}
+                  />
                 )}
               </Td>
               <Td dataLabel="expanded-details-alertstate">

--- a/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
+++ b/web/src/components/Incidents/IncidentsDetailsRowTable.tsx
@@ -45,12 +45,16 @@ const IncidentsDetailsRowTable = ({ alerts }: IncidentsDetailsRowTableProps) => 
                 <SeverityBadge severity={alertDetails.severity} />
               </Td>
               <Td dataLabel="expanded-details-firingstart">
-                <Timestamp
-                  timestamp={new Date(alertDetails.alertsStartFiring * 1000).toISOString()}
-                />
+                {alertDetails.alertsStartFiring ? (
+                  <Timestamp
+                    timestamp={new Date(alertDetails.alertsStartFiring * 1000).toISOString()}
+                  />
+                ) : (
+                  '---'
+                )}
               </Td>
               <Td dataLabel="expanded-details-firingend">
-                {!alertDetails.resolved ? (
+                {!alertDetails.resolved || !alertDetails.alertsEndFiring ? (
                   '---'
                 ) : (
                   <Timestamp

--- a/web/src/components/Incidents/IncidentsTable.tsx
+++ b/web/src/components/Incidents/IncidentsTable.tsx
@@ -180,7 +180,9 @@ export const IncidentsTable = () => {
                       )}
                     </Td>
                     <Td dataLabel={columnNames.startDate}>
-                      <Timestamp timestamp={String(getMinStartDate(alert) * 1000)} />
+                      <Timestamp
+                        timestamp={new Date(getMinStartDate(alert) * 1000).toISOString()}
+                      />
                     </Td>
                     <Td
                       dataLabel={columnNames.state}

--- a/web/src/components/Incidents/IncidentsTable.tsx
+++ b/web/src/components/Incidents/IncidentsTable.tsx
@@ -95,7 +95,10 @@ export const IncidentsTable = () => {
     if (!alert.alertsExpandedRowData || alert.alertsExpandedRowData.length === 0) {
       return 0;
     }
-    return Math.min(...alert.alertsExpandedRowData.map((alertData) => alertData.alertsStartFiring));
+    const min = Math.min(
+      ...alert.alertsExpandedRowData.map((alertData) => alertData.alertsStartFiring),
+    );
+    return Number.isFinite(min) ? min : 0;
   };
 
   if (isEmpty(alertsTableData) || alertsAreLoading || isEmpty(incidentsActiveFilters.groupId)) {
@@ -180,9 +183,13 @@ export const IncidentsTable = () => {
                       )}
                     </Td>
                     <Td dataLabel={columnNames.startDate}>
-                      <Timestamp
-                        timestamp={new Date(getMinStartDate(alert) * 1000).toISOString()}
-                      />
+                      {getMinStartDate(alert) > 0 ? (
+                        <Timestamp
+                          timestamp={new Date(getMinStartDate(alert) * 1000).toISOString()}
+                        />
+                      ) : (
+                        '---'
+                      )}
                     </Td>
                     <Td
                       dataLabel={columnNames.state}


### PR DESCRIPTION
String(epochMs) produces a numeric string that new Date() cannot parse, resulting in Invalid Date and "-" displayed in the Start/End columns. Convert to ISO 8601 format via toISOString() instead.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Start and End timestamps now use standardized ISO formatting for consistent display.
  * When start or end times are unavailable (or an incident isn't resolved), the table shows '---' instead of a timestamp for clearer, more accurate incident status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->