### PR TITLE
OU-1384: allow test cases to log to console

### DIFF
--- a/web/cypress/support/incidents_prometheus_query_mocks/mock-generators.ts
+++ b/web/cypress/support/incidents_prometheus_query_mocks/mock-generators.ts
@@ -185,17 +185,13 @@ export function createIncidentMock(
         return;
       }
 
-      // eslint-disable-next-line no-console
       console.log(`Adding alert: ${alert.name} from incident: ${incident.id}`);
-      // eslint-disable-next-line no-console
       console.log(`Results array length before push: ${results.length}`);
       results.push({ metric, values });
-      // eslint-disable-next-line no-console
       console.log(`Results array length after push: ${results.length}`);
     });
   });
 
-  // eslint-disable-next-line no-console
   console.log(`Final results array length: ${results.length}`);
   return results;
 }
@@ -280,17 +276,13 @@ export function createAlertDetailsMock(
         return;
       }
 
-      // eslint-disable-next-line no-console
       console.log(`Adding ALERTS alert: ${alert.name} from incident: ${incident.id}`);
-      // eslint-disable-next-line no-console
       console.log(`ALERTS Results array length before push: ${results.length}`);
       results.push({ metric, values });
-      // eslint-disable-next-line no-console
       console.log(`ALERTS Results array length after push: ${results.length}`);
     });
   });
 
-  // eslint-disable-next-line no-console
   console.log(`Final ALERTS results array length: ${results.length}`);
   return results;
 }

--- a/web/cypress/support/incidents_prometheus_query_mocks/prometheus-mocks.ts
+++ b/web/cypress/support/incidents_prometheus_query_mocks/prometheus-mocks.ts
@@ -43,17 +43,13 @@ export function mockPrometheusQueryRange(incidents: IncidentDefinition[]): void 
     const queryStartTime = startTime ? parseFloat(startTime) : undefined;
     const queryEndTime = endTime ? parseFloat(endTime) : undefined;
 
-    // eslint-disable-next-line no-console
     console.log(`INTERCEPTED: ${req.method} ${req.url}`);
-    // eslint-disable-next-line no-console
     console.log(`Query: ${query}`);
