### PR TITLE
NO-JIRA: feat: keep current data while loading new data in perses dashboards

### DIFF
--- a/web/src/components/dashboards/perses/dashboard-list-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-list-page.tsx
@@ -10,6 +10,7 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       retry: false,
+      keepPreviousData: true,
     },
   },
 });

--- a/web/src/components/dashboards/perses/dashboard-page.tsx
+++ b/web/src/components/dashboards/perses/dashboard-page.tsx
@@ -17,6 +17,7 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
+      keepPreviousData: true,
     },
   },
 });

--- a/web/src/components/ols-tool-ui/helpers/OlsToolUIPersesWrapper.tsx
+++ b/web/src/components/ols-tool-ui/helpers/OlsToolUIPersesWrapper.tsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
+      keepPreviousData: true,
     },
   },
 });


### PR DESCRIPTION
Keeps the current charts data while loading new data to avoid flickering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard and tool pages so previously loaded data stays visible while new results are loading.
  * Reduced flicker and empty states when switching filters, routes, or query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->