### PR TITLE
OCPBUGS-88396: CVE-2026-44487 bump axios to 1.16.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9474,12 +9474,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -174,7 +174,7 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "axios": "1.15.2",
+    "axios": "^1.16.0",
     "follow-redirects": "^1.16.0",
     "sass": {
       "immutable": "^5.1.5"


### PR DESCRIPTION
OCPBUGS-88396: CVE-2026-44487 bump axios to 1.16.0
https://redhat.atlassian.net/browse/OCPBUGS-88396