### PR TITLE
OCPBUGS-99032: Fix CVE-2026-49978 - bump DOMPurify to >= 3.4.7

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11809,9 +11809,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -166,7 +166,8 @@
     "qs": "^6.14.1",
     "axios": "^1.16.0",
     "ws": "^8.21.0",
-    "form-data": "^4.0.6"
+    "form-data": "^4.0.6",
+    "dompurify": "^3.4.11"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## What this PR does / why we need it

CVE-2026-49978: DOMPurify IN_PLACE sanitization bypass via attached Shadow Root inside `<template>.content` (XSS). Affects DOMPurify versions <= 3.4.6.

monitoring-plugin has DOMPurify 3.2.7 as a transitive dependency via `monaco-editor`. This adds a `dompurify` override in `package.json` to bump it to `^3.4.11` (resolved to 3.4.12).

## Which issue(s) this PR fixes

OCPBUGS-99032

## Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.