### PR TITLE
OBSDA-609: feat: add multi-namespace selector to Developer Metrics page

### DIFF
--- a/web/src/components/MetricsPage.tsx
+++ b/web/src/components/MetricsPage.tsx
@@ -118,6 +118,8 @@ import { MonitoringProvider } from '../contexts/MonitoringContext';
 import { DataTestIDs } from './data-test';
 import { useMonitoring } from '../hooks/useMonitoring';
 import { useMonitoringNamespace } from './hooks/useMonitoringNamespace';
+import { useMultiNamespace } from './hooks/useMultiNamespace';
+import { MultiNamespaceSelector } from './multi-namespace-selector';
 import { useSearchParams } from 'react-router';
 
 // Stores information about the currently focused query input
@@ -952,7 +954,8 @@ const Query: FC<{
   index: number;
   customDatasource?: CustomDataSource;
   units: GraphUnits;
-}> = ({ index, customDatasource, units }) => {
+  namespaceOverride?: string | string[];
+}> = ({ index, customDatasource, units, namespaceOverride }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { plugin } = useMonitoring();
 
@@ -1069,7 +1072,7 @@ const Query: FC<{
         <QueryTable
           index={index}
           customDatasource={customDatasource}
-          namespace={activeNamespace}
+          namespace={namespaceOverride ?? activeNamespace}
           units={units}
         />
       </DataListContent>
@@ -1082,7 +1085,14 @@ const QueryBrowserWrapper: FC<{
   customDataSource: CustomDataSource;
   customDatasourceError: boolean;
   units: GraphUnits;
-}> = ({ customDataSourceName, customDataSource, customDatasourceError, units }) => {
+  namespaceOverride?: string | string[];
+}> = ({
+  customDataSourceName,
+  customDataSource,
+  customDatasourceError,
+  units,
+  namespaceOverride,
+}) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { plugin } = useMonitoring();
   const [activeNamespace] = useActiveNamespace();
@@ -1209,6 +1219,7 @@ const QueryBrowserWrapper: FC<{
     <QueryBrowser
       customDataSource={customDataSource}
       disabledSeries={disabledSeries}
+      namespace={namespaceOverride}
       queries={queryStrings}
       units={units}
       showStackedControl
@@ -1263,10 +1274,11 @@ const RunQueriesButton: FC = () => {
   );
 };
 
-const QueriesList: FC<{ customDatasource?: CustomDataSource; units: GraphUnits }> = ({
-  customDatasource,
-  units,
-}) => {
+const QueriesList: FC<{
+  customDatasource?: CustomDataSource;
+  units: GraphUnits;
+  namespaceOverride?: string | string[];
+}> = ({ customDatasource, units, namespaceOverride }) => {
   const { plugin } = useMonitoring();
   const count = useSelector(
     (state: MonitoringState) => getObserveState(plugin, state).queryBrowser.queries.length,
@@ -1282,6 +1294,7 @@ const QueriesList: FC<{ customDatasource?: CustomDataSource; units: GraphUnits }
             key={reversedIndex}
             customDatasource={customDatasource}
             units={units}
+            namespaceOverride={namespaceOverride}
           />
         );
       })}
@@ -1339,7 +1352,8 @@ const MetricsPage_: FC = () => {
   const [units, setUnits] = useQueryParam(QueryParams.Units, StringParam);
   const [customDataSourceName] = useQueryParam(QueryParams.Datasource, StringParam);
   const { namespace, setNamespace } = useMonitoringNamespace();
-  const { displayNamespaceSelector } = useMonitoring();
+  const { displayNamespaceSelector, useMetricsTenancy } = useMonitoring();
+  const multiNs = useMultiNamespace();
 
   const dispatch = useDispatch();
 
@@ -1456,6 +1470,18 @@ const MetricsPage_: FC = () => {
       </ListPageHeader>
       <PageSection hasBodyWrapper={false}>
         <Stack hasGutter>
+          {useMetricsTenancy && (
+            <StackItem>
+              <MultiNamespaceSelector
+                accessibleNamespaces={multiNs.accessibleNamespaces}
+                selectedNamespaces={multiNs.selectedNamespaces}
+                allSelected={multiNs.allSelected}
+                toggleNamespace={multiNs.toggleNamespace}
+                toggleAll={multiNs.toggleAll}
+                deselectAll={multiNs.deselectAll}
+              />
+            </StackItem>
+          )}
           <StackItem>
             <ToggleGraph />
           </StackItem>
@@ -1465,6 +1491,7 @@ const MetricsPage_: FC = () => {
               customDataSourceName={customDataSourceName}
               customDatasourceError={customDatasourceError}
               units={units as GraphUnits}
+              namespaceOverride={useMetricsTenancy ? multiNs.namespaceForQuery : undefined}
             />
           </StackItem>
           <StackItem>
@@ -1482,7 +1509,11 @@ const MetricsPage_: FC = () => {
             </Flex>
           </StackItem>
           <StackItem>
-            <QueriesList customDatasource={customDataSource} units={units as GraphUnits} />
+            <QueriesList
+              customDatasource={customDataSource}
+              units={units as GraphUnits}
+              namespaceOverride={useMetricsTenancy ? multiNs.namespaceForQuery : undefined}
+            />
           </StackItem>
         </Stack>
       </PageSection>
@@ -1516,7 +1547,7 @@ export const MpCmoDevMetricsPage: FC = () => {
 
 type QueryTableProps = {
   index: number;
-  namespace?: string;
+  namespace?: string | string[];
   customDatasource?: CustomDataSource;
   units: GraphUnits;
 };

--- a/web/src/components/hooks/useMultiNamespace.ts
+++ b/web/src/components/hooks/useMultiNamespace.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  K8sResourceKind,
+  useActiveNamespace,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { ALL_NAMESPACES_KEY } from '../utils';
+import { ProjectModel } from '../console/models';
+
+/**
+ * Hook to manage multi-namespace selection for the monitoring plugin.
+ * Returns the list of accessible namespaces, selected namespaces, and a setter.
+ * When "All Namespaces" is toggled, all accessible namespaces are selected.
+ */
+export const useMultiNamespace = () => {
+  const [activeNamespace] = useActiveNamespace();
+
+  const [namespaceResources] = useK8sWatchResource<K8sResourceKind[]>({
+    kind: ProjectModel.kind,
+    isList: true,
+    optional: true,
+  });
+
+  const accessibleNamespaces = useMemo(
+    () =>
+      (namespaceResources || [])
+        .map((ns) => ns.metadata?.name)
+        .filter(Boolean)
+        .sort() as string[],
+    [namespaceResources],
+  );
+
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
+  const [allSelected, setAllSelected] = useState(false);
+  const isInitialized = useRef(false);
+
+  useEffect(() => {
+    if (
+      !isInitialized.current &&
+      activeNamespace &&
+      activeNamespace !== ALL_NAMESPACES_KEY &&
+      selectedNamespaces.length === 0
+    ) {
+      setSelectedNamespaces([activeNamespace]);
+      isInitialized.current = true;
+    }
+  }, [activeNamespace]);
+
+  const toggleNamespace = useCallback((ns: string) => {
+    setAllSelected(false);
+    setSelectedNamespaces((prev) =>
+      prev.includes(ns) ? prev.filter((n) => n !== ns) : [...prev, ns],
+    );
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setAllSelected(true);
+    setSelectedNamespaces(accessibleNamespaces);
+  }, [accessibleNamespaces]);
+
+  const deselectAll = useCallback(() => {
+    setAllSelected(false);
+    setSelectedNamespaces([]);
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      deselectAll();
+    } else {
+      selectAll();
+    }
+  }, [allSelected, selectAll, deselectAll]);
+
+  const namespaceForQuery = useMemo(() => {
+    if (selectedNamespaces.length === 0) {
+      return activeNamespace === ALL_NAMESPACES_KEY ? undefined : activeNamespace;
+    }
+    if (selectedNamespaces.length === 1) {
+      return selectedNamespaces[0];
+    }
+    return selectedNamespaces;
+  }, [selectedNamespaces, activeNamespace]);
+
+  return {
+    accessibleNamespaces,
+    selectedNamespaces,
+    allSelected,
+    toggleNamespace,
+    selectAll,
+    deselectAll,
+    toggleAll,
+    setSelectedNamespaces,
+    namespaceForQuery,
+  };
+};

--- a/web/src/components/multi-namespace-selector.tsx
+++ b/web/src/components/multi-namespace-selector.tsx
@@ -1,0 +1,182 @@
+import {
+  Label,
+  LabelGroup,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+  Badge,
+  Divider,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import type { FC, Ref } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const MAX_NAMESPACES = 25;
+
+type MultiNamespaceSelectorProps = {
+  accessibleNamespaces: string[];
+  selectedNamespaces: string[];
+  allSelected: boolean;
+  toggleNamespace: (ns: string) => void;
+  toggleAll: () => void;
+  deselectAll: () => void;
+};
+
+export const MultiNamespaceSelector: FC<MultiNamespaceSelectorProps> = ({
+  accessibleNamespaces,
+  selectedNamespaces,
+  allSelected,
+  toggleNamespace,
+  toggleAll,
+  deselectAll,
+}) => {
+  const { t } = useTranslation(process.env.I18N_NAMESPACE);
+  const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
+  const textInputRef = useRef<HTMLInputElement>();
+
+  const filteredNamespaces = useMemo(
+    () =>
+      filterValue
+        ? accessibleNamespaces.filter((ns) => ns.toLowerCase().includes(filterValue.toLowerCase()))
+        : accessibleNamespaces,
+    [accessibleNamespaces, filterValue],
+  );
+
+  const onToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const onSelect = (_event: React.MouseEvent, value: string) => {
+    if (value === '__all__') {
+      toggleAll();
+    } else {
+      if (
+        !allSelected &&
+        selectedNamespaces.length >= MAX_NAMESPACES &&
+        !selectedNamespaces.includes(value)
+      ) {
+        return;
+      }
+      toggleNamespace(value);
+    }
+  };
+
+  const onTextInputChange = (_event: React.FormEvent, value: string) => {
+    setFilterValue(value);
+  };
+
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+    <MenuToggle
+      variant="typeahead"
+      onClick={onToggle}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      style={{ width: '400px' }}
+      data-test="multi-namespace-toggle"
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={filterValue}
+          onClick={onToggle}
+          onChange={onTextInputChange}
+          innerRef={textInputRef}
+          placeholder={
+            selectedNamespaces.length > 0
+              ? t('{{count}} namespace(s) selected', { count: selectedNamespaces.length })
+              : t('Select namespaces...')
+          }
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="multi-namespace-select-listbox"
+        />
+        <TextInputGroupUtilities>
+          {selectedNamespaces.length > 0 && (
+            <Button
+              variant="plain"
+              onClick={() => {
+                deselectAll();
+                setFilterValue('');
+              }}
+              aria-label={t('Clear selections')}
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+          {selectedNamespaces.length > 0 && <Badge isRead>{selectedNamespaces.length}</Badge>}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <div>
+      <Select
+        id="multi-namespace-select"
+        isOpen={isOpen}
+        selected={selectedNamespaces}
+        onSelect={onSelect}
+        onOpenChange={(open) => setIsOpen(open)}
+        toggle={toggle}
+        data-test="multi-namespace-selector"
+      >
+        <SelectList id="multi-namespace-select-listbox">
+          <SelectOption
+            hasCheckbox
+            value="__all__"
+            isSelected={allSelected}
+            data-test="multi-namespace-all-option"
+          >
+            {t('All Namespaces')}
+            <Badge isRead style={{ marginLeft: '8px' }}>
+              {accessibleNamespaces.length}
+            </Badge>
+          </SelectOption>
+          <Divider />
+          {filteredNamespaces.map((ns) => (
+            <SelectOption
+              hasCheckbox
+              key={ns}
+              value={ns}
+              isSelected={selectedNamespaces.includes(ns)}
+              isDisabled={
+                !allSelected &&
+                selectedNamespaces.length >= MAX_NAMESPACES &&
+                !selectedNamespaces.includes(ns)
+              }
+              data-test={`multi-namespace-option-${ns}`}
+            >
+              {ns}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+      {selectedNamespaces.length > 0 && selectedNamespaces.length <= 10 && (
+        <LabelGroup categoryName={t('Namespaces')} style={{ marginTop: '8px' }}>
+          {selectedNamespaces.map((ns) => (
+            <Label key={ns} onClose={() => toggleNamespace(ns)} variant="outline">
+              {ns}
+            </Label>
+          ))}
+        </LabelGroup>
+      )}
+      {selectedNamespaces.length > MAX_NAMESPACES && (
+        <div
+          style={{
+            marginTop: '8px',
+            color: 'var(--pf-t--global--color--status--warning--default)',
+          }}
+        >
+          {t('Maximum {{max}} namespaces can be queried at once.', { max: MAX_NAMESPACES })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -597,6 +597,7 @@ const QueryBrowser_: FC<QueryBrowserProps> = ({
   GraphLink,
   hideControls,
   isStack = false,
+  namespace: namespaceProp,
   onLoadingChange,
   onZoom,
   pollInterval,
@@ -659,7 +660,8 @@ const QueryBrowser_: FC<QueryBrowserProps> = ({
 
   const canStack = _.sumBy(graphData, 'length') <= maxStacks;
 
-  const [namespace] = useActiveNamespace();
+  const [activeNs] = useActiveNamespace();
+  const namespace = namespaceProp ?? activeNs;
 
   // If provided, `timespan` overrides any existing span setting
   useEffect(() => {
@@ -1115,6 +1117,7 @@ export type QueryBrowserProps = {
   GraphLink?: ComponentType;
   hideControls?: boolean;
   isStack?: boolean;
+  namespace?: string | string[];
   onLoadingChange?: (isLoading: boolean) => void;
   onZoom?: GraphOnZoom;
   pollInterval?: number;

--- a/web/src/components/utils.ts
+++ b/web/src/components/utils.ts
@@ -215,6 +215,7 @@ const getSearchParams = ({
   endTime,
   timespan,
   samples,
+  namespace,
   ...params
 }: PrometheusURLProps): URLSearchParams => {
   const searchParams =
@@ -222,8 +223,11 @@ const getSearchParams = ({
       ? getRangeVectorSearchParams(endTime, samples, timespan)
       : new URLSearchParams();
   _.each(params, (value, key) => value && searchParams.append(key, value.toString()));
-  if (searchParams.get(QueryParams.Namespace) === ALL_NAMESPACES_KEY) {
-    searchParams.delete(QueryParams.Namespace);
+  if (Array.isArray(namespace)) {
+    const filtered = namespace.filter((ns) => ns && ns !== ALL_NAMESPACES_KEY);
+    filtered.forEach((ns) => searchParams.append(QueryParams.Namespace, ns));
+  } else if (namespace && namespace !== ALL_NAMESPACES_KEY) {
+    searchParams.append(QueryParams.Namespace, namespace);
   }
   return searchParams;
 };
@@ -257,14 +261,14 @@ export const buildPrometheusUrl = ({
   prometheusUrlProps: PrometheusURLProps;
   basePath: string;
 }): string | null => {
-  if (
-    basePath !== PROMETHEUS_TENANCY_BASE_PATH ||
-    prometheusUrlProps.namespace === ALL_NAMESPACES_KEY
-  ) {
+  const ns = prometheusUrlProps.namespace;
+  const isAllNs = Array.isArray(ns)
+    ? ns.length === 0 || ns.includes(ALL_NAMESPACES_KEY)
+    : ns === ALL_NAMESPACES_KEY;
+  if (basePath !== PROMETHEUS_TENANCY_BASE_PATH || isAllNs) {
     prometheusUrlProps.namespace = undefined;
   }
   if (prometheusUrlProps.endpoint !== PrometheusEndpoint.RULES && !prometheusUrlProps.query) {
-    // Empty query provided, skipping API call
     return null;
   }
 
@@ -277,7 +281,7 @@ export const buildPrometheusUrl = ({
 type PrometheusURLProps = {
   endpoint: PrometheusEndpoint;
   endTime?: number;
-  namespace?: string;
+  namespace?: string | string[];
   query?: string;
   samples?: number;
   timeout?: string;


### PR DESCRIPTION
## Summary

Non-admin users in the Developer Console (Observe > Metrics) can currently only query metrics for one namespace at a time. This PR adds a multi-namespace selector dropdown that allows querying across multiple namespaces simultaneously, without requiring cluster-admin privileges.

- Adds a PatternFly v6 multi-select namespace dropdown to the Metrics page (Developer perspective only)
- Uses the OpenShift Project API (`project.openshift.io`) to list only namespaces the user has RBAC access to
- Extends `PrometheusURLProps.namespace` to accept `string | string[]`, appending each as a separate `?namespace=` query parameter
- Includes "All Namespaces" toggle and a 25-namespace safeguard cap to prevent Thanos overload

### Key finding

The backend monitoring stack (thanos-querier, prom-label-proxy, kube-rbac-proxy, console proxy) **already supports multi-namespace queries natively**. This change is **frontend-only** — no backend, operator, or cluster-level modifications are required.

### Files changed

**New files:**
- `web/src/components/hooks/useMultiNamespace.ts` — Hook managing multi-namespace selection state via ProjectModel
- `web/src/components/multi-namespace-selector.tsx` — PatternFly v6 multi-select dropdown component

**Modified files:**
- `web/src/components/utils.ts` — Extended namespace type and URL builder for arrays
- `web/src/components/MetricsPage.tsx` — Integrated selector and threaded `namespaceOverride` to downstream components
- `web/src/components/query-browser.tsx` — Added optional `namespace` prop to `QueryBrowserProps`

### Design decisions

- **Project API instead of Namespace API** — non-admin users cannot list cluster-scoped Namespaces; the Project API returns only projects the user has access to (pattern already used in `useOcpProjects`, `useActiveProject`)
- **Developer perspective only** — selector renders only when `useMetricsTenancy` is true; Admin perspective already has cluster-wide access
- **Backward compatible** — single namespace selection behaves identically to current behavior

## Screenshots

**Before** — single project selector, one namespace at a time:

![Before](https://github.com/user-attachments/assets/OBSDA-609-before)

**After** — multi-namespace selector with all namespaces selected and cross-namespace graph:

![After](https://github.com/user-attachments/assets/OBSDA-609-after)

## Test plan

- [x] Verified backend supports multi-namespace queries via `oc port-forward` to thanos-querier:9092
- [x] Built and deployed custom image to OCP 4.22 cluster
- [x] Logged in as non-admin user (`titan`) with access to app1, app2, app3
- [x] Multi-namespace selector appears in Developer > Observe > Metrics
- [x] Cross-namespace metric queries return correct results
- [x] "All Namespaces" toggle selects all accessible projects
- [x] RBAC boundaries maintained — no unauthorized data exposed
- [x] Single namespace selection works identically to current behavior
- [x] Admin perspective unaffected — selector does not appear

Jira: https://redhat.atlassian.net/browse/OBSDA-609

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-namespace selector for metrics queries with support for up to 25 namespaces.
  * Select all / deselect all and toggle behavior with visual selection indicators and count badge.
  * Per-query execution now supports single or multiple namespaces.
  * Query building and polling respect the selected namespace(s), including handling of the “all namespaces” case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->