### PR TITLE
OU-1384:  Remove some of the set-state-in-effect overrides

### DIFF
--- a/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
+++ b/web/src/components/Incidents/AlertsChart/AlertsChart.tsx
@@ -42,10 +42,11 @@ import { MonitoringState } from '../../../store/store';
 import { isEmpty } from 'lodash-es';
 import { DataTestIDs } from '../../data-test';
 
+export const DEFAULT_CHART_CONTAINER_HEIGHT = 300;
+export const DEFAULT_CHART_HEIGHT = 250;
+
 const AlertsChart = ({ theme }: { theme: 'light' | 'dark' }) => {
   const dispatch = useDispatch();
-  const [chartContainerHeight, setChartContainerHeight] = useState<number>();
-  const [chartHeight, setChartHeight] = useState<number>();
   const alertsData = useSelector(
     (state: MonitoringState) => state.plugins.mcp.incidentsData.alertsData,
   );
@@ -71,16 +72,34 @@ const AlertsChart = ({ theme }: { theme: 'light' | 'dark' }) => {
     return generateAlertsDateArray(alertsData, currentTime);
   }, [alertsData, currentTime]);
 
-  const chartData: AlertsChartBar[][] = useMemo(() => {
-    if (!Array.isArray(alertsData) || alertsData.length === 0) return [];
-    return alertsData.map((alert) => createAlertsChartBars(alert));
-  }, [alertsData]);
+  const {
+    chartData,
+    chartContainerHeight,
+    chartHeight,
+  }: { chartData: AlertsChartBar[][]; chartContainerHeight: number; chartHeight: number } =
+    useMemo(() => {
+      if (!Array.isArray(alertsData) || alertsData.length === 0) {
+        return {
+          chartData: [],
+          chartContainerHeight: DEFAULT_CHART_CONTAINER_HEIGHT,
+          chartHeight: DEFAULT_CHART_HEIGHT,
+        };
+      }
+      const chartData = alertsData.map((alert) => createAlertsChartBars(alert));
+      if (chartData.length < 5) {
+        return {
+          chartData,
+          chartContainerHeight: DEFAULT_CHART_CONTAINER_HEIGHT,
+          chartHeight: DEFAULT_CHART_HEIGHT,
+        };
+      }
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setChartContainerHeight(chartData?.length < 5 ? 300 : chartData?.length * 55);
-    setChartHeight(chartData?.length < 5 ? 250 : chartData?.length * 55);
-  }, [chartData]);
+      return {
+        chartData,
+        chartContainerHeight: chartData.length * 55,
+        chartHeight: chartData.length * 55,
+      };
+    }, [alertsData]);
 
   const selectedIncidentIsVisible = useMemo(() => {
     return filteredData.some(
@@ -100,8 +119,6 @@ const AlertsChart = ({ theme }: { theme: 'light' | 'dark' }) => {
     }
   }, []);
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const observer = getResizeObserver(containerRef.current, handleResize);
     handleResize();
     return () => observer();

--- a/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
+++ b/web/src/components/Incidents/IncidentsChart/IncidentsChart.tsx
@@ -38,6 +38,7 @@ import {
 import { dateTimeFormatter, timeFormatter } from '../../console/utils/datetime';
 import { useTranslation } from 'react-i18next';
 import { DataTestIDs } from '../../data-test';
+import { DEFAULT_CHART_CONTAINER_HEIGHT, DEFAULT_CHART_HEIGHT } from '../AlertsChart/AlertsChart';
 
 /**
  * Processes component list: moves "Others" to end and limits display to 3 components
@@ -73,8 +74,6 @@ const IncidentsChart = ({
   lastRefreshTime: number | null;
 }) => {
   const [isLoading, setIsLoading] = useState(true);
-  const [chartContainerHeight, setChartContainerHeight] = useState<number>();
-  const [chartHeight, setChartHeight] = useState<number>();
   const dateValues = useMemo(
     () => generateDateArray(chartDays, currentTime),
     [chartDays, currentTime],
@@ -82,8 +81,14 @@ const IncidentsChart = ({
 
   const { t, i18n } = useTranslation(process.env.I18N_NAMESPACE);
 
-  const chartData = useMemo(() => {
-    if (!Array.isArray(incidentsData) || incidentsData.length === 0) return [];
+  const { chartData, chartContainerHeight, chartHeight } = useMemo(() => {
+    if (!Array.isArray(incidentsData) || incidentsData.length === 0) {
+      return {
+        chartData: [],
+        chartContainerHeight: DEFAULT_CHART_CONTAINER_HEIGHT,
+        chartHeight: DEFAULT_CHART_HEIGHT,
+      };
+    }
 
     const filteredIncidents = selectedGroupId
       ? incidentsData.filter((incident) => incident.group_id === selectedGroupId)
@@ -96,19 +101,26 @@ const IncidentsChart = ({
     chartBars.sort((a, b) => a[0].x - b[0].x);
 
     // Reassign consecutive x values to eliminate gaps between bars
-    return chartBars.map((bars, index) => bars.map((bar) => ({ ...bar, x: index + 1 })));
+    const chartData = chartBars.map((bars, index) => bars.map((bar) => ({ ...bar, x: index + 1 })));
+    if (chartData.length < 5) {
+      return {
+        chartData,
+        chartContainerHeight: DEFAULT_CHART_CONTAINER_HEIGHT,
+        chartHeight: DEFAULT_CHART_HEIGHT,
+      };
+    }
+
+    return {
+      chartData,
+      chartContainerHeight: chartData.length * 60,
+      chartHeight: chartData.length * 55,
+    };
   }, [incidentsData, dateValues, selectedGroupId]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsLoading(false);
   }, [incidentsData]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setChartContainerHeight(chartData?.length < 5 ? 300 : chartData?.length * 60);
-    setChartHeight(chartData?.length < 5 ? 250 : chartData?.length * 55);
-  }, [chartData]);
 
   const [width, setWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/web/src/components/console/public/components/autocomplete.tsx
+++ b/web/src/components/console/public/components/autocomplete.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, FC, SetStateAction, Dispatch, FormEvent } from 'react';
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
 import { css } from '@patternfly/react-styles';
 import * as _ from 'lodash-es';
 
@@ -74,7 +74,6 @@ type AutocompleteInputProps = {
 };
 
 const AutocompleteInput: FC<AutocompleteInputProps> = (props) => {
-  const [suggestions, setSuggestions] = useState<string[]>();
   const { visible, setVisible, ref } = useDocumentListener<HTMLDivElement>(suggestionBoxKeyHandler);
   const {
     textValue,
@@ -110,18 +109,19 @@ const AutocompleteInput: FC<AutocompleteInputProps> = (props) => {
     setTextValue(input);
   };
 
-  useEffect(() => {
-    if (textValue && visible && showSuggestions) {
-      const processed = labelParser(data, labelPath);
-      // User input without whitespace
-      const processedText = textValue.trim().replace(/\s*=\s*/, '=');
-      const maxSuggestions = suggestionCount ?? MAX_SUGGESTIONS;
-      const filtered = [...processed]
-        .filter((item) => fuzzyCaseInsensitive(processedText, item))
-        .slice(0, maxSuggestions);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSuggestions(filtered);
+  const suggestions = useMemo(() => {
+    if (!textValue || !visible || !showSuggestions) {
+      return [];
     }
+
+    const processed = labelParser(data, labelPath);
+    // User input without whitespace
+    const processedText = textValue.trim().replace(/\s*=\s*/, '=');
+    const maxSuggestions = suggestionCount ?? MAX_SUGGESTIONS;
+    const filtered = [...processed]
+      .filter((item) => fuzzyCaseInsensitive(processedText, item))
+      .slice(0, maxSuggestions);
+    return filtered;
   }, [visible, textValue, showSuggestions, data, labelPath, suggestionCount]);
 
   return (


### PR DESCRIPTION
These lint rule updates provide refactors of react code to remove the set-state-in-effect overrides. You can read more about this rule here: https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect

These fixes were done by eliminating excess state tracking and returning values directly from useMemo's rather than triggering useEffects off of changes to the useMemo value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced chart sizing calculations in AlertsChart and IncidentsChart components for improved performance and consistency.
  * Optimized suggestion computation in the autocomplete component for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->