### PR TITLE
OBSINTA-1397: fix(perses): fall back to metadata.name when dashboard display name is missing

### DIFF
--- a/web/src/components/dashboards/perses/dashboard-list.tsx
+++ b/web/src/components/dashboards/perses/dashboard-list.tsx
@@ -226,7 +226,7 @@ const DashboardsTable: FC<DashboardsTableProps> = ({
     }
     return persesDashboards.map((board) => {
       const metadata = board?.metadata;
-      const displayName = board?.spec?.display?.name;
+      const displayName = board?.spec?.display?.name || metadata?.name;
       const dashboardsParams = `?dashboard=${metadata?.name}&project=${metadata?.project}`;
       const dashboardName: DashboardRowNameLink = {
         link: (


### PR DESCRIPTION

## Summary
Fall back to `metadata.name` when `spec.display.name` is missing in the Perses dashboard listtable.

## Problem
When new PersesDashboard CRs are created (e.g. during an MCO→MCOA right-sizing mode switch), thedashboard list page shows blank names until the Perses operator reconciles them.

<img width="793" height="404" alt="image-5" src="https://github.com/user-attachments/assets/2f0dc9d7-aefb-4d29-934b-b19cc462f501" />

**Screenshot shows:** 4 right-sizing dashboards with blank names in `observability-analytics`,while 2 pre-existing COO dashboards in `openshift-cluster-observability-operator` display names correctly.

### Data flow
Creator (e.g. MCOA) → PersesDashboard CR (has spec.config.display.name) → Perses operatorreconciles → Perses server API → monitoring-plugin reads /api/v1/dashboards
The CRs have the display name set correctly from the start. The issue is that themonitoring-plugin reads from the Perses server API, not from the CRs. Before the Perses operator reconciles the CR into the server, `spec.displayname` is not available in the API response — resulting in blank rows. 

## Root Cause
`dashboard-list.tsx` line 229 reads only `board?.spec?.display?.name` with no fallback:
```diff
- const displayName = board?.spec?.display?.name;
+ const displayName = board?.spec?.display?.name || metadata?.name;
```
**Existing pattern**
The same fallback is already used elsewhere in this codebase:
- useDashboardsData.ts: spec?.display?.name || name
- dashboard-import-dialog.tsx: spec?.display?.name || metadata.name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard name display to show the appropriate name consistently, even when certain configuration data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->