### PR TITLE
Fix for OCPBUGS-90525 OCPBUGS-90526: CVE-2026-12151 CVE-2026-9697

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12428,9 +12428,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
## Summary
- Bumps `undici` from 7.25.0 to 7.28.0 to fix CVE-2026-12151
- CVE-2026-12151 is a high-severity (CVSS 7.5) WebSocket denial-of-service vulnerability where a malicious server can cause unbounded memory growth via excessive message fragments
- The fix updates `web/package-lock.json` only — no `package.json` change needed since `^7.19.0` already covers 7.28.0

## Test plan
- [ ] Verify `undici` resolves to >= 7.28.0 in the lockfile
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)