### PR TITLE
OU-651: Fix AlertRules page to display user defined loki alerts

### DIFF
--- a/web/src/shared/hooks/useAlerts.ts
+++ b/web/src/shared/hooks/useAlerts.ts
@@ -161,8 +161,8 @@ const useAlertsPoller = ({
     );
 
   const dependencies = useMemo(
-    () => [namespace, rulesUrl, silencesUrl, useAlertsTenancy, accessCheckLoading],
-    [namespace, rulesUrl, silencesUrl, useAlertsTenancy, accessCheckLoading],
+    () => [namespace, rulesUrl, silencesUrl, useAlertsTenancy, accessCheckLoading, alertsSource],
+    [namespace, rulesUrl, silencesUrl, useAlertsTenancy, accessCheckLoading, alertsSource],
   );
 
   usePoll(fetchDispatch, POLLING_INTERVAL_MS, dependencies);


### PR DESCRIPTION
### JIRA 
https://redhat.atlassian.net/browse/OU-651

! Needs to be backported to 4.19 -- the customer who reported the issue is still using this version 

### Demo 
After the fix, rendering the AlertRule Page no longer results in 'No alerts found' when displaying a user-generated Loki alert. 

Before
https://github.com/user-attachments/assets/028d014d-cb5f-41bc-8d91-64387b44a68b

After 
https://github.com/user-attachments/assets/20b70d67-a489-445c-92d0-7f5e985c8362



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Alert polling now refreshes correctly when the configured alert source changes.
  - Ensures subsequent polling uses the latest alert source configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->