### PR TITLE
OCPBUGS-99942: Fix missing query params in Prometheus API requests

### DIFF
--- a/web/src/shared/utils/utils.ts
+++ b/web/src/shared/utils/utils.ts
@@ -270,7 +270,7 @@ export const buildPrometheusUrl = ({
 
   const params = getSearchParams(prometheusUrlProps);
   return `${basePath}/${prometheusUrlProps.endpoint}${
-    params.size > 0 ? '?' + params.toString() : ''
+    params.toString() ? '?' + params.toString() : ''
   }`;
 };
 


### PR DESCRIPTION
## Problem

After upgrading to 4.20.17, the Metrics UI sends GET requests to `/api/prometheus/api/v1/query_range` without query parameters, causing 400 Bad Request errors and preventing graphs from rendering.

## Root Cause

In `web/src/shared/utils/utils.ts` line 272-274, the code checks `params.size > 0` to determine whether to append query parameters:

```typescript
return `${basePath}/${prometheusUrlProps.endpoint}${
  params.size > 0 ? '?' + params.toString() : ''  // ❌ BUG
}`;
```

**URLSearchParams does not have a `.size` property.** The value is always `undefined`, so the condition `undefined > 0` is always `false`, causing the query parameters to never be appended.

## Solution

Changed the condition to check if `params.toString()` returns a non-empty string:

```typescript
return `${basePath}/${prometheusUrlProps.endpoint}${
  params.toString() ? '?' + params.toString() : ''  // ✅ FIXED
}`;
```

## Testing

**Before (Broken):**
```
Request: GET /api/prometheus/api/v1/query_range
Error: 400 Bad Request - cannot parse "" to a valid timestamp
```

**After (Fixed):**
```
Request: GET /api/prometheus/api/v1/query_range?query=up&start=...&end=...&step=30
Response: 200 OK with valid metric data
```

## Impact

- **1 line changed** - minimal, surgical fix
- Restores Metrics UI and Dashboards functionality
- No breaking changes

## Related

- JIRA: https://redhat.atlassian.net/browse/OCPBUGS-99942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL generation so query parameters are included only when they contain values.
  * Prevented empty query markers from appearing in generated URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->