### PR TITLE
Fix for OCPBUGS-91628: CVE-2026-45736

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26691,9 +26691,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -164,7 +164,7 @@
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
     "axios": "^1.16.0",
-    "ws": "^8.20.1"
+    "ws": "^8.21.0"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",

--- a/web/package.json
+++ b/web/package.json
@@ -163,7 +163,8 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "axios": "^1.16.0"
+    "axios": "^1.16.0",
+    "ws": "^8.20.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-45736: uninitialized memory disclosure vulnerability in the `ws` WebSocket library (versions >= 8.0.0, < 8.20.1)
- Adds `"ws": "^8.20.1"` to npm overrides in `web/package.json`, bumping the resolved version from 8.18.0 to 8.21.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)