### PR TITLE
NO-JIRA: don't filter silences based on namespace in acm

### DIFF
--- a/web/src/features/alerts/pages/silences-page/filter-silences.ts
+++ b/web/src/features/alerts/pages/silences-page/filter-silences.ts
@@ -17,7 +17,7 @@ export const filterSilences = (
     return [];
   }
 
-  const shouldFilterNamespace = namespace !== ALL_NAMESPACES_KEY;
+  const shouldFilterNamespace = namespace !== ALL_NAMESPACES_KEY && perspective !== 'acm';
   /**
    * Filters alerts based on tenancy:
    * - with tenancy: alerts are automatically pre-filtered.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected silence filtering for the ACM perspective so alerts are not incorrectly excluded by namespace when viewing all namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->