### PR TITLE
OU-1389: Remove Shared Dashbaords Components

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -196,6 +196,10 @@ export default defineConfig([
     },
     settings: {
       'import/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+          project: './tsconfig.json',
+        },
         node: { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
       },
     },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -86,6 +86,7 @@
         "cypress-wait-until": "^3.0.2",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.37.5",
@@ -12807,6 +12808,31 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -12851,6 +12877,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils": {
@@ -15795,6 +15856,29 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -23592,6 +23676,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/stack-utils": {

--- a/web/package.json
+++ b/web/package.json
@@ -127,6 +127,7 @@
     "cypress-wait-until": "^3.0.2",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",

--- a/web/src/features/legacy-dashboards/components/DashboardSkeletonLegacy.tsx
+++ b/web/src/features/legacy-dashboards/components/DashboardSkeletonLegacy.tsx
@@ -5,13 +5,13 @@ import type { FC, PropsWithChildren } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DashboardDropdown } from '@/features/legacy-dashboards/components/LegacyDashboardDropdown';
 import { LegacyDashboardsAllVariableDropdowns } from '@/features/legacy-dashboards/components/LegacyVariableDropdowns';
 import {
   PollIntervalDropdown,
   TimespanDropdown,
 } from '@/features/legacy-dashboards/components/TimeDropdowns';
