### PR TITLE
NO-JIRA: test: refactor createRuleViaAPI()

### DIFF
--- a/test/e2e/create_alert_rule_test.go
+++ b/test/e2e/create_alert_rule_test.go
@@ -1,12 +1,8 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"io"
-	"net/http"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,11 +29,11 @@ func TestCreateUserDefinedAlertRule(t *testing.T) {
 	defer cleanup()
 
 	createExpr := "vector(1) or vector(0)"
-	payload := managementrouter.CreateAlertRuleRequest{
+	id, err := createRuleViaAPI(ctx, f, managementrouter.CreateAlertRuleRequest{
 		AlertingRule: &managementrouter.AlertRuleSpec{
-			Alert: strPtr("E2ECreateAlert"),
+			Alert: new("E2ECreateAlert"),
 			Expr:  &createExpr,
-			For:   strPtr("1m"),
+			For:   new("1m"),
 			Labels: &map[string]string{
 				"severity": "info",
 			},
@@ -49,43 +45,11 @@ func TestCreateUserDefinedAlertRule(t *testing.T) {
 			PrometheusRuleName:      "e2e-create-pr",
 			PrometheusRuleNamespace: testNamespace,
 		},
-	}
-
-	reqBody, err := json.Marshal(payload)
+	})
 	if err != nil {
-		t.Fatalf("Failed to marshal request: %v", err)
+		t.Fatalf("Failed to create alert rule: %v", err)
 	}
-
-	createURL := f.PluginURL + "/api/v1/alerting/rules"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, createURL, bytes.NewBuffer(reqBody))
-	if err != nil {
-		t.Fatalf("Failed to create HTTP request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if f.BearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+f.BearerToken)
-	}
-
-	resp, err := f.HTTPClient().Do(req)
-	if err != nil {
-		t.Fatalf("Failed to make create request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("Expected status 201, got %d. Body: %s", resp.StatusCode, string(body))
-	}
-
-	var createResp managementrouter.CreateAlertRuleResponse
-	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	if createResp.Id == "" {
-		t.Fatal("Expected non-empty rule ID in response")
-	}
-	t.Logf("Created rule with ID: %s", createResp.Id)
+	t.Logf("Created rule with ID: %s", id)
 
 	promRule, err := f.Monitoringv1clientset.MonitoringV1().PrometheusRules(testNamespace).Get(
 		ctx, "e2e-create-pr", metav1.GetOptions{},

--- a/test/e2e/delete_alert_rule_test.go
+++ b/test/e2e/delete_alert_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -37,7 +38,28 @@ func TestDeleteAlertRule(t *testing.T) {
 	ruleIDs := make([]string, 0, len(ruleNames))
 
 	for _, name := range ruleNames {
-		id := createRuleViaAPI(t, f, ctx, testNamespace, name, "e2e-delete-pr")
+		// Each rule needs a unique expression so the spec-equivalence check
+		// does not reject it as a duplicate of a rule from another test.
+		// absent() returns 1 when the selector matches nothing, which is
+		// always the case for a fabricated metric name.
+		expr := fmt.Sprintf("absent(nonexistent{e2e_rule=%q})", name)
+		id, err := createRuleViaAPI(ctx, f, managementrouter.CreateAlertRuleRequest{
+			AlertingRule: &managementrouter.AlertRuleSpec{
+				Alert: new(name),
+				Expr:  &expr,
+				For:   new("1m"),
+				Labels: &map[string]string{
+					"severity": "info",
+				},
+			},
+			PrometheusRule: &managementrouter.PrometheusRuleTarget{
+				PrometheusRuleName:      "e2e-delete-pr",
+				PrometheusRuleNamespace: testNamespace,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create alert rule %s: %v", name, err)
+		}
 		ruleIDs = append(ruleIDs, id)
 	}
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -7,47 +7,25 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"testing"
+	"net/url"
 
 	"github.com/openshift/monitoring-plugin/internal/managementrouter"
 	"github.com/openshift/monitoring-plugin/test/e2e/framework"
 )
 
-func strPtr(s string) *string { return &s }
-
-func createRuleViaAPI(t *testing.T, f *framework.Framework, ctx context.Context, namespace, alertName, prName string) string {
-	t.Helper()
-
-	// Each rule needs a unique expression so the spec-equivalence check
-	// does not reject it as a duplicate of a rule from another test.
-	// absent() returns 1 when the selector matches nothing, which is
-	// always the case for a fabricated metric name.
-	expr := fmt.Sprintf("absent(nonexistent{e2e_rule=%q})", alertName)
-
-	payload := managementrouter.CreateAlertRuleRequest{
-		AlertingRule: &managementrouter.AlertRuleSpec{
-			Alert: &alertName,
-			Expr:  &expr,
-			For:   strPtr("1m"),
-			Labels: &map[string]string{
-				"severity": "info",
-			},
-		},
-		PrometheusRule: &managementrouter.PrometheusRuleTarget{
-			PrometheusRuleName:      prName,
-			PrometheusRuleNamespace: namespace,
-		},
-	}
-
+func createRuleViaAPI(ctx context.Context, f *framework.Framework, payload managementrouter.CreateAlertRuleRequest) (string, error) {
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
-		t.Fatalf("Failed to marshal create request for %s: %v", alertName, err)
+		return "", fmt.Errorf("marshal create request: %w", err)
 	}
 
-	createURL := f.PluginURL + "/api/v1/alerting/rules"
+	createURL, err := url.JoinPath(f.PluginURL, "api/v1/alerting/rules")
+	if err != nil {
+		return "", fmt.Errorf("build create URL: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, createURL, bytes.NewBuffer(reqBody))
 	if err != nil {
-		t.Fatalf("Failed to create HTTP request for %s: %v", alertName, err)
+		return "", fmt.Errorf("create HTTP request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if f.BearerToken != "" {
@@ -56,22 +34,25 @@ func createRuleViaAPI(t *testing.T, f *framework.Framework, ctx context.Context,
 
 	resp, err := f.HTTPClient().Do(req)
 	if err != nil {
-		t.Fatalf("Failed to make create request for %s: %v", alertName, err)
+		return "", fmt.Errorf("make create request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("Create %s: expected 201, got %d. Body: %s", alertName, resp.StatusCode, string(body))
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("failed to read body: %w", err)
+		}
+		return "", fmt.Errorf("expected 201, got %d: %s", resp.StatusCode, string(body))
 	}
 
 	var createResp managementrouter.CreateAlertRuleResponse
 	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
-		t.Fatalf("Failed to decode create response for %s: %v", alertName, err)
+		return "", fmt.Errorf("decode create response: %w", err)
 	}
 
 	if createResp.Id == "" {
-		t.Fatalf("Got empty ID for %s", alertName)
+		return "", fmt.Errorf("got empty ID")
 	}
-	return createResp.Id
+	return createResp.Id, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end alert rule creation and deletion flows to use the alert-rule API for creating rules.
  * Ensures each test rule uses a unique PromQL expression to avoid conflicts from duplicate/spec-equivalent rules.
  * Enhanced the shared API helper to validate HTTP success, parse the response, and fail with clearer error details if creation fails.
  * Preserved existing verification that the created alert rules contain the expected groups and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->