### PR TITLE
NO-JIRA: use build tags for e2e tests, remove ErrSkip pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-backend:
 
 .PHONY: test-e2e
 test-e2e:
-	go test -v -timeout=150m -count=1 ./test/e2e
+	go test -tags e2e -v -timeout=150m -count=1 ./test/e2e
 
 .PHONY: test-frontend
 test-frontend:

--- a/test/e2e/create_alert_rule_test.go
+++ b/test/e2e/create_alert_rule_test.go
@@ -1,8 +1,9 @@
+//go:build e2e
+
 package e2e
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,9 +14,6 @@ import (
 
 func TestCreateUserDefinedAlertRule(t *testing.T) {
 	f, err := framework.New()
-	if errors.Is(err, framework.ErrSkip) {
-		t.Skip(err)
-	}
 	if err != nil {
 		t.Fatalf("Failed to create framework: %v", err)
 	}

--- a/test/e2e/delete_alert_rule_test.go
+++ b/test/e2e/delete_alert_rule_test.go
@@ -1,10 +1,11 @@
+//go:build e2e
+
 package e2e
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,9 +20,6 @@ import (
 
 func TestDeleteAlertRule(t *testing.T) {
 	f, err := framework.New()
-	if errors.Is(err, framework.ErrSkip) {
-		t.Skip(err)
-	}
 	if err != nil {
 		t.Fatalf("Failed to create framework: %v", err)
 	}
@@ -38,10 +36,6 @@ func TestDeleteAlertRule(t *testing.T) {
 	ruleIDs := make([]string, 0, len(ruleNames))
 
 	for _, name := range ruleNames {
-		// Each rule needs a unique expression so the spec-equivalence check
-		// does not reject it as a duplicate of a rule from another test.
-		// absent() returns 1 when the selector matches nothing, which is
-		// always the case for a fabricated metric name.
 		expr := fmt.Sprintf("absent(nonexistent{e2e_rule=%q})", name)
 		id, err := createRuleViaAPI(ctx, f, managementrouter.CreateAlertRuleRequest{
 			AlertingRule: &managementrouter.AlertRuleSpec{
@@ -65,8 +59,6 @@ func TestDeleteAlertRule(t *testing.T) {
 
 	t.Logf("Created 3 rules with IDs: %v", ruleIDs)
 
-	// Allow time for the informer watch event to propagate and
-	// the relabeled-rules cache to sync the new PrometheusRule.
 	time.Sleep(2 * time.Second)
 
 	deleteReq := managementrouter.BulkDeleteAlertRulesRequest{

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package framework
 
 import (
@@ -38,10 +40,9 @@ type Framework struct {
 
 type CleanupFunc func() error
 
-// ErrSkip is returned by New when required environment variables are not set,
-// so callers can distinguish a missing-env skip from a real error.
-var ErrSkip = fmt.Errorf("required environment variables not set, skipping e2e test")
-
+// New creates a Framework backed by a real Kubernetes cluster. It reads
+// KUBECONFIG and PLUGIN_URL from the environment and returns a singleton
+// so that expensive client setup happens only once per test binary.
 func New() (*Framework, error) {
 	if f != nil {
 		return f, nil
@@ -49,12 +50,12 @@ func New() (*Framework, error) {
 
 	kubeConfigPath := os.Getenv("KUBECONFIG")
 	if kubeConfigPath == "" {
-		return nil, fmt.Errorf("%w: KUBECONFIG", ErrSkip)
+		return nil, fmt.Errorf("KUBECONFIG environment variable is not set")
 	}
 
 	pluginURL := os.Getenv("PLUGIN_URL")
 	if pluginURL == "" {
-		return nil, fmt.Errorf("%w: PLUGIN_URL", ErrSkip)
+		return nil, fmt.Errorf("PLUGIN_URL environment variable is not set")
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (


### PR DESCRIPTION
## Summary

- Adds `//go:build e2e` constraint to all e2e test files and the framework so `go test ./...` works locally without a cluster
- Removes the `ErrSkip` sentinel pattern — `framework.New()` returns a direct error if `KUBECONFIG` or `PLUGIN_URL` are unset; tests `t.Fatal` immediately
- CI runs e2e via `make test-e2e` which passes `-tags e2e`
- Adds `unit-test` Makefile alias (delegates to `test-backend`) for clarity

## Test plan

- [x] `go test ./pkg/... ./internal/...` passes locally (e2e files excluded)
- [x] `go build ./...` succeeds (e2e files excluded without tag)
- [ ] CI `go-tests` job passes (uses `make test-backend`)
- [ ] CI `e2e-management-api` job passes (uses `make test-e2e` with `-tags e2e`)

Signed-off-by: Shirly Radco <sradco@redhat.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated command for running backend unit tests.
  * End-to-end tests now run explicitly with the E2E test configuration.
  * E2E tests and supporting helpers are isolated from standard test runs.
  * Missing E2E configuration now produces clear test failures instead of silently skipping tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->