### PR TITLE
Fix for OCPBUGS-98163: CVE-2026-13676

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5776,9 +5776,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -102,7 +102,8 @@
     "ws": "^8.17.1",
     "braces": "^3.0.3",
     "cross-spawn": "^7.0.5",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "fast-uri": "3.1.3"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-13676: security policy bypass via improper Unicode hostname canonicalization in `fast-uri` (CVSS 7.5)
- Bumps `fast-uri` override from `3.1.0` to `3.1.3` in `web/package.json`
- Follows established CVE fix pattern (npm overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)