-import { DashboardDropdown } from '@/shared/components/DashboardDropdown';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
+import { LegacyDashboardMetadata } from '@/features/legacy-dashboards/types/types';
 
 const HeaderTop: FC = memo(() => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
@@ -33,7 +33,7 @@ const HeaderTop: FC = memo(() => {
 HeaderTop.displayName = 'HeaderTop';
 
 type MonitoringDashboardsLegacyPageProps = PropsWithChildren<{
-  boardItems: CombinedDashboardMetadata[];
+  boardItems: LegacyDashboardMetadata[];
   changeBoard: (params: { newBoard?: string; initialLoad?: boolean; newProject?: string }) => void;
   dashboardName: string;
 }>;

--- a/web/src/features/legacy-dashboards/components/LegacyDashboardDropdown.tsx
+++ b/web/src/features/legacy-dashboards/components/LegacyDashboardDropdown.tsx
@@ -13,8 +13,9 @@ import type { FC } from 'react';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { CombinedDashboardMetadata } from '@/features/perses-dashboards/hooks/useDashboardsData';
+import { LegacyDashboardMetadata } from '@/features/legacy-dashboards/types/types';
 import { SingleTypeaheadDropdown } from '@/shared/console/utils/SingleTypeaheadDropdown';
+import { LegacyDashboardPageTestIDs } from '@/shared/constants/data-test';
 
 type TagColor = 'red' | 'purple' | 'blue' | 'green' | 'teal' | 'orange';
 const tagColors: TagColor[] = ['red', 'purple', 'blue', 'green', 'teal', 'orange'];
@@ -59,7 +60,7 @@ export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange,
     );
   };
 
-  const selectItems = _.map(items, (item: CombinedDashboardMetadata) => ({
+  const selectItems = _.map(items, (item: LegacyDashboardMetadata) => ({
     value: item.name,
     children: item.title,
   }));
@@ -71,7 +72,7 @@ export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange,
   }, [items, selectedKey, onChange]);
 
   return (
-    <Stack data-test="dashboard-dropdown" className="pf-v6-u-mb-sm">
+    <Stack data-test={LegacyDashboardPageTestIDs.DashboardDropdown} className="pf-v6-u-mb-sm">
       <StackItem>
         <label htmlFor="monitoring-board-dropdown">{t('Dashboard')}</label>
       </StackItem>
@@ -90,7 +91,7 @@ export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange,
 };
 
 type DashboardDropdownProps = {
-  items: CombinedDashboardMetadata[];
+  items: LegacyDashboardMetadata[];
   onChange: (v: string) => void;
   selectedKey: string;
 };

--- a/web/src/features/legacy-dashboards/hooks/useLegacyDashboards.ts
+++ b/web/src/features/legacy-dashboards/hooks/useLegacyDashboards.ts
@@ -5,14 +5,13 @@ import { useDispatch } from 'react-redux';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import { useLegacyDashboardsProject } from '@/features/legacy-dashboards/hooks/useLegacyDashboardsProject';
-import { Board } from '@/features/legacy-dashboards/types/types';
+import { Board, LegacyDashboardMetadata } from '@/features/legacy-dashboards/types/types';
 import { MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from '@/features/legacy-dashboards/utils/utils';
 import { useSafeFetch } from '@/shared/console/utils/safe-fetch-hook';
 import { QueryParams } from '@/shared/constants/query-params';
 import { useBoolean } from '@/shared/hooks/useBoolean';
 import { getLegacyDashboardsUrl, usePerspective } from '@/shared/hooks/usePerspective';
 import { dashboardsPatchAllVariables } from '@/shared/store/actions';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
 import { ALL_NAMESPACES_KEY } from '@/shared/utils/utils';
 
 export const useLegacyDashboards = (urlBoard: string) => {
@@ -96,7 +95,7 @@ export const useLegacyDashboards = (urlBoard: string) => {
 
   // Homogenize data needed for dashboards dropdown between legacy and perses dashboards
   // to enable both to use the same component
-  const legacyDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
+  const legacyDashboardsMetadata = useMemo<LegacyDashboardMetadata[]>(() => {
     if (legacyDashboardsLoading) {
       return [];
     }

--- a/web/src/features/legacy-dashboards/types/types.ts
+++ b/web/src/features/legacy-dashboards/types/types.ts
@@ -98,3 +98,9 @@ export type DataSource = {
   name: string;
   type: string;
 };
+
+export type LegacyDashboardMetadata = {
+  name: string;
+  tags: string[];
+  title: string;
+};

--- a/web/src/features/perses-dashboards/components/DashboardDropdown.tsx
+++ b/web/src/features/perses-dashboards/components/DashboardDropdown.tsx
@@ -1,0 +1,97 @@
+import {
+  Label,
+  LabelGroup,
+  Level,
+  LevelItem,
+  SelectOption,
+  SelectOptionProps,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import * as _ from 'lodash-es';
+import type { FC } from 'react';
+import { memo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DashboardMetadata } from '@/features/perses-dashboards/types/types';
+import { SingleTypeaheadDropdown } from '@/shared/console/utils/SingleTypeaheadDropdown';
+import { DataTestIDs } from '@/shared/constants/data-test';
+
+type TagColor = 'red' | 'purple' | 'blue' | 'green' | 'teal' | 'orange';
+const tagColors: TagColor[] = ['red', 'purple', 'blue', 'green', 'teal', 'orange'];
+
+const Tag = memo(({ color, text }: { color: TagColor; text: string }) => (
+  <Label isCompact color={color}>
+    {text}
+  </Label>
+));
+
+Tag.displayName = 'Tag';
+
+export const DashboardDropdown: FC<DashboardDropdownProps> = ({ items, onChange, selectedKey }) => {
+  const { t } = useTranslation(process.env.I18N_NAMESPACE);
+
+  const allTags = _.flatMap(items, 'tags');
+  const uniqueTags = _.uniq(allTags);
+
+  const OptionComponent = ({ value, isSelected, ...rest }: SelectOptionProps) => {
+    const matchedValue = items.find((item) => {
+      return item.name === value;
+    });
+    return (
+      <SelectOption value={value} isSelected={isSelected || false} {...rest}>
+        <Level hasGutter>
+          <LevelItem>
+            <span>{matchedValue?.title}</span>
+          </LevelItem>
+          <LevelItem>
+            <LabelGroup>
+              {matchedValue?.tags?.map((tag, i) => (
+                <Tag
+                  key={i}
+                  color={tagColors[_.indexOf(uniqueTags, tag) % tagColors.length]}
+                  text={tag}
+                />
+              ))}
+            </LabelGroup>
+          </LevelItem>
+        </Level>
+      </SelectOption>
+    );
+  };
+
+  const selectItems = _.map(items, (item: DashboardMetadata) => ({
+    value: item.name,
+    children: item.title,
+  }));
+
+  useEffect(() => {
+    if (items.filter((item) => item.name === selectedKey).length === 0) {
+      onChange(items.at(0)?.name);
+    }
+  }, [items, selectedKey, onChange]);
+
+  return (
+    <Stack data-test={DataTestIDs.PersesDashboardDropdown} className="pf-v6-u-mb-sm">
+      <StackItem>
+        <label htmlFor="monitoring-board-dropdown">{t('Dashboard')}</label>
+      </StackItem>
+      <StackItem isFilled>
+        <SingleTypeaheadDropdown
+          items={selectItems}
+          onChange={onChange}
+          OptionComponent={OptionComponent}
+          selectedKey={selectedKey}
+          hideClearButton
+          resizeToFit
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+type DashboardDropdownProps = {
+  items: DashboardMetadata[];
+  onChange: (v: string) => void;
+  selectedKey: string;
+};

--- a/web/src/features/perses-dashboards/components/DashboardHeader.tsx
+++ b/web/src/features/perses-dashboards/components/DashboardHeader.tsx
@@ -8,7 +8,7 @@ import {
   t_global_spacer_xl,
 } from '@patternfly/react-tokens';
 import { memo } from 'react';
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -17,7 +17,6 @@ import { PagePadding } from '@/features/perses-dashboards/pages/dashboard-page/D
 import { listPersesDashboardsDataTestIDs } from '@/shared/constants/data-test';
 import { usePatternFlyTheme } from '@/shared/hooks/usePatternflyTheme';
 import { getDashboardsListUrl, usePerspective } from '@/shared/hooks/usePerspective';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
 
 const DASHBOARD_VIEW_PATH = 'v2/dashboards/view';
 
@@ -106,10 +105,7 @@ const DashboardListPageHeader: FC = () => {
 };
 
 type MonitoringDashboardsPageProps = PropsWithChildren<{
-  boardItems: CombinedDashboardMetadata[];
-  changeBoard: (dashboardName: string) => void;
   dashboardDisplayName: string;
-  activeProject?: string;
 }>;
 
 export const DashboardHeader = memo(
@@ -130,7 +126,7 @@ export const DashboardHeader = memo(
 
 DashboardHeader.displayName = 'DashboardHeader';
 
-export const DashboardListHeader = memo(({ children }: MonitoringDashboardsPageProps) => {
+export const DashboardListHeader = memo(({ children }: { children: ReactNode | undefined }) => {
   const { t } = useTranslation(process.env.I18N_NAMESPACE);
 
   return (

--- a/web/src/features/perses-dashboards/hooks/useDashboardsData.ts
+++ b/web/src/features/perses-dashboards/hooks/useDashboardsData.ts
@@ -6,10 +6,10 @@ import { StringParam, useQueryParam } from 'use-query-params';
 
 import { useActiveProject } from '@/features/perses-dashboards/components/project/useActiveProject';
 import { usePerses } from '@/features/perses-dashboards/hooks/usePerses';
+import type { DashboardMetadata } from '@/features/perses-dashboards/types/types';
 import { QueryParams } from '@/shared/constants/query-params';
 import { useBoolean } from '@/shared/hooks/useBoolean';
 import { getDashboardUrl, usePerspective } from '@/shared/hooks/usePerspective';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
 import { ALL_NAMESPACES_KEY } from '@/shared/utils/utils';
 
 // This hook syncs with mutliple external API's, redux, and URL state. Its a lot, but needs to all
@@ -43,11 +43,11 @@ export const useDashboardsData = () => {
   }, [persesProjectsLoading, persesDashboardsLoading, initialPageLoad, setInitialPageLoadFalse]);
 
   const prevDashboardsRef = useRef<DashboardResource[]>([]);
-  const prevMetadataRef = useRef<CombinedDashboardMetadata[]>([]);
+  const prevMetadataRef = useRef<DashboardMetadata[]>([]);
 
   // Homogenize data needed for dashboards dropdown between legacy and perses dashboards
   // to enable both to use the same component
-  const combinedDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
+  const combinedDashboardsMetadata = useMemo<DashboardMetadata[]>(() => {
     if (combinedInitialLoad) {
       return [];
     }
@@ -87,7 +87,7 @@ export const useDashboardsData = () => {
   }, [persesDashboards, combinedInitialLoad]);
 
   // Retrieve dashboard metadata for the currently selected project
-  const activeProjectDashboardsMetadata = useMemo<CombinedDashboardMetadata[]>(() => {
+  const activeProjectDashboardsMetadata = useMemo<DashboardMetadata[]>(() => {
     if (activeProject === ALL_NAMESPACES_KEY) {
       return combinedDashboardsMetadata;
     }

--- a/web/src/features/perses-dashboards/pages/dashboard-list-page/DashboardList.tsx
+++ b/web/src/features/perses-dashboards/pages/dashboard-list-page/DashboardList.tsx
@@ -435,22 +435,10 @@ const DashboardsTable: FC<DashboardsTableProps> = ({
 };
 
 export const DashboardList: FC = () => {
-  const {
-    activeProjectDashboardsMetadata,
-    changeBoard,
-    dashboardName,
-    activeProject,
-    persesDashboards,
-    combinedInitialLoad,
-  } = useDashboardsData();
+  const { activeProject, persesDashboards, combinedInitialLoad } = useDashboardsData();
 
   return (
-    <DashboardListFrame
-      activeProject={activeProject}
-      activeProjectDashboardsMetadata={activeProjectDashboardsMetadata}
-      changeBoard={changeBoard}
-      dashboardName={dashboardName}
-    >
+    <DashboardListFrame activeProject={activeProject}>
       <DashboardsTable
         persesDashboards={persesDashboards}
         persesDashboardsLoading={combinedInitialLoad}

--- a/web/src/features/perses-dashboards/pages/dashboard-list-page/DashboardListFrame.tsx
+++ b/web/src/features/perses-dashboards/pages/dashboard-list-page/DashboardListFrame.tsx
@@ -2,34 +2,17 @@ import { FC, ReactNode } from 'react';
 
 import { DashboardListHeader } from '@/features/perses-dashboards/components/DashboardHeader';
 import { ProjectBar } from '@/features/perses-dashboards/components/project/ProjectBar';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
 
 interface DashboardListFrameProps {
   activeProject: string | null;
-  activeProjectDashboardsMetadata: CombinedDashboardMetadata[];
-  changeBoard: (boardName: string) => void;
-  dashboardName: string;
   children: ReactNode;
 }
 
-export const DashboardListFrame: FC<DashboardListFrameProps> = ({
-  activeProject,
-  activeProjectDashboardsMetadata,
-  changeBoard,
-  dashboardName,
-  children,
-}) => {
+export const DashboardListFrame: FC<DashboardListFrameProps> = ({ activeProject, children }) => {
   return (
     <>
       <ProjectBar activeProject={activeProject} />
-      <DashboardListHeader
-        boardItems={activeProjectDashboardsMetadata}
-        changeBoard={changeBoard}
-        dashboardDisplayName={dashboardName}
-        activeProject={activeProject}
-      >
-        {children}
-      </DashboardListHeader>
+      <DashboardListHeader>{children}</DashboardListHeader>
     </>
   );
 };

--- a/web/src/features/perses-dashboards/pages/dashboard-page/DashboardFrame.tsx
+++ b/web/src/features/perses-dashboards/pages/dashboard-page/DashboardFrame.tsx
@@ -6,12 +6,11 @@ import { PersesWrapper } from '@/features/perses-dashboards/components/PersesWra
 import { ProjectBar } from '@/features/perses-dashboards/components/project/ProjectBar';
 import { ToastProvider } from '@/features/perses-dashboards/components/ToastProvider';
 import { PagePadding } from '@/features/perses-dashboards/pages/dashboard-page/DashboardPagePadding';
-import type { CombinedDashboardMetadata } from '@/shared/types/types';
+import type { DashboardMetadata } from '@/features/perses-dashboards/types/types';
 
 interface DashboardFrameProps {
   activeProject: string | null;
-  activeProjectDashboardsMetadata: CombinedDashboardMetadata[];
-  changeBoard: (boardName: string) => void;
+  activeProjectDashboardsMetadata: DashboardMetadata[];
   dashboardDisplayName: string;
   children: ReactNode;
 }
@@ -19,7 +18,6 @@ interface DashboardFrameProps {
 export const DashboardFrame: FC<DashboardFrameProps> = ({
   activeProject,
   activeProjectDashboardsMetadata,
-  changeBoard,
   dashboardDisplayName,
   children,
 }) => {
@@ -32,12 +30,7 @@ export const DashboardFrame: FC<DashboardFrameProps> = ({
             <DashboardEmptyState />
           ) : (
             <>
-              <DashboardHeader
-                boardItems={activeProjectDashboardsMetadata}
-                changeBoard={changeBoard}
-                dashboardDisplayName={dashboardDisplayName}
-                activeProject={activeProject}
-              >
+              <DashboardHeader dashboardDisplayName={dashboardDisplayName}>
                 <PagePadding top="0">{children}</PagePadding>
               </DashboardHeader>
             </>

--- a/web/src/features/perses-dashboards/pages/dashboard-page/DashboardPage.tsx
+++ b/web/src/features/perses-dashboards/pages/dashboard-page/DashboardPage.tsx
@@ -83,7 +83,6 @@ const DashboardPage_: FC = () => {
     <DashboardFrame
       activeProject={activeProject}
       activeProjectDashboardsMetadata={activeProjectDashboardsMetadata}
-      changeBoard={changeBoard}
       dashboardDisplayName={currentDashboard.title}
     >
       <OCPDashboardApp

--- a/web/src/features/perses-dashboards/pages/dashboard-page/DashboardToolbar.tsx
+++ b/web/src/features/perses-dashboards/pages/dashboard-page/DashboardToolbar.tsx
@@ -20,9 +20,9 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import { ReactElement, ReactNode, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DashboardDropdown } from '@/features/perses-dashboards/components/DashboardDropdown';
 import { useDashboardsData } from '@/features/perses-dashboards/hooks/useDashboardsData';
 import { usePersesEditPermissions } from '@/features/perses-dashboards/hooks/usePersesEditPermissions';
-import { DashboardDropdown } from '@/shared/components/DashboardDropdown';
 import { persesDashboardDataTestIDs } from '@/shared/constants/data-test';
 
 export interface DashboardToolbarProps {

--- a/web/src/features/perses-dashboards/types/types.ts
+++ b/web/src/features/perses-dashboards/types/types.ts
@@ -1,0 +1,9 @@
+import type { DashboardResource } from '@perses-dev/core';
+
+export type DashboardMetadata = {
+  name: string;
+  project: string;
+  tags: string[];
+  title: string;
+  persesDashboard: DashboardResource;
+};

--- a/web/src/shared/constants/data-test.ts
+++ b/web/src/shared/constants/data-test.ts
@@ -60,7 +60,7 @@ export const DataTestIDs = {
   NameLabelDropdownOptions: 'console-select-item',
   NamespaceDropdownShowSwitch: 'showSystemSwitch',
   NamespaceDropdownTextFilter: 'dropdown-text-filter',
-  PersesDashboardDropdown: 'dashboard-dropdown',
+  PersesDashboardDropdown: 'perses-dashboard-dropdown',
   PersesCreateDashboardButton: 'create-dashboard-button-list-page',
   SeverityBadgeHeader: 'severity-badge-header',
   SeverityBadge: 'severity-badge',

--- a/web/src/shared/types/types.ts
+++ b/web/src/shared/types/types.ts
@@ -1,5 +1,4 @@
 import { Alert, PrometheusLabels, Silence } from '@openshift-console/dynamic-plugin-sdk';
-import type { DashboardResource } from '@perses-dev/core';
 
 export const enum AlertSource {
   Platform = 'platform',
@@ -59,12 +58,4 @@ export type PatternflyToken = {
   name: string;
   value: string;
   var: string;
-};
-
-export type CombinedDashboardMetadata = {
-  name: string;
-  project?: string;
-  tags: string[];
-  title: string;
-  persesDashboard?: DashboardResource;
 };


### PR DESCRIPTION
This PR includes two changes:

1. A fix to perform eslint checks on imports even when they are using an alias
2. Removal of shared dashboard code from perses and legacy, enabling a more clear definition of boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a legacy dashboard selector with dashboard titles and colored tag badges.

- **Improvements**
  - Standardized dashboard dropdown and metadata handling across legacy and Perses dashboards.
  - Ensured the dropdown selection always stays aligned with available dashboards.
  - Simplified dashboard header and list frame layouts for a cleaner experience.

- **Refactor**
  - Improved separation between legacy and Perses dashboard implementations while preserving existing loading and navigation behavior.

- **Chores**
  - Updated linting configuration for TypeScript-based module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->