### PR TITLE
OCPBUGS-85473: fix: escape regex variable values in regex matcher contexts

### DIFF
--- a/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
+++ b/web/src/components/dashboards/legacy/legacy-variable-dropdowns.tsx
@@ -1,4 +1,3 @@
-import * as _ from 'lodash-es';
 import {
   PrometheusEndpoint,
   PrometheusResponse,
@@ -7,97 +6,48 @@ import {
   useResolvedExtensions,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  Tooltip,
-  Select,
-  SelectOption,
   MenuToggle,
   MenuToggleElement,
+  Select,
+  SelectOption,
+  SelectOptionProps,
+  Split,
+  SplitItem,
   Stack,
   StackItem,
-  SplitItem,
-  Split,
-  SelectOptionProps,
+  Tooltip,
 } from '@patternfly/react-core';
+import * as _ from 'lodash-es';
 import type { FC, Ref } from 'react';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { SingleTypeaheadDropdown } from '../../console/utils/single-typeahead-dropdown';
-import { getPrometheusBasePath, buildPrometheusUrl, ALL_NAMESPACES_KEY } from '../../utils';
 import { useSafeFetch } from '../../console/utils/safe-fetch-hook';
+import { SingleTypeaheadDropdown } from '../../console/utils/single-typeahead-dropdown';
+import { buildPrometheusUrl, getPrometheusBasePath } from '../../utils';
 
+import {
+  DataSource,
+  isDataSource,
+} from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
+import { StringParam, useQueryParam } from 'use-query-params';
+import { useMonitoring } from '../../../hooks/useMonitoring';
 import { dashboardsPatchVariable, dashboardsVariableOptionsLoaded } from '../../../store/actions';
-import { getTimeRanges, isTimeoutError, QUERY_CHUNK_SIZE } from '../../utils';
-import { getObserveState, usePerspective } from '../../hooks/usePerspective';
 import { MonitoringState } from '../../../store/store';
+import { useDeepMemo } from '../../hooks/useDeepMemo';
+import { getObserveState, usePerspective } from '../../hooks/usePerspective';
+import { QueryParams } from '../../query-params';
+import { getTimeRanges, isTimeoutError, QUERY_CHUNK_SIZE } from '../../utils';
 import {
   DEFAULT_GRAPH_SAMPLES,
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
   TimeRangeParam,
 } from './utils';
-import { QueryParams } from '../../query-params';
-import {
-  DataSource,
-  isDataSource,
-} from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-data-source';
-import { useMonitoring } from '../../../hooks/useMonitoring';
-import { useDeepMemo } from '../../hooks/useDeepMemo';
-import { StringParam, useQueryParam } from 'use-query-params';
-
-const intervalVariableRegExps = ['__interval', '__rate_interval', '__auto_interval_[a-z]+'];
-
-const isIntervalVariable = (itemKey: string): boolean =>
-  _.some(intervalVariableRegExps, (re) => itemKey?.match(new RegExp(`\\$${re}`, 'g')));
-
-export const evaluateVariableTemplate = (
-  template: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  variables: any,
-  timespan: number,
-  namespace: string,
-): string => {
-  if (_.isEmpty(template)) {
-    return undefined;
-  }
-
-  const range: Variable = { value: `${Math.floor(timespan / 1000)}s` };
-  const allVariables = {
-    ...variables,
-    __range: range,
-    __range_ms: range,
-    __range_s: range,
-  };
-
-  // Handle the special "interval" variables
-  const intervalMS = timespan / DEFAULT_GRAPH_SAMPLES;
-  const intervalMinutes = Math.floor(intervalMS / 1000 / 60);
-  // Use a minimum of 5m to make sure we have enough data to perform `irate` calculations, which
-  // require 2 data points each. Otherwise, there could be gaps in the graph.
-  const interval: Variable = { value: `${Math.max(intervalMinutes, 5)}m` };
-  // Add these last to ensure they are applied after other variable substitutions (because the other
-  // variable substitutions may result in interval variables like $__interval being inserted)
-  intervalVariableRegExps.forEach((k) => (allVariables[k] = interval));
-
-  let result = template;
-  _.each(allVariables, (v, k) => {
-    const re = new RegExp(`\\$${k}`, 'g');
-    if (result.match(re)) {
-      if (v.isLoading) {
-        result = undefined;
-        return false;
-      }
-      let replacement =
-        v.value === MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY ? '.+' : v.value || '';
-      if (v.name === 'namespace' && namespace !== ALL_NAMESPACES_KEY) {
-        replacement = namespace;
-      }
-      result = result.replace(re, replacement);
-    }
-  });
-
-  return result;
-};
+import type { Variable } from './variable-utils';
+import { evaluateVariableTemplate, isIntervalVariable } from './variable-utils';
+export { evaluateVariableTemplate } from './variable-utils';
+export type { Variable } from './variable-utils';
 
 const LegacyDashboardsVariableOption = ({ value, isSelected, ...rest }: SelectOptionProps) =>
   isIntervalVariable(String(value)) ? (
@@ -375,17 +325,6 @@ export const LegacyDashboardsAllVariableDropdowns: FC<{ dashboardName: string }>
       ))}
     </Split>
   );
