### PR TITLE
OBSINTA-1387: add OLS add-to-dashboard e2e test

### DIFF
--- a/web/cypress/E2E_TEST_SCENARIOS.md
+++ b/web/cypress/E2E_TEST_SCENARIOS.md
@@ -31,6 +31,7 @@ Located in `e2e/coo/`
 | File | Test Suite | Test Scenario | Description |
 |------|------------|---------------|-------------|
 | `03.coo_lightspeed_show_timeseries.cy.ts` | COO-LightSpeed: show_timeseries | switches to troubleshooting mode, sends a prompt, and renders a Perses dashboard | **Non-deterministic** — sends a natural-language prompt to the live OLS AI and asserts it responds with a `show_timeseries` tool call that renders a Perses chart. Tagged `@ols`, must not gate CI. |
+| `03.coo_lightspeed_show_timeseries.cy.ts` | COO-LightSpeed: show_timeseries | adds the rendered chart to a new Perses dashboard via Add to Dashboard button | **Non-deterministic** — creates a new Perses dashboard, sends a prompt to OLS, then uses the "Add to Dashboard" button to add the rendered chart to the dashboard. Verifies the panel appears and persists after save. Tagged `@ols`, must not gate CI. |
 
 ---
 

--- a/web/cypress/e2e/coo/03.coo_lightspeed_show_timeseries.cy.ts
+++ b/web/cypress/e2e/coo/03.coo_lightspeed_show_timeseries.cy.ts
@@ -1,9 +1,18 @@
 import { operatorAuthUtils } from '../../support/commands/auth-commands';
+import { nav } from '../../views/nav';
+import { commonPages } from '../../views/common';
+import { listPersesDashboardsPage } from '../../views/perses-dashboards-list-dashboards';
+import { persesCreateDashboardsPage } from '../../views/perses-dashboards-create-dashboard';
+import { persesDashboardsPage } from '../../views/perses-dashboards';
+import { persesMUIDataTestIDs } from '../../../src/components/data-test';
 
 const PROMPT = 'visualize CPU consumption in the openshift-monitoring namespace in last 2 hours';
 
 // LLM responses can be slow under CI load or cold-start conditions
 const OLS_RESPONSE_TIMEOUT = 120_000;
