### PR TITLE
OU-1384: Add missing prop types

### DIFF
--- a/web/cypress/component/mocks/AddToDashboardButton.tsx
+++ b/web/cypress/component/mocks/AddToDashboardButton.tsx
@@ -1,5 +1,6 @@
-// eslint-disable-next-line react/prop-types
-export const AddToDashboardButton = ({ query, name, description }) => (
+import { AddToDashboardButtonProps } from '../../../src/components/ols-tool-ui/helpers/AddToDashboardButton';
+
+export const AddToDashboardButton = ({ query, name, description }: AddToDashboardButtonProps) => (
   <button
     data-testid="add-to-dashboard"
     data-name={name}

--- a/web/cypress/component/mocks/OlsToolUIPersesWrapper.tsx
+++ b/web/cypress/component/mocks/OlsToolUIPersesWrapper.tsx
@@ -1,9 +1,10 @@
-/* eslint-disable react/prop-types */
+import { OlsToolUIPersesWrapperProps } from '../../../src/components/ols-tool-ui/helpers/OlsToolUIPersesWrapper';
+
 export const OlsToolUIPersesWrapper = ({
   children,
   initialTimeRange,
   initialTimeZone = 'local',
-}) => (
+}: OlsToolUIPersesWrapperProps) => (
   <div
     data-testid="perses-wrapper"
     data-time-range={JSON.stringify(initialTimeRange)}

--- a/web/cypress/component/mocks/perses-dashboards.tsx
+++ b/web/cypress/component/mocks/perses-dashboards.tsx
@@ -1,9 +1,11 @@
-/* eslint-disable react/prop-types */
-export const Panel = ({ definition, panelOptions }) => (
+import { PanelProps } from '@perses-dev/dashboards';
+import { ReactNode } from 'react';
+
+export const Panel = ({ definition, panelOptions }: PanelProps) => (
   <div data-testid="mock-panel">
     <div data-testid="panel-definition" data-definition={JSON.stringify(definition)} />
-    {panelOptions?.extra && <div data-testid="panel-extra">{panelOptions.extra()}</div>}
+    {panelOptions?.extra && <div data-testid="panel-extra">{panelOptions.extra({})}</div>}
   </div>
 );
 
-export const VariableProvider = ({ children }) => <>{children}</>;
+export const VariableProvider = ({ children }: { children: ReactNode }) => <>{children}</>;

--- a/web/cypress/dummy.tsx
+++ b/web/cypress/dummy.tsx
@@ -22,20 +22,6 @@ consoleFetchJSON.post = (url, json) =>
 
 export const ListPageFilter = () => <input data-test="name-filter-input"></input>;
 
-// eslint-disable-next-line react/prop-types
-export const VirtualizedTable = ({ data, Row }) => (
-  <table>
-    <tbody>
-      <tr data-test-rows="resource-row">
-        {/*eslint-disable-next-line react/prop-types*/}
-        {data.map((obj, i) => (
-          <Row key={i} obj={obj} />
-        ))}
-      </tr>
-    </tbody>
-  </table>
-);
-
 export const Timestamp = () => <div>Mock_Timestamp</div>;
 
 export const useActivePerspective = () => ['admin'];

--- a/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
+++ b/web/src/components/alerting/AlertList/AggregateAlertTableRow.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable react/prop-types */
 import { Alert, ResourceIcon, TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import type { FC } from 'react';
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRuleUrl, usePerspective } from '../../../components/hooks/usePerspective';
@@ -16,15 +14,15 @@ import { Badge, Flex, FlexItem } from '@patternfly/react-core';
 import { DataTestIDs } from '../../data-test';
 import { AggregatedAlertFilters } from '../AlertsPage';
 
-type AggregateAlertTableRowProps = FC<{
+type AggregateAlertTableRowProps = {
   aggregatedAlert: AggregatedAlert;
   rowData: { rowIndex: number; selectedFilters: AggregatedAlertFilters };
-}>;
+};
 
-const AggregateAlertTableRow: AggregateAlertTableRowProps = ({
+const AggregateAlertTableRow = ({
   aggregatedAlert,
   rowData: { rowIndex, selectedFilters },
-}) => {
+}: AggregateAlertTableRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { perspective } = usePerspective();

--- a/web/src/components/alerting/AlertRulesDetailsPage.tsx
+++ b/web/src/components/alerting/AlertRulesDetailsPage.tsx
@@ -71,11 +71,9 @@ import { DataTestIDs } from '../data-test';
 import { useAlerts } from '../../hooks/useAlerts';
 
 // Renders Prometheus template text and highlights any {{ ... }} tags that it contains
-// eslint-disable-next-line react/prop-types
-const PrometheusTemplate = ({ text }) => (
+const PrometheusTemplate = ({ text }: { text: string }) => (
   <>
     {text
-      // eslint-disable-next-line react/prop-types
       ?.split(/(\{\{[^{}]*\}\})/)
       ?.map((part: string, i: number) =>
         part.match(/^\{\{[^{}]*\}\}$/) ? <code key={i}>{part}</code> : part,

--- a/web/src/components/alerting/AlertUtils.tsx
+++ b/web/src/components/alerting/AlertUtils.tsx
@@ -124,8 +124,7 @@ const getSeverityKey = (severity: string, t) => {
   }
 };
 
-// eslint-disable-next-line react/prop-types
-export const SeverityIcon: FC<{ severity: string }> = memo(({ severity }) => {
+export const SeverityIcon = memo(({ severity }: { severity: string }) => {
   switch (severity) {
     case AlertSeverity.Critical:
       return <ExclamationCircleIcon color={t_global_color_status_danger_default.var} />;
@@ -142,8 +141,7 @@ export const SeverityIcon: FC<{ severity: string }> = memo(({ severity }) => {
 
 SeverityIcon.displayName = 'SeverityIcon';
 
-// eslint-disable-next-line react/prop-types
-export const AlertState: FC<AlertStateProps> = memo(({ state }) => {
+export const AlertState = memo(({ state }: AlertStateProps) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const icon = <AlertStateIcon state={state} />;
@@ -165,8 +163,7 @@ type AlertStateProps = {
   state: AlertStates;
 };
 
-// eslint-disable-next-line react/prop-types
-export const AlertStateIcon: FC<{ state: string }> = memo(({ state }) => {
+export const AlertStateIcon = memo(({ state }: { state: string }) => {
   switch (state) {
     case AlertStates.Firing:
       return <BellIcon />;
@@ -206,42 +203,38 @@ export const AlertStateDescription: FC<{ alert: Alert }> = ({ alert }) => {
   return null;
 };
 
-// eslint-disable-next-line react/prop-types
-export const StateTimestamp = ({ text, timestamp }) => (
+export const StateTimestamp = ({ text, timestamp }: { text: string; timestamp: string }) => (
   <div style={{ color: t_global_text_color_subtle.var }}>
     {text}&nbsp;
     <Timestamp timestamp={timestamp} className="pf-v6-u-display-inline" />
   </div>
 );
 
-export const SeverityBadge: FC<{ severity: string; count?: number }> = memo(
-  // eslint-disable-next-line react/prop-types
-  ({ severity, count }) => {
-    const { t } = useTranslation(process.env.I18N_NAMESPACE);
+export const SeverityBadge = memo(({ severity, count }: { severity: string; count?: number }) => {
+  const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
-    if (_.isNil(severity)) return null;
+  if (_.isNil(severity)) return null;
 
-    const labelText = count ? count : getSeverityKey(severity, t);
-    switch (severity) {
-      case AlertSeverity.Critical:
-        return <Label status="danger">{labelText}</Label>;
-      case AlertSeverity.Warning:
-        return <Label status="warning">{labelText}</Label>;
-      case AlertSeverity.Info:
-        return <Label status="info">{labelText}</Label>;
-      case AlertSeverity.None:
-        return (
-          <Label variant="outline">
-            <SeverityUndefinedIcon color={t_global_icon_color_severity_undefined_default.var} />
-            &nbsp;
-            {labelText}
-          </Label>
-        );
-      default:
-        return <Label status="custom">{labelText}</Label>;
-    }
-  },
-);
+  const labelText = count ? count : getSeverityKey(severity, t);
+  switch (severity) {
+    case AlertSeverity.Critical:
+      return <Label status="danger">{labelText}</Label>;
+    case AlertSeverity.Warning:
+      return <Label status="warning">{labelText}</Label>;
+    case AlertSeverity.Info:
+      return <Label status="info">{labelText}</Label>;
+    case AlertSeverity.None:
+      return (
+        <Label variant="outline">
+          <SeverityUndefinedIcon color={t_global_icon_color_severity_undefined_default.var} />
+          &nbsp;
+          {labelText}
+        </Label>
+      );
+    default:
+      return <Label status="custom">{labelText}</Label>;
+  }
+});
 
 SeverityBadge.displayName = 'SeverityBadge';
 

--- a/web/src/components/alerting/SilencesUtils.tsx
+++ b/web/src/components/alerting/SilencesUtils.tsx
@@ -44,10 +44,8 @@ import { useMonitoringNamespace } from '../hooks/useMonitoringNamespace';
 import { silenceMatcherEqualitySymbol, silenceState } from '../utils';
 import { DataTestIDs } from '../data-test';
 
-// eslint-disable-next-line react/prop-types
-export const SilenceMatchersList = ({ silence }) => (
+export const SilenceMatchersList = ({ silence }: { silence: Silence }) => (
   <LabelGroup numLabels={20}>
-    {/*eslint-disable-next-line react/prop-types*/}
     {_.map(silence.matchers, ({ name, isEqual, isRegex, value }, i) => (
       <Label key={i}>
         <span>{name}</span>
@@ -64,8 +62,7 @@ type ExpireSilenceModalProps = {
   silenceID: string;
 };
 
-// eslint-disable-next-line react/prop-types
-export const SilenceState = ({ silence }) => {
+export const SilenceState = ({ silence }: { silence: Silence }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   const state = silenceState(silence);

--- a/web/src/components/console/console-shared/src/components/empty-state/EmptyBox.tsx
+++ b/web/src/components/console/console-shared/src/components/empty-state/EmptyBox.tsx
@@ -1,9 +1,7 @@
-import type { FCC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConsoleEmptyState } from './ConsoleEmptyState';
 
-// eslint-disable-next-line react/prop-types
-export const EmptyBox: FCC<EmptyBoxProps> = ({ label, customMessage }) => {
+export const EmptyBox = ({ label, customMessage }: EmptyBoxProps) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/console/console-shared/src/components/loading/Loading.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/Loading.tsx
@@ -1,7 +1,6 @@
 import { Spinner } from '@patternfly/react-core';
-import type { FCC } from 'react';
 
-export const Loading: FCC<LoadingProps> = ({ className }: { className: string }) => (
+export const Loading = ({ className }: LoadingProps) => (
   <div className={className} data-test="loading-indicator">
     <Spinner size="lg" />
   </div>

--- a/web/src/components/console/console-shared/src/components/loading/Loading.tsx
+++ b/web/src/components/console/console-shared/src/components/loading/Loading.tsx
@@ -1,8 +1,7 @@
 import { Spinner } from '@patternfly/react-core';
 import type { FCC } from 'react';
 
-// eslint-disable-next-line react/prop-types
-export const Loading: FCC<LoadingProps> = ({ className }) => (
+export const Loading: FCC<LoadingProps> = ({ className }: { className: string }) => (
   <div className={className} data-test="loading-indicator">
     <Spinner size="lg" />
   </div>

--- a/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
+++ b/web/src/components/dashboards/legacy/dashboard-skeleton-legacy.tsx
@@ -35,9 +35,8 @@ type MonitoringDashboardsLegacyPageProps = PropsWithChildren<{
   dashboardName: string;
 }>;
 
-export const DashboardSkeletonLegacy: FC<MonitoringDashboardsLegacyPageProps> = memo(
-  // eslint-disable-next-line react/prop-types
-  ({ children, boardItems, changeBoard, dashboardName }) => {
+export const DashboardSkeletonLegacy = memo(
+  ({ children, boardItems, changeBoard, dashboardName }: MonitoringDashboardsLegacyPageProps) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
     const onChangeBoard = useCallback(

--- a/web/src/components/dashboards/legacy/legacy-dashboard.tsx
+++ b/web/src/components/dashboards/legacy/legacy-dashboard.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-
 import * as _ from 'lodash-es';
 import {
   RedExclamationCircleIcon,
@@ -102,7 +100,7 @@ const getPanelSpan = (panel: Panel): gridSpans => {
   return 12;
 };
 
-const Card: FC<CardProps> = memo(({ panel, perspective, dashboardName }) => {
+const Card = memo(({ panel, perspective, dashboardName }: CardProps) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
   const { plugin } = useMonitoring();
 

--- a/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
@@ -16,6 +16,7 @@ import {
   StackItem,
   SplitItem,
   Split,
+  SelectOptionProps,
 } from '@patternfly/react-core';
 import type { FC, Ref } from 'react';
 import { useCallback, useState, useEffect } from 'react';
@@ -98,8 +99,7 @@ export const evaluateVariableTemplate = (
   return result;
 };
 
-// eslint-disable-next-line react/prop-types
-const LegacyDashboardsVariableOption = ({ value, isSelected, ...rest }) =>
+const LegacyDashboardsVariableOption = ({ value, isSelected, ...rest }: SelectOptionProps) =>
   isIntervalVariable(String(value)) ? (
     <Tooltip content={value}>
       <SelectOption value={value} isSelected={isSelected || false}>

--- a/web/src/components/dashboards/perses/dashboard-header.tsx
+++ b/web/src/components/dashboards/perses/dashboard-header.tsx
@@ -115,9 +115,8 @@ type MonitoringDashboardsPageProps = PropsWithChildren<{
   activeProject?: string;
 }>;
 
-export const DashboardHeader: FC<MonitoringDashboardsPageProps> = memo(
-  // eslint-disable-next-line react/prop-types
-  ({ children, dashboardDisplayName }) => {
+export const DashboardHeader = memo(
+  ({ children, dashboardDisplayName }: MonitoringDashboardsPageProps) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
     return (
@@ -134,8 +133,7 @@ export const DashboardHeader: FC<MonitoringDashboardsPageProps> = memo(
 
 DashboardHeader.displayName = 'DashboardHeader';
 
-// eslint-disable-next-line react/prop-types
-export const DashboardListHeader: FC<MonitoringDashboardsPageProps> = memo(({ children }) => {
+export const DashboardListHeader = memo(({ children }: MonitoringDashboardsPageProps) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/components/dashboards/shared/dashboard-dropdown.tsx
+++ b/web/src/components/dashboards/shared/dashboard-dropdown.tsx
@@ -5,6 +5,7 @@ import {
   Level,
   LevelItem,
   SelectOption,
+  SelectOptionProps,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -18,8 +19,7 @@ import { CombinedDashboardMetadata } from '../perses/hooks/useDashboardsData';
 type TagColor = 'red' | 'purple' | 'blue' | 'green' | 'teal' | 'orange';
 const tagColors: TagColor[] = ['red', 'purple', 'blue', 'green', 'teal', 'orange'];
 
-// eslint-disable-next-line react/prop-types
-const Tag: FC<{ color: TagColor; text: string }> = memo(({ color, text }) => (
+const Tag = memo(({ color, text }: { color: TagColor; text: string }) => (
   <Label isCompact color={color}>
     {text}
   </Label>
@@ -33,8 +33,7 @@ export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange,
   const allTags = _.flatMap(items, 'tags');
   const uniqueTags = _.uniq(allTags);
 
-  // eslint-disable-next-line react/prop-types
-  const OptionComponent = ({ value, isSelected, ...rest }) => {
+  const OptionComponent = ({ value, isSelected, ...rest }: SelectOptionProps) => {
     const matchedValue = items.find((item) => {
       return item.name === value;
     });

--- a/web/src/components/labels.tsx
+++ b/web/src/components/labels.tsx
@@ -11,7 +11,7 @@ const Label = ({ k, v }: { k: string; v: string }) => (
   </PfLabel>
 );
 
-export const Labels = ({ labels }: { labels: PrometheusLabels }) => {
+export const Labels = ({ labels }: { labels?: PrometheusLabels }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return _.isEmpty(labels) ? (

--- a/web/src/components/labels.tsx
+++ b/web/src/components/labels.tsx
@@ -1,9 +1,9 @@
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { Label as PfLabel, LabelGroup as PfLabelGroup } from '@patternfly/react-core';
+import { PrometheusLabels } from '@openshift-console/dynamic-plugin-sdk';
 
-// eslint-disable-next-line react/prop-types
-const Label = ({ k, v }) => (
+const Label = ({ k, v }: { k: string; v: string }) => (
   <PfLabel key={k}>
     <span>{k}</span>
     <span>=</span>
@@ -11,8 +11,7 @@ const Label = ({ k, v }) => (
   </PfLabel>
 );
 
-// eslint-disable-next-line react/prop-types
-export const Labels = ({ labels }) => {
+export const Labels = ({ labels }: { labels: PrometheusLabels }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return _.isEmpty(labels) ? (

--- a/web/src/components/ols-tool-ui/helpers/AddToDashboardButton.tsx
+++ b/web/src/components/ols-tool-ui/helpers/AddToDashboardButton.tsx
@@ -48,7 +48,7 @@ function createPanelDefinition(query: string, name: string, description: string)
   };
 }
 
-type AddToDashboardButtonProps = {
+export type AddToDashboardButtonProps = {
   query: string;
   name?: string;
   description?: string;

--- a/web/src/components/ols-tool-ui/helpers/OlsToolUIPersesWrapper.tsx
+++ b/web/src/components/ols-tool-ui/helpers/OlsToolUIPersesWrapper.tsx
@@ -19,7 +19,7 @@ const queryClient = new QueryClient({
   },
 });
 
-interface OlsToolUIPersesWrapperProps {
+export interface OlsToolUIPersesWrapperProps {
   children: ReactNode;
   height?: string;
   initialTimeRange?: TimeRangeValue;

--- a/web/src/components/query-browser.tsx
+++ b/web/src/components/query-browser.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import {
   PrometheusEndpoint,
   PrometheusLabels,
@@ -124,8 +123,8 @@ const GraphEmptyState: FC<GraphEmptyStateProps> = ({ children, title }) => (
   </div>
 );
 
-const SpanControls: FC<SpanControlsProps> = memo(
-  ({ defaultSpanText, onChange, span, hasReducedResolution }) => {
+const SpanControls = memo(
+  ({ defaultSpanText, onChange, span, hasReducedResolution }: SpanControlsProps) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
     const [isValid, setIsValid] = useState(true);
@@ -241,7 +240,7 @@ const getXDomain = (endTime: number, span: number): AxisDomain => [endTime - spa
 
 const ONE_MINUTE = 60 * 1000;
 
-const Graph: FC<GraphProps> = memo(
+const Graph = memo(
   ({
     allSeries,
     disabledSeries,
@@ -252,7 +251,7 @@ const Graph: FC<GraphProps> = memo(
     span,
     units,
     width,
-  }) => {
+  }: GraphProps) => {
     const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
     const data: GraphSeries[] = [];

--- a/web/src/components/targets-page.tsx
+++ b/web/src/components/targets-page.tsx
@@ -212,7 +212,7 @@ const ServiceMonitor: FC<{ target: Target }> = ({ target }) => {
   );
 };
 
-const Health = memo(({ health }: { health: 'up' | 'down' }) => {
+const Health = memo(({ health }: { health?: 'up' | 'down' }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return health === 'up' ? (

--- a/web/src/components/targets-page.tsx
+++ b/web/src/components/targets-page.tsx
@@ -212,8 +212,7 @@ const ServiceMonitor: FC<{ target: Target }> = ({ target }) => {
   );
 };
 
-// eslint-disable-next-line react/prop-types
-const Health: FC<{ health: 'up' | 'down' }> = memo(({ health }) => {
+const Health = memo(({ health }: { health: 'up' | 'down' }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return health === 'up' ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety across React components by adding explicit prop typings (including `memo`-based components) and removing prop-type lint suppressions.
  * Updated Cypress mock components to use typed props and more consistent prop passing for stable test rendering.
  * Removed an unused `VirtualizedTable` mock export from the Cypress dummy setup.
  * Made the `health` prop optional in the targets page UI component (typing only).
  * Exported shared prop types for OLS tool UI components to enable reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->