### PR TITLE
OU-1240: Makefile and package.json to enable test-frontend-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ test-backend:
 test-frontend:
 	cd web && npm run test:unit
 
+.PHONY: test-frontend-unit
+test-frontend-unit:
+	cd web && npm run test:unit:ci
+
 .PHONY: build-image
 build-image:
 	./scripts/build-image.sh

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "dev": "npm run ts-node node_modules/.bin/webpack serve",
     "start-console": "../scripts/start-console.sh",
     "test:unit": "TZ=UTC jest --config jest.config.js --passWithNoTests",
+    "test:unit:ci": "TZ=UTC jest --config jest.config.js --passWithNoTests --maxWorkers=2",
     "test": "npm run cypress:run:ci",
     "test-cypress-console": "./node_modules/.bin/cypress open --browser chrome",
     "test-cypress-console-headless": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI-specific frontend unit test command.
  * Limited parallel test workers during CI runs to improve execution reliability.
  * Added a convenient Make target for running the CI test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->