### PR TITLE
OU-1389: don't match on feature_* webpack bundles

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -246,12 +246,12 @@ func setupRoutes(cfg *Config) (*mux.Router, *PluginConfig) {
 
 	router := mux.NewRouter()
 
-	router.PathPrefix("/health").HandlerFunc(healthHandler())
+	router.Path("/health").HandlerFunc(healthHandler())
 
 	router.Path("/plugin-manifest.json").Handler(manifestHandler(cfg))
 
-	router.PathPrefix("/features").HandlerFunc(featuresHandler(cfg))
-	router.PathPrefix("/config").HandlerFunc(configHandlerFunc)
+	router.Path("/features").HandlerFunc(featuresHandler(cfg))
+	router.Path("/config").HandlerFunc(configHandlerFunc)
 	router.PathPrefix("/").Handler(filesHandler(http.Dir(cfg.StaticPath)))
 
 	return router, pluginConfig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint routing so health, manifest, feature, and configuration requests only match their exact paths.
  * Prevented unintended matches for URLs that merely begin with these endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->