### PR TITLE
OCPBUGS-84991,OCPBUGS-85007,OCPBUGS-84828,OCPBUGS-85037: Update Axios to v1.15.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9474,9 +9474,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/web/package.json
+++ b/web/package.json
@@ -174,7 +174,7 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "sass": {
       "immutable": "^5.1.5"
     }


### PR DESCRIPTION
This update remediates three CVEs in axios < 1.15.1:

CVE-2026-42043 (GHSA-pmwg-cvhr-8vh7) - CVSS 7.2 HIGH
  NO_PROXY bypass vulnerability allowing SSRF attacks via 127.0.0.0/8
  addresses (except 127.0.0.1).

CVE-2026-42039 (GHSA-62hf-57xw-28j9) - CVSS 6.9 MODERATE
  Denial of Service via unbounded recursion in toFormData causing
  RangeError at depth ~2500.

CVE-2026-42033 (GHSA-pf86-5x62-jrwf) - CVSS 7.4 HIGH
  Prototype Pollution gadgets enabling response tampering and request
  hijacking when Object.prototype is polluted.

Risk Assessment: LOW
  - axios is a transitive dependency via @perses-dev/plugin-system
  - NOT directly imported in application code
  - Only used by webpack build tooling, not in runtime

Local Testing Performed:
  - ESLint: PASSED (1 pre-existing warning unrelated to axios)
  - Unit Tests: PASSED (119/120 - 1 pre-existing failure unrelated)
  - Build: PASSED (webpack compiled successfully)

Updated axios from 1.15.0 to 1.15.2 via npm overrides.