### PR TITLE
OCPBUGS-99027: Fix CVE-2026-49978 - bump DOMPurify to >= 3.4.7

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12374,9 +12374,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/web/package.json
+++ b/web/package.json
@@ -182,7 +182,8 @@
     "sass": {
       "immutable": "^5.1.5"
     },
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "dompurify": "^3.4.11"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## What this PR does / why we need it

CVE-2026-49978: DOMPurify IN_PLACE sanitization bypass via attached Shadow Root inside `<template>.content` (XSS). Affects DOMPurify versions <= 3.4.6.

monitoring-plugin has DOMPurify 3.3.0 as a transitive dependency via `monaco-editor`. This adds a `dompurify` override in `package.json` to bump it to `^3.4.11` (resolved to 3.4.12).

## Which issue(s) this PR fixes

OCPBUGS-99027

## Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.