### PR TITLE
OU-1389: add OWNERS_ALIAS and feature based OWNERS files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+aliases:
+  observability-ui-devs:
+    - jgbernalp
+    - zhuje
+    - peteryurkovich
+  observability-ui:
+    - jgbernalp
+    - zhuje
+    - peteryurkovich
+    - etmurasaki

--- a/web/cypress/OWNERS
+++ b/web/cypress/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - etmurasaki
+  - DavidRajnoha
+  - jgbernalp
+  - peteryurkovich
+approvers:
+  - etmurasaki
+  - DavidRajnoha
+  - jgbernalp
+  - peteryurkovich
+  - zhuje

--- a/web/eslint-rules/require-feature-owners.spec.ts
+++ b/web/eslint-rules/require-feature-owners.spec.ts
@@ -1,3 +1,4 @@
+import type { Rule } from 'eslint';
 import { RuleTester } from 'eslint';
 import { createRequireFeatureOwners } from './require-feature-owners';
 
@@ -43,3 +44,31 @@ ruleTester.run(
     ],
   },
 );
+
+describe('require-feature-owners (stale cache regression)', () => {
+  it('re-checks existsSync on each invocation instead of reusing a cached result', () => {
+    let ownersExists = false;
+    const rule = createRequireFeatureOwners(() => ownersExists);
+
+    const reports: Rule.ReportDescriptor[] = [];
+    const makeContext = (filename: string) =>
+      ({
+        filename,
+        report: (descriptor: Rule.ReportDescriptor) => reports.push(descriptor),
+      }) as unknown as Rule.RuleContext;
+
+    const filename = '/repo/web/src/features/alerts/AlertList.tsx';
+
+    // First invocation: OWNERS missing — expect one report.
+    rule.create(makeContext(filename));
+    expect(reports).toHaveLength(1);
+
+    // OWNERS file now exists (e.g. created mid watch-mode session).
+    ownersExists = true;
+    reports.length = 0;
+
+    // Second invocation with the same rule instance — must not return a stale result.
+    rule.create(makeContext(filename));
+    expect(reports).toHaveLength(0);
+  });
+});

--- a/web/eslint-rules/require-feature-owners.spec.ts
+++ b/web/eslint-rules/require-feature-owners.spec.ts
@@ -1,0 +1,45 @@
+import { RuleTester } from 'eslint';
+import { createRequireFeatureOwners } from './require-feature-owners';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2021, sourceType: 'module' },
+});
+
+ruleTester.run(
+  'require-feature-owners (OWNERS present)',
+  createRequireFeatureOwners(() => true),
+  {
+    valid: [
+      { code: '', filename: '/repo/web/src/features/alerts/components/AlertList.tsx' },
+      { code: '', filename: '/repo/web/src/features/metrics/pages/MetricsPage.tsx' },
+      { code: '', filename: '/repo/web/src/features/alerts/index.ts' },
+      { code: '', filename: '/repo/web/src/shared/utils/format.ts' },
+      { code: '', filename: '/repo/web/src/shared/hooks/useAlerts.ts' },
+    ],
+    invalid: [],
+  },
+);
+
+ruleTester.run(
+  'require-feature-owners (OWNERS absent)',
+  createRequireFeatureOwners(() => false),
+  {
+    // Not in features folder
+    valid: [
+      { code: '', filename: '/repo/web/src/shared/utils/format.ts' },
+      { code: '', filename: '/repo/web/src/shared/hooks/useAlerts.ts' },
+    ],
+    invalid: [
+      {
+        code: '',
+        filename: '/repo/web/src/features/alerts/components/AlertList.tsx',
+        errors: [{ messageId: 'missingOwners', data: { feature: 'alerts' } }],
+      },
+      {
+        code: '',
+        filename: '/repo/web/src/features/new-feature/NewFeature.tsx',
+        errors: [{ messageId: 'missingOwners', data: { feature: 'new-feature' } }],
+      },
+    ],
+  },
+);

