### PR TITLE
OCPBUGS-87979:[release-4.22] fast-uri: URI authority bypass due to improper delimiter handling

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13663,9 +13663,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -162,6 +162,7 @@
   },
   "overrides": {
     "echarts": "^5.6.0",
+    "fast-uri": "^3.1.2",
     "qs": "^6.14.1"
   },
   "consolePlugin": {


### PR DESCRIPTION
While working on CVE-2026-6322 I have observed fast-uri package has been used as a transitive dependency and in addition to it is using the vulnerable version. So, in order to resolve this issue I have bumped the fast-uri package to the patched version (3.1.2).