-    // eslint-disable-next-line no-console
     console.log(`Time range: ${queryStartTime} - ${queryEndTime}`);
 
     const versioned_metric = query.includes(NEW_METRIC_NAME) ? NEW_METRIC_NAME : OLD_METRIC_NAME;
 
     if (!(query.includes(versioned_metric) || query.includes('ALERTS{'))) {
-      // eslint-disable-next-line no-console
       console.log(`Passing through non-mocked query`);
       req.continue();
       return;
@@ -135,7 +131,6 @@ Cypress.Commands.add('transformMetrics', () => {
 
     if (hasNewMetric) {
       const transformedQuery = query.replace(new RegExp(NEW_METRIC_NAME, 'g'), OLD_METRIC_NAME);
-      // eslint-disable-next-line no-console
       console.log(`Transforming metric query: ${query} -> ${transformedQuery}`);
 
       // Update the URL with the transformed query
@@ -148,7 +143,6 @@ Cypress.Commands.add('transformMetrics', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           res.body.data.result.forEach((result: any) => {
             if (result?.metric?.__name__ === OLD_METRIC_NAME) {
-              // eslint-disable-next-line no-console
               console.log(
                 `Transforming response metric name: ${OLD_METRIC_NAME} -> ${NEW_METRIC_NAME}`,
               );

--- a/web/cypress/support/incidents_prometheus_query_mocks/schema/validate-fixtures.ts
+++ b/web/cypress/support/incidents_prometheus_query_mocks/schema/validate-fixtures.ts
@@ -22,7 +22,6 @@ const validate = ajv.compile(schema);
 
 function validateFixture(filePath: string): boolean {
   try {
-    // eslint-disable-next-line no-console
     console.log(`Validating: ${filePath}`);
 
     // Read and parse YAML
@@ -33,27 +32,22 @@ function validateFixture(filePath: string): boolean {
     const valid = validate(fixture);
 
     if (valid) {
-      // eslint-disable-next-line no-console
       console.log(`VALID: ${filePath}`);
-      // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       console.log(`   Name: ${(fixture as any).name}`);
-      // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       console.log(`   Incidents: ${(fixture as any).incidents?.length || 0}`);
       return true;
     } else {
-      // eslint-disable-next-line no-console
       console.log(`INVALID: ${filePath}`);
       validate.errors?.forEach((error) => {
         const errorPath = error.instancePath || 'root';
-        // eslint-disable-next-line no-console
         console.log(`   ${errorPath}: ${error.message}`);
       });
       return false;
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.log(`PARSE ERROR: ${filePath}`);
-    // eslint-disable-next-line no-console
     console.log(`   ${error instanceof Error ? error.message : 'Unknown error'}`);
     return false;
   }
@@ -63,13 +57,10 @@ function validateFixture(filePath: string): boolean {
 const args: string[] = process.argv.slice(2);
 
 if (args.length === 0) {
-  // eslint-disable-next-line no-console
   console.log('Usage: npm run ts-node validate-fixtures.ts <fixture-file.yaml> [<file2.yaml> ...]');
-  // eslint-disable-next-line no-console
   console.log(
     '   or: npm run ts-node validate-fixtures.ts --all (validates all .yaml files in fixtures directory)',
   );
-  // eslint-disable-next-line no-console
   console.log(
     'From web directory: npm run ts-node cypress/support/incidents_prometheus_query_mocks/schema/validate-fixtures.ts -- --all',
   );
@@ -83,7 +74,6 @@ if (args[0] === '--all') {
   const fixturesDir = path.join(__dirname, '../../../fixtures/incident-scenarios');
 
   if (!fs.existsSync(fixturesDir)) {
-    // eslint-disable-next-line no-console
     console.log(`ERROR: Fixtures directory not found: ${fixturesDir}`);
     process.exit(1);
   }
@@ -93,28 +83,23 @@ if (args[0] === '--all') {
     .filter((file) => file.endsWith('.yaml') || file.endsWith('.yml'));
 
   if (files.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('No YAML fixture files found');
     process.exit(0);
   }
 
-  // eslint-disable-next-line no-console
   console.log(`Found ${files.length} YAML fixture files:`);
-  // eslint-disable-next-line no-console
   console.log('');
 
   files.forEach((file) => {
     const filePath = path.join(fixturesDir, file);
     const valid = validateFixture(filePath);
     if (!valid) allValid = false;
-    // eslint-disable-next-line no-console
     console.log('');
   });
 } else {
   // Validate specific files
   args.forEach((filePath) => {
     if (!fs.existsSync(filePath)) {
-      // eslint-disable-next-line no-console
       console.log(`ERROR: File not found: ${filePath}`);
       allValid = false;
       return;
@@ -122,7 +107,6 @@ if (args[0] === '--all') {
 
     const valid = validateFixture(filePath);
     if (!valid) allValid = false;
-    // eslint-disable-next-line no-console
     console.log('');
   });
 }

--- a/web/cypress/support/index.ts
+++ b/web/cypress/support/index.ts
@@ -35,7 +35,6 @@ Cypress.on('uncaught:exception', (err) => {
     message.includes(`Cannot read properties of null (reading '0')`) ||
     message.includes(`load_plugin_entry`)
   ) {
-    // eslint-disable-next-line no-console
     console.warn('Ignored frontend exception:', err.message);
     return false;
   }

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -89,4 +89,10 @@ export default defineConfig([
       ],
     },
   },
+  {
+    files: ['cypress/**/*'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
 ]);


### PR DESCRIPTION
Test cases need to log to console to display information about the currently running test. This PR removes the lint rule on the cypress folder preventing that, removing the need for frequent overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified ESLint configuration for test files by disabling the `no-console` rule globally for Cypress test directories, eliminating the need for individual rule-suppression comments throughout test code.
  * Cleaned up redundant linting directives in test support files.
  * Enhanced test fixture validation output formatting for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->