### PR TITLE
Fix for OCPBUGS-94011: CVE-2026-13676

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14200,9 +14200,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -174,7 +174,7 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",   
-    "fast-uri": "^3.1.2",
+    "fast-uri": "3.1.3",
     "axios": "^1.16.0",
     "follow-redirects": "^1.16.0",
     "sass": {


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-13676: security policy bypass via improper Unicode hostname canonicalization in `fast-uri` (CVSS 7.5)
- Bumps `fast-uri` override from `^3.1.2` to `3.1.3` in `web/package.json`
- Follows established CVE fix pattern (npm overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)