### PR TITLE
OU-1409: fix: remove deprecation in favor of k8sListItems to fetch agentic runs

### DIFF
--- a/web/src/features/alerts/pages/alerts-page/agentic-runs/useAgenticRunCheck.ts
+++ b/web/src/features/alerts/pages/alerts-page/agentic-runs/useAgenticRunCheck.ts
@@ -1,5 +1,5 @@
 import { Alert, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { k8sListResourceItems } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s';
+import { k8sListItems } from '@openshift-console/dynamic-plugin-sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -14,7 +14,7 @@ import {
 import { AgenticRunModel } from '@/shared/console/models';
 
 const buildQueryFn = (namespace: string, alertFingerprint: string) => () =>
-  k8sListResourceItems<K8sResourceCommon>({
+  k8sListItems<K8sResourceCommon>({
     model: AgenticRunModel,
     queryParams: {
       ns: namespace,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of agentic-run alert checks while preserving existing query behavior and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->