### PR TITLE
OCPBUGS-99942: Fix missing query params in Prometheus API requests

### DIFF
--- a/web/src/shared/utils/utils.ts
+++ b/web/src/shared/utils/utils.ts
@@ -269,9 +269,8 @@ export const buildPrometheusUrl = ({
   }
 
   const params = getSearchParams(prometheusUrlProps);
-  return `${basePath}/${prometheusUrlProps.endpoint}${
-    params.size > 0 ? '?' + params.toString() : ''
-  }`;
+  const queryString = params.toString();
+  return `${basePath}/${prometheusUrlProps.endpoint}${queryString ? '?' + queryString : ''}`;
 };
 
 type PrometheusURLProps = {


### PR DESCRIPTION
## Claude analysis
Replace params.size > 0 with params.toString() check in buildPrometheusUrl. URLSearchParams.size is
unsupported in older browsers (pre-Chrome 113, pre-Firefox 112, pre-Safari 17), causing query parameters
to be silently dropped and Thanos to return 400.

https://caniuse.com/mdn-api_urlsearchparams_size

Affected versions: OCP 4.19 through current.
- 4.19-4.22: web/src/components/utils.ts
- 4.23+: web/src/shared/utils/utils.ts
- 4.18 and earlier: not affected.

## Verification

Headless Chrome test with `URLSearchParams.prototype.size` overridden to `undefined`:
- Old code (`params.size > 0`): returns empty string, query params dropped
- New code (`params.toString()`): returns `?query=up&start=123&end=456&step=30`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL generation for Prometheus queries, including cleaner handling when no search parameters are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->