### PR TITLE
OCPBUGS-92067: graph redirect query parameter

### DIFF
--- a/web/src/features/metrics/pages/PrometheusRedirectPage.tsx
+++ b/web/src/features/metrics/pages/PrometheusRedirectPage.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { Navigate, useSearchParams } from 'react-router';
 
+import { buildPrometheusRedirectUrl } from '@/features/metrics/utils/prometheus-redirect';
 import { usePerspective } from '@/shared/hooks/usePerspective';
 
 // Handles links that have the Prometheus UI's URL format (expected for links in alerts sent by
@@ -11,13 +12,7 @@ const PrometheusRouterRedirect: FC = () => {
 
   const [params] = useSearchParams();
   // leaving perspective redirect to future work
-  return (
-    <Navigate
-      to={`/${urlRoot}/query-browser?query0=${
-        params['g0.expr'] ? encodeURIComponent(params['g0.expr']) : ''
-      }`}
-    />
-  );
+  return <Navigate to={buildPrometheusRedirectUrl(params, urlRoot)} />;
 };
 
 export default PrometheusRouterRedirect;

--- a/web/src/features/metrics/utils/prometheus-redirect.spec.ts
+++ b/web/src/features/metrics/utils/prometheus-redirect.spec.ts
@@ -1,0 +1,38 @@
+import { buildPrometheusRedirectUrl } from '@/features/metrics/utils/prometheus-redirect';
+
+describe('buildPrometheusRedirectUrl', () => {
+  it('maps g0.expr to query0 with the correct urlRoot', () => {
+    const params = new URLSearchParams('g0.expr=vector(1)&g0.tab=1');
+    expect(buildPrometheusRedirectUrl(params, 'monitoring')).toBe(
+      '/monitoring/query-browser?query0=vector(1)',
+    );
+  });
+
+  it('percent-encodes the PromQL expression', () => {
+    const params = new URLSearchParams('g0.expr=up{job="prometheus"}&g0.tab=1');
+    expect(buildPrometheusRedirectUrl(params, 'monitoring')).toBe(
+      '/monitoring/query-browser?query0=up%7Bjob%3D%22prometheus%22%7D',
+    );
+  });
+
+  it('produces an empty query0 when g0.expr is absent', () => {
+    const params = new URLSearchParams('g0.tab=1');
+    expect(buildPrometheusRedirectUrl(params, 'monitoring')).toBe(
+      '/monitoring/query-browser?query0=',
+    );
+  });
+
+  it('produces an empty query0 when g0.expr is an empty string', () => {
+    const params = new URLSearchParams('g0.expr=&g0.tab=1');
+    expect(buildPrometheusRedirectUrl(params, 'monitoring')).toBe(
+      '/monitoring/query-browser?query0=',
+    );
+  });
+
+  it('uses the urlRoot from the active perspective', () => {
+    const params = new URLSearchParams('g0.expr=up&g0.tab=0');
+    expect(buildPrometheusRedirectUrl(params, 'dev-monitoring')).toBe(
+      '/dev-monitoring/query-browser?query0=up',
+    );
+  });
+});

--- a/web/src/features/metrics/utils/prometheus-redirect.ts
+++ b/web/src/features/metrics/utils/prometheus-redirect.ts
@@ -1,0 +1,4 @@
+export const buildPrometheusRedirectUrl = (params: URLSearchParams, urlRoot: string): string => {
+  const expr = params.get('g0.expr');
+  return `/${urlRoot}/query-browser?query0=${expr ? encodeURIComponent(expr) : ''}`;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus query redirects by consistently encoding query expressions and preserving the correct URL prefix.
  * Ensured redirects handle missing or empty queries gracefully.

* **Tests**
  * Added coverage for query conversion, URL encoding, empty parameters, and environment-specific redirect paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->