--- a/web/eslint-rules/require-feature-owners.ts
+++ b/web/eslint-rules/require-feature-owners.ts
@@ -7,10 +7,6 @@ const FEATURES_MARKER = path.join('src', 'features') + path.sep;
 export function createRequireFeatureOwners(
   existsSync: (p: string) => boolean = fs.existsSync,
 ): Rule.RuleModule {
-  // Cache results per feature directory so each feature is checked at most once
-  // per ESLint run, regardless of how many files it contains.
-  const cache = new Map<string, boolean>();
-
   return {
     meta: {
       type: 'problem',
@@ -38,17 +34,12 @@ export function createRequireFeatureOwners(
       const featureDir = filename.slice(0, markerIndex + FEATURES_MARKER.length + feature.length);
       const ownersPath = path.join(featureDir, 'OWNERS');
 
-      if (!cache.has(featureDir)) {
-        const ownersExists = existsSync(ownersPath);
-        cache.set(featureDir, ownersExists);
-
-        if (!ownersExists) {
-          context.report({
-            loc: { line: 1, column: 0 },
-            messageId: 'missingOwners',
-            data: { feature },
-          });
-        }
+      if (!existsSync(ownersPath)) {
+        context.report({
+          loc: { line: 1, column: 0 },
+          messageId: 'missingOwners',
+          data: { feature },
+        });
       }
 
       return {};

--- a/web/eslint-rules/require-feature-owners.ts
+++ b/web/eslint-rules/require-feature-owners.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Rule } from 'eslint';
+
+const FEATURES_MARKER = path.join('src', 'features') + path.sep;
+
+export function createRequireFeatureOwners(
+  existsSync: (p: string) => boolean = fs.existsSync,
+): Rule.RuleModule {
+  // Cache results per feature directory so each feature is checked at most once
+  // per ESLint run, regardless of how many files it contains.
+  const cache = new Map<string, boolean>();
+
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description:
+          'Require an OWNERS file in the root of every feature directory under src/features/',
+      },
+      schema: [],
+      messages: {
+        missingOwners:
+          'Feature directory "src/features/{{feature}}" is missing an OWNERS file. ' +
+          'Add an OWNERS file to define reviewers and approvers for this feature.',
+      },
+    },
+    create(context) {
+      const filename = context.filename;
+      const markerIndex = filename.indexOf(FEATURES_MARKER);
+
+      if (markerIndex === -1) {
+        return {};
+      }
+
+      const afterMarker = filename.slice(markerIndex + FEATURES_MARKER.length);
+      const feature = afterMarker.split(path.sep)[0];
+      const featureDir = filename.slice(0, markerIndex + FEATURES_MARKER.length + feature.length);
+      const ownersPath = path.join(featureDir, 'OWNERS');
+
+      if (!cache.has(featureDir)) {
+        const ownersExists = existsSync(ownersPath);
+        cache.set(featureDir, ownersExists);
+
+        if (!ownersExists) {
+          context.report({
+            loc: { line: 1, column: 0 },
+            messageId: 'missingOwners',
+            data: { feature },
+          });
+        }
+      }
+
+      return {};
+    },
+  };
+}
+
+export const requireFeatureOwners = createRequireFeatureOwners();

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -184,7 +184,9 @@ export default defineConfig([
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     ignores: ['cypress/**', 'src/**/*.d.ts'],
     plugins: {
-      'local-rules': { rules: { 'file-naming': fileNaming, 'require-feature-owners': requireFeatureOwners } } as any,
+      'local-rules': {
+        rules: { 'file-naming': fileNaming, 'require-feature-owners': requireFeatureOwners },
+      } as any,
     },
     rules: {
       'local-rules/file-naming': 'error',

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -12,6 +12,7 @@ import { FlatCompat } from '@eslint/eslintrc';
 import importPlugin from 'eslint-plugin-import';
 import { importBoundaryZones } from './eslint-rules/import-boundary-zones';
 import { fileNaming } from './eslint-rules/file-naming';
+import { requireFeatureOwners } from './eslint-rules/require-feature-owners';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -183,10 +184,11 @@ export default defineConfig([
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     ignores: ['cypress/**', 'src/**/*.d.ts'],
     plugins: {
-      'local-rules': { rules: { 'file-naming': fileNaming } } as any,
+      'local-rules': { rules: { 'file-naming': fileNaming, 'require-feature-owners': requireFeatureOwners } } as any,
     },
     rules: {
       'local-rules/file-naming': 'error',
+      'local-rules/require-feature-owners': 'error',
     },
   },
   {

--- a/web/src/features/alerts/OWNERS
+++ b/web/src/features/alerts/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui

--- a/web/src/features/incidents/OWNERS
+++ b/web/src/features/incidents/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
   - observability-ui-devs
+  - DavidRajnoha
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui
+  - DavidRajnoha

--- a/web/src/features/legacy-dashboards/OWNERS
+++ b/web/src/features/legacy-dashboards/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui

--- a/web/src/features/metrics/OWNERS
+++ b/web/src/features/metrics/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui

--- a/web/src/features/perses-dashboards/OWNERS
+++ b/web/src/features/perses-dashboards/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui

--- a/web/src/features/targets/OWNERS
+++ b/web/src/features/targets/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui

--- a/web/src/shared/OWNERS
+++ b/web/src/shared/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - observability-ui-devs
 approvers:
-  - jan--f
-  - kyoto
   - observability-ui


### PR DESCRIPTION
Add per-feature OWNERS files and specific `shared` and `cypress` OWNER's files.

Adds @DavidRajnoha as a reviewer and approver in the cypress folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated ownership/approval configurations across the web app, including new feature-area `OWNERS` files and Cypress-specific ownership rules.
  * Added centralized ownership alias groups to streamline reviewer/approver assignments.

* **New Features**
  * Introduced a linting rule that validates required feature ownership data and reports clear diagnostics when missing.

* **Bug Fixes**
  * Improved lint feedback by tying missing ownership reports to the specific affected feature.

* **Tests**
  * Added rule test coverage for valid/invalid cases and a regression scenario to prevent stale results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->