### PR TITLE
Fix for OCPBUGS-91621: CVE-2026-45736

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26726,9 +26726,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -179,7 +179,8 @@
     "koa": "^3.1.2",
     "sass": {
       "immutable": "^5.1.5"
-    }
+    },
+    "ws": "^8.20.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",

--- a/web/package.json
+++ b/web/package.json
@@ -180,7 +180,7 @@
     "sass": {
       "immutable": "^5.1.5"
     },
-    "ws": "^8.20.1"
+    "ws": "^8.21.0"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-45736: uninitialized memory disclosure vulnerability in the `ws` WebSocket library (versions >= 8.0.0, < 8.20.1)
- Adds `"ws": "^8.20.1"` to npm overrides in `web/package.json`, bumping the resolved version from 8.18.0 to 8.21.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)