### PR TITLE
OCPBUGS-84290: bump follow-redirects to 1.16.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14482,9 +14482,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/web/package.json
+++ b/web/package.json
@@ -175,6 +175,7 @@
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
     "axios": "1.15.2",
+    "follow-redirects": "^1.16.0",
     "sass": {
       "immutable": "^5.1.5"
     }


### PR DESCRIPTION
bump follow-redirects to 1.16.0