### PR TITLE
Fix for OCPBUGS-98164: CVE-2026-13676

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -124,7 +124,8 @@
     "http-errors": "2.0.1",
     "sass": {
       "immutable": "^4.3.7"
-    }
+    },
+    "fast-uri": "3.1.3"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-13676: security policy bypass via improper Unicode hostname canonicalization in `fast-uri` (CVSS 7.5)
- Adds `fast-uri` override pinned to `3.1.3` in `web/package.json` (preventive — current dependency tree uses `uri-js` via `ajv` 6.12.6, but the override ensures protection if a future dependency update introduces `fast-uri`)
- Follows established CVE fix pattern (npm overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)