### PR TITLE
OU-1389: remove default features from plugin-backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 COPY config/ /opt/app-root/config
 
-ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config", "-features", "alerting,metrics,legacy-dashboards,targets"]

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -31,4 +31,4 @@ COPY --from=web-builder /usr/src/app/web/dist /opt/app-root/web/dist
 COPY --from=go-builder $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/plugin-backend /opt/app-root
 COPY config/ /opt/app-root/config
 
-ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config", "-features", "alerting,metrics,legacy-dashboards,targets"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -36,4 +36,4 @@ COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 COPY config/ /opt/app-root/config
 
-ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config"]
+ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist", "-config-path", "/opt/app-root/config", "-features", "alerting,metrics,legacy-dashboards,targets"]

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -107,6 +107,17 @@ func (s *PluginServer) Shutdown(ctx context.Context) error {
 }
 
 func createHTTPServer(ctx context.Context, cfg *Config) (*http.Server, error) {
+	hasFeatures := false
+	for _, enabled := range cfg.Features {
+		if enabled {
+			hasFeatures = true
+			break
+		}
+	}
+	if !hasFeatures {
+		return nil, fmt.Errorf("cannot start server without any features selected")
+	}
+
 	acmMode := cfg.Features[AcmAlerting]
 	acmLocationsLength := len(cfg.AlertmanagerUrl) + len(cfg.ThanosQuerierUrl)
 
@@ -119,14 +130,6 @@ func createHTTPServer(ctx context.Context, cfg *Config) (*http.Server, error) {
 
 	if cfg.Port == int(monitoring.AlertmanagerPort) || cfg.Port == int(monitoring.ThanosQuerierPort) {
 		return nil, fmt.Errorf("cannot set default port to reserved port %d", cfg.Port)
-	}
-
-	if len(cfg.Features) == 0 {
-		cfg.Features = make(map[Feature]bool)
-		cfg.Features[Alerting] = true
-		cfg.Features[LegacyDashboards] = true
-		cfg.Features[Metrics] = true
-		cfg.Features[Targets] = true
 	}
 
 	// Uncomment the following line for local development:

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -34,6 +34,13 @@ const (
 	testHostname = "127.0.0.1"
 )
 
+var defaultFeatures = map[Feature]bool{
+	Alerting:         true,
+	Metrics:          true,
+	LegacyDashboards: true,
+	Targets:          true,
+}
+
 func TestCreateHTTPServer(t *testing.T) {
 	for _, tc := range []struct {
 		cfg *Config
@@ -45,6 +52,7 @@ func TestCreateHTTPServer(t *testing.T) {
 				TLSMaxVersion:  tls.VersionTLS11,
 				CertFile:       "/etc/tls/server.crt",
 				PrivateKeyFile: "/etc/tls/server.key",
+				Features:       defaultFeatures,
 			},
 			err: true,
 		},
@@ -54,6 +62,7 @@ func TestCreateHTTPServer(t *testing.T) {
 				TLSMaxVersion:  tls.VersionTLS12,
 				CertFile:       "/etc/tls/server.crt",
 				PrivateKeyFile: "/etc/tls/server.key",
+				Features:       defaultFeatures,
 			},
 			err: true,
 		},
@@ -115,7 +124,8 @@ func TestServerRunning(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	_, cleanup := startTestServer(t, &Config{
-		Port: testPort,
+		Port:     testPort,
+		Features: defaultFeatures,
 	})
 	defer cleanup()
 
@@ -186,6 +196,7 @@ func TestSecureServerRunning(t *testing.T) {
 		CertFile:       testServerCertFile,
 		PrivateKeyFile: testServerKeyFile,
 		Port:           testPort,
+		Features:       defaultFeatures,
 	}
 
 	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
@@ -430,6 +441,7 @@ func TestTLSConfigWithCustomSettings(t *testing.T) {
 		TLSMinVersion:   tls.VersionTLS12,
 		TLSMaxVersion:   tls.VersionTLS13,
 		TLSCipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		Features:        defaultFeatures,
 	}
 
 	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
@@ -518,6 +530,7 @@ func TestTLSConfigWithDefaults(t *testing.T) {
 		PrivateKeyFile: testServerKeyFile,
 		Port:           testPort,
 		// No TLS settings - should use Go defaults
+		Features: defaultFeatures,
 	}
 
 	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
@@ -602,6 +615,7 @@ func TestTLSConfigMinVersionOnly(t *testing.T) {
 		Port:           testPort,
 		TLSMinVersion:  tls.VersionTLS13,
 		// No MaxVersion - should allow TLS 1.3
+		Features: defaultFeatures,
 	}
 
 	serverURL := fmt.Sprintf("https://%s", testServerHostPort)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container deployments now start with alerting, metrics, legacy dashboards, and targets enabled via runtime flags.

* **Bug Fixes**
  * Server startup now fails fast when no features are selected, instead of silently enabling defaults.

* **Tests**
  * Updated server and TLS-related tests to explicitly configure the supported feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->