### PR TITLE
OU-1396: fix: use replace to set variables to avoid navigation trap

### DIFF
--- a/web/src/components/MetricsPage.tsx
+++ b/web/src/components/MetricsPage.tsx
@@ -1144,7 +1144,7 @@ const QueryBrowserWrapper: FC<{
     if (!newParams.get(QueryParams.Units)) {
       newParams.set(QueryParams.Units, 'short');
     }
-    setQueryParams(newParams);
+    setQueryParams(newParams, { replace: true });
   }, [queryStrings, customDataSourceName, isFirstRender, queryParams]);
 
   if (hideGraphs) {


### PR DESCRIPTION
This PR sets the navigation to replace when setting params from the query browser (metrics view). This prevents the multiple redirections that cause a user to be "trapped" in this view, for example when coming from the dashboards inspect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metric page URL parameter changes to replace the current browser history entry instead of adding a new one, making navigation smoother and reducing back-button clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->