### PR TITLE
Fix for OCPBUGS-81614: CVE-2026-4800

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -69,7 +69,7 @@
         "immer": "^10.1.3",
         "immutable": "^3.8.3",
         "js-yaml": "^4.1.0",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "lru-cache": "^6.0.0",
         "murmurhash-js": "1.0.x",
         "react": "^17.0.1",
@@ -18856,9 +18856,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeepwith": {

--- a/web/package.json
+++ b/web/package.json
@@ -105,7 +105,7 @@
     "immer": "^10.1.3",
     "immutable": "^3.8.3",
     "js-yaml": "^4.1.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.18.1",
     "lru-cache": "^6.0.0",
     "murmurhash-js": "1.0.x",
     "react": "^17.0.1",


### PR DESCRIPTION
CVE-2026-4800:  Arbitrary code execution via untrusted input in template imports

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED