### PR TITLE
OCPBUGS-88413: [release-4.22] Fix CVE-2026-44494: bump axios to ^1.16.0 via overrides

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8717,6 +8717,18 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -9201,13 +9213,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -15271,6 +15284,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/web/package.json
+++ b/web/package.json
@@ -162,7 +162,8 @@
   },
   "overrides": {
     "echarts": "^5.6.0",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "axios": "^1.16.0"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary

- `axios` >=1.0.0 <1.16.0 is vulnerable to a Prototype Pollution gadget attack that allows MITM interception of all HTTP traffic (CVSS **8.7 HIGH**)
- `axios` enters transitively via `@module-federation/dts-plugin@0.21.6` (build tooling, not runtime)
- Fix: add npm `overrides` entry to force `axios >=1.16.0` which contains the upstream fix

## Changes

- `web/package.json` — added `"axios": "^1.16.0"` to existing `overrides` section
- `web/package-lock.json` — resolved `axios` `1.15.2` → `1.16.0`

## References

- Fixes: https://redhat.atlassian.net/browse/OCPBUGS-88413
- Advisory: https://github.com/axios/axios/security/advisories/GHSA-35jp-ww65-95wh