-};
-
-export type Variable = {
-  isHidden?: boolean;
-  isLoading?: boolean;
-  includeAll?: boolean;
-  options?: string[];
-  query?: string;
-  value?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  datasource?: any;
 };
 
 type VariableDropdownProps = {

--- a/web/src/components/dashboards/legacy/variable-utils.spec.ts
+++ b/web/src/components/dashboards/legacy/variable-utils.spec.ts
@@ -1,0 +1,172 @@
+import { evaluateVariableTemplate, Variable } from './variable-utils';
+import { MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from './utils';
+
+const timespan = 30 * 60 * 1000; // 30 minutes
+const makeVariables = (
+  overrides: Record<string, Partial<Variable>> = {},
+): Record<string, Variable> => {
+  const vars: Record<string, Variable> = {};
+  for (const [k, v] of Object.entries(overrides)) {
+    vars[k] = { value: '', ...v } as Variable;
+  }
+  return vars;
+};
+
+describe('evaluateVariableTemplate', () => {
+  it('substitutes a literal value in exact match context', () => {
+    const vars = makeVariables({ job: { value: 'prometheus' } });
+    expect(evaluateVariableTemplate('metric{job="$job"}', vars, timespan, '')).toBe(
+      'metric{job="prometheus"}',
+    );
+  });
+
+  it('substitutes multiple variables', () => {
+    const vars = makeVariables({
+      job: { value: 'prometheus' },
+      instance: { value: 'localhost:9090' },
+    });
+    expect(
+      evaluateVariableTemplate('metric{job="$job",instance="$instance"}', vars, timespan, ''),
+    ).toBe('metric{job="prometheus",instance="localhost:9090"}');
+  });
+
+  it('escapes IPv6 brackets in =~ context', () => {
+    const vars = makeVariables({ instance: { value: '[fd02:0:0:1::6]:9092' } });
+    expect(evaluateVariableTemplate('metric{instance=~"$instance"}', vars, timespan, '')).toBe(
+      'metric{instance=~"\\\\[fd02:0:0:1::6\\\\]:9092"}',
+    );
+  });
+
+  it('does NOT escape IPv6 brackets in = context', () => {
+    const vars = makeVariables({ instance: { value: '[fd02:0:0:1::6]:9092' } });
+    expect(evaluateVariableTemplate('metric{instance="$instance"}', vars, timespan, '')).toBe(
+      'metric{instance="[fd02:0:0:1::6]:9092"}',
+    );
+  });
+
+  it('escapes dots in =~ context', () => {
+    const vars = makeVariables({ host: { value: 'my.host.example.com' } });
+    expect(evaluateVariableTemplate('metric{host=~"$host"}', vars, timespan, '')).toBe(
+      'metric{host=~"my\\\\.host\\\\.example\\\\.com"}',
+    );
+  });
+
+  it('escapes in !~ context', () => {
+    const vars = makeVariables({ instance: { value: '[::1]:9090' } });
+    expect(evaluateVariableTemplate('metric{instance!~"$instance"}', vars, timespan, '')).toBe(
+      'metric{instance!~"\\\\[::1\\\\]:9090"}',
+    );
+  });
+
+  it('does NOT escape in != context', () => {
+    const vars = makeVariables({ instance: { value: '[::1]:9090' } });
+    expect(evaluateVariableTemplate('metric{instance!="$instance"}', vars, timespan, '')).toBe(
+      'metric{instance!="[::1]:9090"}',
+    );
+  });
+
+  it('does NOT escape .+ for ALL option in =~ context', () => {
+    const vars = makeVariables({
+      instance: { value: MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY },
+    });
+    expect(evaluateVariableTemplate('metric{instance=~"$instance"}', vars, timespan, '')).toBe(
+      'metric{instance=~".+"}',
+    );
+  });
+
+  it('applies different escaping per site for the same variable in mixed contexts', () => {
+    const vars = makeVariables({ var: { value: '[test]' } });
+    expect(
+      evaluateVariableTemplate('metric{a=~"$var"} + other{b="$var"}', vars, timespan, ''),
+    ).toBe('metric{a=~"\\\\[test\\\\]"} + other{b="[test]"}');
+  });
+
+  it('handles interval variables in range selector', () => {
+    const vars = makeVariables({ job: { value: 'prometheus' } });
+    const result = evaluateVariableTemplate(
+      'rate(metric{job="$job"}[$__interval])',
+      vars,
+      timespan,
+      '',
+    );
+    expect(result).toMatch(/^rate\(metric\{job="prometheus"\}\[\d+m\]\)$/);
+  });
+
+  it('returns undefined for empty template', () => {
+    expect(evaluateVariableTemplate('', {}, timespan, '')).toBeUndefined();
+  });
+
+  it('returns undefined when variable is loading', () => {
+    const vars = makeVariables({ job: { value: 'x', isLoading: true } });
+    expect(evaluateVariableTemplate('metric{job="$job"}', vars, timespan, '')).toBeUndefined();
+  });
+
+  it('overrides namespace variable with the provided namespace', () => {
+    const vars = makeVariables({ namespace: { value: 'stored-ns' } });
+    expect(
+      evaluateVariableTemplate('metric{namespace="$namespace"}', vars, timespan, 'actual-ns'),
+    ).toBe('metric{namespace="actual-ns"}');
+  });
+
+  it('uses ALL option .+ correctly alongside escaped variable', () => {
+    const vars = makeVariables({
+      job: { value: MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY },
+      instance: { value: '[fd02:0:0:1::6]:9092' },
+    });
+    const result = evaluateVariableTemplate(
+      'sum(rate(prometheus_target_sync_length_seconds_sum{job=~"$job",instance=~"$instance"}[5m])) by (scrape_job) * 1e3',
+      vars,
+      timespan,
+      '',
+    );
+    expect(result).toBe(
+      'sum(rate(prometheus_target_sync_length_seconds_sum{job=~".+",instance=~"\\\\[fd02:0:0:1::6\\\\]:9092"}[5m])) by (scrape_job) * 1e3',
+    );
+  });
+
+  it('escapes variable value after a literal prefix in =~ context', () => {
+    const vars = makeVariables({ pod: { value: '[test]' } });
+    expect(evaluateVariableTemplate('metric{pod=~"prefix-$pod"}', vars, timespan, '')).toBe(
+      'metric{pod=~"prefix-\\\\[test\\\\]"}',
+    );
+  });
+
+  it('escapes variable value after a literal prefix in !~ context', () => {
+    const vars = makeVariables({ suffix: { value: 'a.b' } });
+    expect(evaluateVariableTemplate('metric{path!~".*api.*$suffix"}', vars, timespan, '')).toBe(
+      'metric{path!~".*api.*a\\\\.b"}',
+    );
+  });
+
+  it('escapes both variables inside a single =~ matcher', () => {
+    const vars = makeVariables({
+      prefix: { value: 'hello.world' },
+      suffix: { value: '[test]' },
+    });
+    expect(evaluateVariableTemplate('metric{pod=~"$prefix-$suffix"}', vars, timespan, '')).toBe(
+      'metric{pod=~"hello\\\\.world-\\\\[test\\\\]"}',
+    );
+  });
+
+  it('does NOT escape variable after a literal prefix in = context', () => {
+    const vars = makeVariables({ pod: { value: '[test]' } });
+    expect(evaluateVariableTemplate('metric{pod="prefix-$pod"}', vars, timespan, '')).toBe(
+      'metric{pod="prefix-[test]"}',
+    );
+  });
+
+  it('__range_ms substitutes the millisecond value', () => {
+    const vars = makeVariables({});
+    expect(evaluateVariableTemplate('foo[$__range_ms]', vars, timespan, '')).toBe('foo[1800000]');
+  });
+
+  it('__range_s substitutes numeric seconds without suffix', () => {
+    const vars = makeVariables({});
+    expect(evaluateVariableTemplate('foo[$__range_s]', vars, timespan, '')).toBe('foo[1800]');
+  });
+
+  it('__range substitutes seconds with s suffix', () => {
+    const vars = makeVariables({});
+    expect(evaluateVariableTemplate('foo[$__range]', vars, timespan, '')).toBe('foo[1800s]');
+  });
+});

--- a/web/src/components/dashboards/legacy/variable-utils.ts
+++ b/web/src/components/dashboards/legacy/variable-utils.ts
@@ -1,0 +1,88 @@
+import * as _ from 'lodash-es';
+import { DEFAULT_GRAPH_SAMPLES, MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from './utils';
+import { ALL_NAMESPACES_KEY } from '../../utils';
+
+const intervalVariableRegExps = ['__interval', '__rate_interval', '__auto_interval_[a-z]+'];
+
+export const isIntervalVariable = (itemKey: string): boolean =>
+  _.some(intervalVariableRegExps, (re) => itemKey?.match(new RegExp(`\\$${re}`, 'g')));
+
+export type Variable = {
+  isHidden?: boolean;
+  isLoading?: boolean;
+  includeAll?: boolean;
+  options?: string[];
+  query?: string;
+  value?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  datasource?: any;
+};
+
+/*
+ * Escapes a variable value if it is in a regex context (i.e., after =~ or !~ operators).
+ * Backslashes are doubled because PromQL parses string literals using Go-style escape rules
+ * before passing the result to RE2. A single \[ is not a valid Go escape and causes a parse
+ * error; \\[ is parsed by Go as literal \ then [, giving RE2 the pattern \[ which matches
+ * a literal bracket.
+ */
+const escapeIfRegexContext = (template: string, position: number, value: string): string => {
+  const prefix = template.substring(0, position);
+  if (/[!=]~"[^"]*$/.test(prefix)) {
+    return _.escapeRegExp(value).replace(/\\/g, '\\\\');
+  }
+  return value;
+};
+
+export const evaluateVariableTemplate = (
+  template: string,
+  variables: Record<string, Variable>,
+  timespan: number,
+  namespace: string,
+): string | undefined => {
+  if (_.isEmpty(template)) {
+    return undefined;
+  }
+
+  const allVariables = {
+    ...variables,
+    __range: { value: `${Math.floor(timespan / 1000)}s` } as Variable,
+    __range_ms: { value: `${timespan}` } as Variable,
+    __range_s: { value: `${Math.floor(timespan / 1000)}` } as Variable,
+  };
+
+  // Handle the special "interval" variables
+  const intervalMS = timespan / DEFAULT_GRAPH_SAMPLES;
+  const intervalMinutes = Math.floor(intervalMS / 1000 / 60);
+  // Use a minimum of 5m to make sure we have enough data to perform `irate` calculations, which
+  // require 2 data points each. Otherwise, there could be gaps in the graph.
+  const interval: Variable = { value: `${Math.max(intervalMinutes, 5)}m` };
+  // Add these last to ensure they are applied after other variable substitutions (because the other
+  // variable substitutions may result in interval variables like $__interval being inserted)
+  intervalVariableRegExps.forEach((k) => (allVariables[k] = interval));
+
+  let result = template;
+  _.each(allVariables, (v, k) => {
+    const re = new RegExp(`\\$${k}`, 'g');
+    if (result.match(re)) {
+      if (v.isLoading) {
+        result = undefined;
+        return false;
+      }
+      const isAllOption = v.value === MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY;
+      let replacement = isAllOption ? '.+' : v.value || '';
+      if (k === 'namespace' && namespace !== ALL_NAMESPACES_KEY) {
+        replacement = namespace;
+      }
+
+      if (isAllOption) {
+        result = result.replace(re, replacement);
+      } else {
+        result = result.replace(re, (_match, offset) =>
+          escapeIfRegexContext(result, offset, replacement),
+        );
+      }
+    }
+  });
+
+  return result;
+};


### PR DESCRIPTION
This PR moves the `evaluateVariableTemplate` into its own utility file and adds tests for the regex escape bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized dashboard variable-template evaluation into a shared utility, including support for interval/range-derived placeholders and consistent namespace handling.
  * Improved substitution behavior for “all” selections and PromQL regex contexts to ensure generated queries remain valid.

* **Tests**
  * Added a Jest suite covering variable substitution, escaping rules for different matcher types, IPv6/regex escaping, namespace overrides, loading/undefined cases, and combined template scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->