### PR TITLE
NO-JIRA: split CreateNamespace() into 2 functions

### DIFF
--- a/test/e2e/create_alert_rule_test.go
+++ b/test/e2e/create_alert_rule_test.go
@@ -20,7 +20,7 @@ func TestCreateUserDefinedAlertRule(t *testing.T) {
 
 	ctx := context.Background()
 
-	testNamespace, cleanup, err := f.CreateNamespace(ctx, "test-create-rule", false)
+	testNamespace, cleanup, err := f.CreateUserNamespace(ctx, "test-create-rule")
 	if err != nil {
 		t.Fatalf("Failed to create test namespace: %v", err)
 	}

--- a/test/e2e/delete_alert_rule_test.go
+++ b/test/e2e/delete_alert_rule_test.go
@@ -26,7 +26,7 @@ func TestDeleteAlertRule(t *testing.T) {
 
 	ctx := context.Background()
 
-	testNamespace, cleanup, err := f.CreateNamespace(ctx, "test-delete-rule", false)
+	testNamespace, cleanup, err := f.CreateUserNamespace(ctx, "test-delete-rule")
 	if err != nil {
 		t.Fatalf("Failed to create test namespace: %v", err)
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -113,15 +112,27 @@ func (f *Framework) HTTPClient() *http.Client {
 	return f.httpClient
 }
 
-func (f *Framework) CreateNamespace(ctx context.Context, name string, isClusterMonitoringNamespace bool) (string, CleanupFunc, error) {
+// CreatePlatformNamespace creates a namespace which is monitored by the platform monitoring stack.
+func (f *Framework) CreatePlatformNamespace(ctx context.Context, name string) (string, CleanupFunc, error) {
+	return f.createNamespace(ctx, name, true)
+}
+
+// CreateUserNamespace creates a namespace which is monitored by the user-defined monitoring stack.
+func (f *Framework) CreateUserNamespace(ctx context.Context, name string) (string, CleanupFunc, error) {
+	return f.createNamespace(ctx, name, false)
+}
+
+func (f *Framework) createNamespace(ctx context.Context, name string, isClusterMonitoringNamespace bool) (string, CleanupFunc, error) {
 	testNamespace := fmt.Sprintf("%s-%d", name, time.Now().Unix())
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testNamespace,
-			Labels: map[string]string{
-				k8s.ClusterMonitoringLabel: strconv.FormatBool(isClusterMonitoringNamespace),
-			},
+			Name:   testNamespace,
+			Labels: map[string]string{},
 		},
+	}
+
+	if isClusterMonitoringNamespace {
+		namespace.Labels[k8s.ClusterMonitoringLabel] = "true"
 	}
 
 	_, err := f.Clientset.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})


### PR DESCRIPTION
This commit adds 2 functions instead of the unique CreateNamespace() to make it more readable:
* `CreatePlatformNamespace()` (not used yet)
* `CreateUserNamespace()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end alert rule tests to create user namespaces through the supported namespace workflow.
  * Preserved existing alert rule creation, deletion, and validation coverage.

* **Refactor**
  * Added distinct workflows for creating platform and user namespaces.
  * Simplified namespace setup while maintaining automatic cleanup and monitoring labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->