+
+const DASHBOARD_PROJECT = Cypress.env('COO_NAMESPACE');
+const DASHBOARD_NAME = 'OLS-test-dashboard-' + Math.random().toString(36).substring(2, 8);
 
 // Selectors prefixed with ols-plugin__ are defined in the OLS plugin repo (openshift-lightspeed)
 const SEL = {
@@ -15,6 +24,7 @@ const SEL = {
   aiResponse: '[data-test="ols-plugin__chat-entry-ai"]',
   persesPanel: '[data-test="ols-plugin__chat-entry-ai"] [class*="MuiPaper"]',
   persesSvg: 'svg path',
+  addToDashboard: '[aria-label="Add to dashboard"]',
 };
 
 /**
@@ -36,8 +46,30 @@ describe('COO-LightSpeed: show_timeseries', { tags: ['@ols'] }, () => {
   after(() => {
     cy.get('body').then(($body) => {
       if ($body.find(SEL.chatPanel).length > 0) {
-        cy.get(SEL.chatButton).click();
+        cy.get(SEL.chatButton).click({ force: true });
       }
+    });
+
+    // Clean up the test dashboard via CLI — more reliable than UI cleanup
+    // when modals or overlays may be blocking interaction.
+    cy.adminCLI(
+      `oc delete persesdashboard -n ${DASHBOARD_PROJECT} -l app.kubernetes.io/managed-by=perses ` +
+        `--field-selector metadata.name=${DASHBOARD_NAME} --ignore-not-found`,
+    ).then(() => {
+      // Fallback: delete any dashboard whose CR name matches the display name pattern
+      cy.exec(
+        `oc get persesdashboard -n ${DASHBOARD_PROJECT} -o name --kubeconfig ${Cypress.env('KUBECONFIG_PATH')}`,
+        { failOnNonZeroExit: false },
+      ).then((result) => {
+        if (result.stdout) {
+          const dashboards = result.stdout
+            .split('\n')
+            .filter((d) => d.includes('ols-test-dashboard'));
+          dashboards.forEach((d) => {
+            cy.adminCLI(`oc delete ${d} -n ${DASHBOARD_PROJECT} --ignore-not-found`);
+          });
+        }
+      });
     });
   });
 
@@ -70,5 +102,75 @@ describe('COO-LightSpeed: show_timeseries', { tags: ['@ols'] }, () => {
     cy.get(SEL.persesPanel).should('contain.text', 'CPU');
     cy.get(SEL.persesPanel).should('contain.text', 'openshift-monitoring');
     cy.get(SEL.persesPanel).find('svg path[d]').should('have.length.greaterThan', 0);
+  });
+
+  it('adds the rendered chart to a new Perses dashboard via Add to Dashboard button', () => {
+    // Close the chat panel if it is open from the previous test
+    cy.get('body').then(($body) => {
+      if ($body.find(SEL.chatPanel).length > 0) {
+        cy.get(SEL.chatButton).click();
+      }
+    });
+
+    // Navigate to Dashboards (Perses) and create a new dashboard
+    nav.sidenav.clickNavLink(['Observe', 'Dashboards (Perses)']);
+    commonPages.titleShouldHaveText('Dashboards');
+
+    listPersesDashboardsPage.clickCreateButton();
+    persesCreateDashboardsPage.createDashboardShouldBeLoaded();
+    persesCreateDashboardsPage.selectProject(DASHBOARD_PROJECT);
+    persesCreateDashboardsPage.enterDashboardName(DASHBOARD_NAME);
+    persesCreateDashboardsPage.createDashboardDialogCreateButton();
+    persesDashboardsPage.shouldBeLoadedEditionMode(DASHBOARD_NAME);
+    persesDashboardsPage.shouldBeLoadedEditionModeFromCreateDashboard();
+
+    // Save the empty dashboard first so it exits edit mode
+    persesDashboardsPage.clickEditActionButton('Save');
+
+    // Open OLS chat and send prompt
+    cy.get(SEL.chatButton).click();
+    cy.get(SEL.chatPanel).should('be.visible');
+
+    cy.get(SEL.modeToggle).click();
+    cy.get('[role="option"]').contains('Troubleshooting').click();
+    cy.get(SEL.modeToggle).should('contain.text', 'Troubleshooting');
+
+    cy.get(SEL.promptTextarea).clear().type(PROMPT);
+    cy.get(SEL.sendButton).click();
+
+    // Wait for the AI response with show_timeseries tool call
+    cy.get(SEL.aiResponse, { timeout: OLS_RESPONSE_TIMEOUT }).last().should('be.visible');
+
+    cy.get(SEL.aiResponse, { timeout: OLS_RESPONSE_TIMEOUT })
+      .last()
+      .find('[class*="label"]')
+      .contains('show_timeseries')
+      .should('exist');
+
+    cy.get(SEL.persesPanel, { timeout: OLS_RESPONSE_TIMEOUT }).should('exist');
+
+    // Wait for the streaming response to stabilize before interacting
+    cy.wait(5000);
+
+    // The "Add to dashboard" button should be visible because a dashboard is open.
+    // The AI may return multiple show_timeseries tool calls, so pick the first one.
+    // The button may be inside a collapsed tool-call accordion in the OLS chat,
+    // so use force:true to click it regardless of visibility.
+    cy.get(SEL.aiResponse).last().find(SEL.addToDashboard).first().click({ force: true });
+
+    // Close the chat panel to see the dashboard
+    cy.get(SEL.chatButton).click();
+
+    // The dashboard should have entered edit mode and the panel should be added
+    cy.wait(5000);
+
+    // Verify a panel was added to the dashboard
+    cy.byDataTestID(persesMUIDataTestIDs.panelHeader).find('h6').should('be.visible');
+
+    // Save the dashboard with the added panel
+    persesDashboardsPage.clickEditActionButton('Save');
+
+    // Verify the panel persists after save
+    cy.byDataTestID(persesMUIDataTestIDs.panelHeader).find('h6').should('be.visible');
   });
 });


### PR DESCRIPTION
Extend the OLS show_timeseries e2e test with a second scenario that creates a new Perses dashboard, sends a prompt to OLS, and uses the "Add to Dashboard" button to add the rendered chart. Verifies the panel appears and persists after save. Dashboard cleanup uses CLI for reliability against UI overlays.

Ref: https://redhat.atlassian.net/browse/OBSINTA-1387


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test scenario for the "Add to Dashboard" feature, verifying that AI-generated charts can be added to Perses dashboards and persist after saving.
  * Improved test cleanup logic for dashboard management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->