### PR TITLE
OU-1472: remove incidents feature from backend and tests

### DIFF
--- a/.claude/commands/cypress/cypress-run.md
+++ b/.claude/commands/cypress/cypress-run.md
@@ -323,7 +323,7 @@ Use these tags with `--env grepTags`:
 - `@coo` - Observability Operator tests
 - `@acm` - Advanced Cluster Management tests
 - `@virtualization` - OpenShift Virtualization tests
-- `@incidents` - Incidents feature tests
+- `@cluster-health-analyzer` - Incidents feature tests
 
 **Modifier Tags:**
 - `@smoke` - Quick smoke tests

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ web/po-files/
 .claude/commands/configs
 .claude/settings.local.json
 _output/
+.tokensave/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,28 +69,29 @@ The `web/src/` directory is organized into two top-level areas:
 - **`web/src/features/`** — Feature-specific code, one subdirectory per feature. Each feature directory contains sub-folders as needed: `components/`, `pages/`, `hooks/`, `utils/`, `types/`, `assets/`.
 - **`web/src/shared/`** — Code used by more than one feature, organized by kind.
 
-| Feature | Directory |
-| ------- | --------- |
-| Alerting (alerts, silences, alert rules) | `features/alerts/` |
-| Incidents | `features/incidents/` |
-| Legacy Dashboards | `features/legacy-dashboards/` |
-| Metrics / PromQL | `features/metrics/` |
-| Perses Dashboards | `features/perses-dashboards/` |
-| Targets | `features/targets/` |
+| Feature                                  | Directory                     |
+| ---------------------------------------- | ----------------------------- |
+| Alerting (alerts, silences, alert rules) | `features/alerts/`            |
+| Incidents                                | `features/incidents/`         |
+| Legacy Dashboards                        | `features/legacy-dashboards/` |
+| Metrics / PromQL                         | `features/metrics/`           |
+| Perses Dashboards                        | `features/perses-dashboards/` |
+| Targets                                  | `features/targets/`           |
 
-| Shared Directory | Contents |
-| ---------------- | -------- |
+| Shared Directory     | Contents                                                              |
+| -------------------- | --------------------------------------------------------------------- |
 | `shared/components/` | Reusable UI components (`labels.tsx`, `format.tsx`, `query-browser/`) |
-| `shared/hooks/` | Shared React hooks (`useAlerts.ts`, `usePerspective.tsx`) |
-| `shared/store/` | Redux store, actions, reducers, thunks, alert fetching |
-| `shared/contexts/` | React contexts (`MonitoringContext.tsx`) |
-| `shared/constants/` | Shared constants (`data-test.ts`, `query-params.ts`) |
-| `shared/types/` | Shared TypeScript types (`types.ts`) |
-| `shared/utils/` | Shared pure utility functions (`utils.ts`) |
-| `shared/assets/` | Static assets such as fonts (`codicon.ttf`) |
-| `shared/console/` | Vendored/adapted OpenShift Console internals |
+| `shared/hooks/`      | Shared React hooks (`useAlerts.ts`, `usePerspective.tsx`)             |
+| `shared/store/`      | Redux store, actions, reducers, thunks, alert fetching                |
+| `shared/contexts/`   | React contexts (`MonitoringContext.tsx`)                              |
+| `shared/constants/`  | Shared constants (`data-test.ts`, `query-params.ts`)                  |
+| `shared/types/`      | Shared TypeScript types (`types.ts`)                                  |
+| `shared/utils/`      | Shared pure utility functions (`utils.ts`)                            |
+| `shared/assets/`     | Static assets such as fonts (`codicon.ttf`)                           |
+| `shared/console/`    | Vendored/adapted OpenShift Console internals                          |
 
 **Placement rules:**
+
 - If a file is only used within one feature, it belongs in that feature's directory.
 - If a component or utility is only used by a single page, co-locate it inside that page's own subdirectory (e.g. `features/alerts/pages/alerts-page/AggregateAlertTableRow.tsx`).
 - If a file is used across multiple features, it belongs in `shared/`.
@@ -136,7 +137,7 @@ spec:
         url: "https://rbac-query-proxy.open-cluster-management-observability.svc:8443"
     perses:
       enabled: true
-    incidents:
+    clusterHealthAnalyzer:
       enabled: true
 ```
 

--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -17,7 +17,7 @@ var (
 	portArg             = flag.Int("port", 9443, "server port to listen on\nports 9444 and 9445 reserved for other use")
 	certArg             = flag.String("cert", "", "cert file path to enable TLS (disabled by default)")
 	keyArg              = flag.String("key", "", "private key file path to enable TLS (disabled by default)")
-	featuresArg         = flag.String("features", "", "enabled features, comma separated.\noptions: ['acm-alerting', 'alerting', 'incidents', 'legacy-dashboards', 'metrics', 'targets', 'perses-dashboards', 'cluster-health-analyzer']")
+	featuresArg         = flag.String("features", "", "enabled features, comma separated.\noptions: ['acm-alerting', 'alerting', 'legacy-dashboards', 'metrics', 'targets', 'perses-dashboards', 'cluster-health-analyzer']")
 	staticPathArg       = flag.String("static-path", "/opt/app-root/web/dist", "static files path to serve frontend")
 	configPathArg       = flag.String("config-path", "/opt/app-root/config", "config files path")
 	pluginConfigArg     = flag.String("plugin-config-path", "/etc/plugin/config.yaml", "plugin yaml configuration")

--- a/pkg/server/plugin_handler.go
+++ b/pkg/server/plugin_handler.go
@@ -42,9 +42,9 @@ func patchManifest(baseManifestData []byte, cfg *Config) []byte {
 		{"metrics.patch.json", features[Metrics]},
 		{"legacy-dashboards.patch.json", features[LegacyDashboards]},
 		{"targets.patch.json", features[Targets]},
-		{"monitoring-console-plugin.patch.json", features[Incidents] || features[ClusterHealthAnalyzer] || features[PersesDashboards] || features[AcmAlerting]},
+		{"monitoring-console-plugin.patch.json", features[ClusterHealthAnalyzer] || features[PersesDashboards] || features[AcmAlerting]},
 		{"acm-alerting.patch.json", features[AcmAlerting]},
-		{"cluster-health-analyzer.patch.json", features[Incidents] || features[ClusterHealthAnalyzer]},
+		{"cluster-health-analyzer.patch.json", features[ClusterHealthAnalyzer]},
 		{"perses-dashboards.patch.json", features[PersesDashboards]},
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,7 +59,6 @@ type Feature string
 const (
 	AcmAlerting           Feature = "acm-alerting"
 	Alerting              Feature = "alerting"
-	Incidents             Feature = "incidents"
 	LegacyDashboards      Feature = "legacy-dashboards"
 	Metrics               Feature = "metrics"
 	Targets               Feature = "targets"

--- a/web/cypress/README.md
+++ b/web/cypress/README.md
@@ -219,7 +219,6 @@ Tests are organized using tags for selective execution using [@cypress/grep](htt
 
 **2. High-Level Component Tags:**
 - `@monitoring` - Monitoring plugin tests
-- `@incidents` - Incidents feature tests
 - `@coo` - Cluster Observability Operator functionality tests (operator installation, ACM integration)
 - `@virtualization` - Virtualization integration tests
 - `@alerts` - Alert-related tests
@@ -229,6 +228,7 @@ Tests are organized using tags for selective execution using [@cypress/grep](htt
 **3. Specific Feature Tags** (format: `@{component}-{label}`):
 - Example: `@incidents-redux`
 - Add specific feature tags as needed
+- `@cluster-health-analyzer` - Incidents feature tests
 
 **4. JIRA Tags** (format: `@JIRA-{ID}`):
 - Example: `@JIRA-OU-1033`
@@ -277,12 +277,12 @@ npx cypress run --env grepTags="@smoke @slow"
 
 **Run tests with BOTH tags (AND logic):**
 ```bash
-npx cypress run --env grepTags="@smoke+@incidents"
+npx cypress run --env grepTags="@smoke+@cluster-health-analyzer"
 ```
 
 **Complex filtering:**
 ```bash
-npx cypress run --env grepTags="@incidents --@slow --@flaky"
+npx cypress run --env grepTags="@cluster-health-analyzer --@slow --@flaky"
 ```
 
 ---

--- a/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
+++ b/web/cypress/e2e/incidents/00.coo_incidents_e2e.cy.ts
@@ -20,7 +20,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('BVT: Incidents - e2e', { tags: ['@smoke', '@slow', '@incidents', '@e2e-real'] }, () => {
+describe('BVT: Incidents - e2e', { tags: ['@slow', '@cluster-health-analyzer'] }, () => {
   let currentAlertName: string;
 
   before(() => {

--- a/web/cypress/e2e/incidents/01.incidents.cy.ts
+++ b/web/cypress/e2e/incidents/01.incidents.cy.ts
@@ -24,7 +24,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('BVT: Incidents - UI', { tags: ['@smoke', '@incidents'] }, () => {
+describe('BVT: Incidents - UI', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
     incidentsPage.warmUpForPlugin();

--- a/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
+++ b/web/cypress/e2e/incidents/02.incidents-mocking-example.cy.ts
@@ -24,7 +24,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Incidents - Mocking Examples', { tags: ['@demo', '@incidents'] }, () => {
+describe('Incidents - Mocking Examples', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
   });

--- a/web/cypress/e2e/incidents/performance/01.performance_benchmark.cy.ts
+++ b/web/cypress/e2e/incidents/performance/01.performance_benchmark.cy.ts
@@ -54,7 +54,7 @@ const collector = new BenchmarkCollector('01.performance_benchmark.cy.ts');
 
 describe(
   'Regression: Performance Benchmark',
-  { tags: ['@incidents', '@performance', '@regression'], numTestsKeptInMemory: 0 },
+  { tags: ['@cluster-health-analyzer'], numTestsKeptInMemory: 0 },
   () => {
     before(() => {
       cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });

--- a/web/cypress/e2e/incidents/performance/02.performance_walkthrough.cy.ts
+++ b/web/cypress/e2e/incidents/performance/02.performance_walkthrough.cy.ts
@@ -38,7 +38,7 @@ const collector = new BenchmarkCollector('02.performance_walkthrough.cy.ts');
 
 describe(
   'Performance: Interactive Walkthrough',
-  { tags: ['@incidents', '@performance'], numTestsKeptInMemory: 0 },
+  { tags: ['@cluster-health-analyzer'], numTestsKeptInMemory: 0 },
   () => {
     before(() => {
       cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });

--- a/web/cypress/e2e/incidents/regression/01.reg_filtering.cy.ts
+++ b/web/cypress/e2e/incidents/regression/01.reg_filtering.cy.ts
@@ -25,7 +25,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Incidents Filtering', { tags: ['@incidents'] }, () => {
+describe('Regression: Incidents Filtering', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
   });

--- a/web/cypress/e2e/incidents/regression/02.reg_ui_charts_comprehensive.cy.ts
+++ b/web/cypress/e2e/incidents/regression/02.reg_ui_charts_comprehensive.cy.ts
@@ -3,7 +3,7 @@ Regression test for Charts UI bugs and Data Loading bugs (Sections 2 & 3.1 of TE
 
 This test loads comprehensive test data covering:
 - 2.1: Tooltip Positioning Issues
-- 2.2: Bar Sorting & Visibility Issues  
+- 2.2: Bar Sorting & Visibility Issues
 - 2.3: Date/Time Display Issues
 - 3.1: Short Duration Incidents Visibility (< 5 min)
 
@@ -100,7 +100,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Charts UI - Comprehensive', { tags: ['@incidents'] }, () => {
+describe('Regression: Charts UI - Comprehensive', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
     incidentsPage.warmUpForPlugin();

--- a/web/cypress/e2e/incidents/regression/02.reg_ui_tooltip_boundary_times.cy.ts
+++ b/web/cypress/e2e/incidents/regression/02.reg_ui_tooltip_boundary_times.cy.ts
@@ -30,7 +30,7 @@ const MP = {
 
 describe(
   'Regression: Mixed Severity Interval Boundary Times',
-  { tags: ['@incidents', '@xfail'] },
+  { tags: ['@cluster-health-analyzer', '@xfail'] },
   () => {
     before(() => {
       cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });

--- a/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03-04.reg_e2e_firing_alerts.cy.ts
@@ -36,7 +36,7 @@ const MP = {
 
 describe(
   'Regression: Time-Based Alert Resolution (E2E with Firing Alerts)',
-  { tags: ['@incidents', '@slow', '@e2e-real'] },
+  { tags: ['@cluster-health-analyzer', '@slow'] },
   () => {
     let currentAlertName: string;
 

--- a/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
+++ b/web/cypress/e2e/incidents/regression/03.reg_api_calls.cy.ts
@@ -31,113 +31,117 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Silences Not Applied Correctly', { tags: ['@incidents'] }, () => {
-  before(() => {
-    cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
-    incidentsPage.warmUpForPlugin();
-  });
+describe(
+  'Regression: Silences Not Applied Correctly',
+  { tags: ['@cluster-health-analyzer'] },
+  () => {
+    before(() => {
+      cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
+      incidentsPage.warmUpForPlugin();
+    });
 
-  beforeEach(() => {
-    cy.log('Setting up silenced alerts mixed scenario');
-    cy.mockIncidentFixture('incident-scenarios/9-silenced-alerts-mixed-scenario.yaml');
-  });
+    beforeEach(() => {
+      cy.log('Setting up silenced alerts mixed scenario');
+      cy.mockIncidentFixture('incident-scenarios/9-silenced-alerts-mixed-scenario.yaml');
+    });
 
-  it('Silence matching verification flow - opacity and tooltip indicators', () => {
-    const selectIncidentAndWaitForAlerts = (incidentId: string, expectedAlertCount?: number) => {
-      incidentsPage.elements.incidentsChartBar(incidentId).click();
-      cy.wait(2000);
-      incidentsPage.elements.alertsChartContainer().should('be.visible');
-      incidentsPage.elements.alertsChartCard().should('be.visible');
+    it('Silence matching verification flow - opacity and tooltip indicators', () => {
+      const selectIncidentAndWaitForAlerts = (incidentId: string, expectedAlertCount?: number) => {
+        incidentsPage.elements.incidentsChartBar(incidentId).click();
+        cy.wait(2000);
+        incidentsPage.elements.alertsChartContainer().should('be.visible');
+        incidentsPage.elements.alertsChartCard().should('be.visible');
 
-      if (expectedAlertCount !== undefined) {
+        if (expectedAlertCount !== undefined) {
+          incidentsPage.elements
+            .alertsChartBarsVisiblePaths()
+            .should('have.length', expectedAlertCount);
+        }
+      };
+
+      const verifyAlertOpacity = (alertIndex: number, expectedOpacity: number) => {
         incidentsPage.elements
           .alertsChartBarsVisiblePaths()
-          .should('have.length', expectedAlertCount);
-      }
-    };
+          .eq(alertIndex)
+          .then(($bar) => {
+            cy.log('Bar: ' + $bar);
+            cy.log('Fill-opacity: ' + $bar.css('fill-opacity'));
+            const opacity = parseFloat($bar.css('fill-opacity') || '1');
+            expect(opacity).to.equal(expectedOpacity);
+          });
+      };
 
-    const verifyAlertOpacity = (alertIndex: number, expectedOpacity: number) => {
-      incidentsPage.elements
-        .alertsChartBarsVisiblePaths()
-        .eq(alertIndex)
-        .then(($bar) => {
-          cy.log('Bar: ' + $bar);
-          cy.log('Fill-opacity: ' + $bar.css('fill-opacity'));
-          const opacity = parseFloat($bar.css('fill-opacity') || '1');
-          expect(opacity).to.equal(expectedOpacity);
+      const verifyAlertTooltip = (
+        alertIndex: number,
+        expectedTexts: string[],
+        shouldBeSilenced: boolean,
+      ) => {
+        incidentsPage.hoverOverAlertBar(alertIndex);
+        const tooltip = incidentsPage.elements.alertsChartTooltip().should('be.visible');
+        expectedTexts.forEach((text) => {
+          tooltip.should('contain.text', text);
         });
-    };
+        tooltip.should(shouldBeSilenced ? 'contain.text' : 'not.contain.text', '(silenced)');
+      };
 
-    const verifyAlertTooltip = (
-      alertIndex: number,
-      expectedTexts: string[],
-      shouldBeSilenced: boolean,
-    ) => {
-      incidentsPage.hoverOverAlertBar(alertIndex);
-      const tooltip = incidentsPage.elements.alertsChartTooltip().should('be.visible');
-      expectedTexts.forEach((text) => {
-        tooltip.should('contain.text', text);
-      });
-      tooltip.should(shouldBeSilenced ? 'contain.text' : 'not.contain.text', '(silenced)');
-    };
+      cy.log('1.1 Verify all incidents loaded');
+      incidentsPage.clearAllFilters();
+      incidentsPage.elements.incidentsChartBarsGroups().should('have.length.greaterThan', 0);
 
-    cy.log('1.1 Verify all incidents loaded');
-    incidentsPage.clearAllFilters();
-    incidentsPage.elements.incidentsChartBarsGroups().should('have.length.greaterThan', 0);
+      cy.log('1.2 Select silenced alert incident (PAIR-2-storage-SILENCED)');
+      selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-storage-SILENCED', 1);
 
-    cy.log('1.2 Select silenced alert incident (PAIR-2-storage-SILENCED)');
-    selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-storage-SILENCED', 1);
+      cy.log('1.3 Hover over silenced alert and verify tooltip shows (silenced)');
+      verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
+      cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
 
-    cy.log('1.3 Hover over silenced alert and verify tooltip shows (silenced)');
-    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
-    cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
+      cy.log('1.4 Hover over silenced alert and verify tooltip shows (silenced)');
+      verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
+      cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
 
-    cy.log('1.4 Hover over silenced alert and verify tooltip shows (silenced)');
-    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], true);
-    cy.log('Verified: Silenced alert has opacity 0.3 and tooltip shows (silenced)');
+      cy.log('2.0 Deselect incident');
+      incidentsPage.deselectIncidentByBar();
 
-    cy.log('2.0 Deselect incident');
-    incidentsPage.deselectIncidentByBar();
+      cy.log(
+        '2.1 Select non-silenced alert incident with same alert name (PAIR-2-network-UNSILENCED)',
+      );
+      selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-network-UNSILENCED', 1);
 
-    cy.log(
-      '2.1 Select non-silenced alert incident with same alert name (PAIR-2-network-UNSILENCED)',
-    );
-    selectIncidentAndWaitForAlerts('PAIR-2-shared-alert-name-network-UNSILENCED', 1);
+      cy.log('2.2 Verify non-silenced alert has full opacity 1.0');
+      verifyAlertOpacity(0, 1.0);
 
-    cy.log('2.2 Verify non-silenced alert has full opacity 1.0');
-    verifyAlertOpacity(0, 1.0);
+      cy.log('2.3 Hover over non-silenced alert and verify tooltip does not show (silenced)');
+      verifyAlertTooltip(0, ['SyntheticSharedFiring002'], false);
+      cy.log('Verified: Non-silenced alert has opacity 1.0 and tooltip does not show (silenced)');
 
-    cy.log('2.3 Hover over non-silenced alert and verify tooltip does not show (silenced)');
-    verifyAlertTooltip(0, ['SyntheticSharedFiring002'], false);
-    cy.log('Verified: Non-silenced alert has opacity 1.0 and tooltip does not show (silenced)');
+      cy.log('3.0 Deselect incident');
+      incidentsPage.deselectIncidentByBar();
 
-    cy.log('3.0 Deselect incident');
-    incidentsPage.deselectIncidentByBar();
+      cy.log('3.1 Select incident with both silenced and non-silenced alerts (CASE-3)');
+      selectIncidentAndWaitForAlerts(
+        'CASE-3-shared-alert-single-incident-storage-network-SILENCED-UNSILENCED',
+        2,
+      );
 
-    cy.log('3.1 Select incident with both silenced and non-silenced alerts (CASE-3)');
-    selectIncidentAndWaitForAlerts(
-      'CASE-3-shared-alert-single-incident-storage-network-SILENCED-UNSILENCED',
-      2,
-    );
+      cy.log('3.2 Verify first alert (storage namespace / silenced) has opacity 0.3');
+      verifyAlertOpacity(0, 0.3);
 
-    cy.log('3.2 Verify first alert (storage namespace / silenced) has opacity 0.3');
-    verifyAlertOpacity(0, 0.3);
+      cy.log('3.3 Verify second alert (network namespace / non-silenced) has opacity 1.0');
+      verifyAlertOpacity(1, 1.0);
 
-    cy.log('3.3 Verify second alert (network namespace / non-silenced) has opacity 1.0');
-    verifyAlertOpacity(1, 1.0);
+      cy.log('3.4 Hover over first alert and verify tooltip shows (silenced) with storage');
+      verifyAlertTooltip(0, ['storage'], true);
 
-    cy.log('3.4 Hover over first alert and verify tooltip shows (silenced) with storage');
-    verifyAlertTooltip(0, ['storage'], true);
+      cy.log('3.5 Hover over second alert and verify tooltip shows network without (silenced)');
+      verifyAlertTooltip(1, ['network'], false);
 
-    cy.log('3.5 Hover over second alert and verify tooltip shows network without (silenced)');
-    verifyAlertTooltip(1, ['network'], false);
+      cy.log('Verified: Same alert name with different namespaces handled correctly');
+      cy.log('Verified: Silence matching uses alertname + namespace + severity');
+    });
+  },
+);
 
-    cy.log('Verified: Same alert name with different namespaces handled correctly');
-    cy.log('Verified: Silence matching uses alertname + namespace + severity');
-  });
-});
-
-describe('Regression: Permission Denied Handling', { tags: ['@incidents'] }, () => {
+describe('Regression: Permission Denied Handling', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
   });

--- a/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
+++ b/web/cypress/e2e/incidents/regression/04.reg_redux_effects.cy.ts
@@ -30,7 +30,7 @@ const MP = {
   operatorName: 'Cluster Monitoring Operator',
 };
 
-describe('Regression: Redux State Management', { tags: ['@incidents', '@incidents-redux'] }, () => {
+describe('Regression: Redux State Management', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
     incidentsPage.warmUpForPlugin();

--- a/web/cypress/e2e/incidents/regression/05.reg_stress_testing_ui.cy.ts
+++ b/web/cypress/e2e/incidents/regression/05.reg_stress_testing_ui.cy.ts
@@ -31,7 +31,7 @@ const MP = {
 const MAX_GAP_STANDARD = 250;
 const MAX_GAP_RELAXED = 500;
 
-describe('Regression: Stress Testing UI', { tags: ['@incidents'] }, () => {
+describe('Regression: Stress Testing UI', { tags: ['@cluster-health-analyzer'] }, () => {
   before(() => {
     cy.beforeBlockCOO(MCP, MP, { dashboards: false, troubleshootingPanel: false });
     incidentsPage.warmUpForPlugin();

--- a/web/cypress/fixtures/coo/acm-install.sh
+++ b/web/cypress/fixtures/coo/acm-install.sh
@@ -54,9 +54,9 @@ spec:
 EOF
 tries=30
 while [[ $tries -gt 0 ]] &&
-	! oc -n open-cluster-management rollout status deploy/multiclusterhub-operator; do
-	sleep 10
-	((tries--))
+    ! oc -n open-cluster-management rollout status deploy/multiclusterhub-operator; do
+    sleep 10
+    ((tries--))
 done
 oc wait -n open-cluster-management --for=condition=Available deploy/multiclusterhub-operator --timeout=300s
 # install mch
@@ -75,12 +75,12 @@ oc wait -n open-cluster-management --for=condition=Available deploy/search-index
 oc -n open-cluster-management get pod
 # create mco
 if ! oc get ns open-cluster-management-observability >/dev/null 2>&1; then
-  echo "[INFO] Creating namespace open-cluster-management-observability"
-  oc create ns open-cluster-management-observability
+    echo "[INFO] Creating namespace open-cluster-management-observability"
+    oc create ns open-cluster-management-observability
 else
-  echo "[INFO] Namespace open-cluster-management-observability already exists"
+    echo "[INFO] Namespace open-cluster-management-observability already exists"
 fi
-oc apply -f -<<EOF
+oc apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -155,7 +155,7 @@ metadata:
   namespace: open-cluster-management-observability
 type: Opaque
 EOF
-oc apply -f -<<EOF
+oc apply -f - <<EOF
 apiVersion: v1
 kind: Service
 metadata:
@@ -181,7 +181,7 @@ spec:
   storageConfig:
     metricObjectStorage:
       name: thanos-object-storage
-      key: thanos.yaml 
+      key: thanos.yaml
 EOF
 sleep 1m
 oc wait --for=condition=Ready pod -l alertmanager=observability,app=multicluster-observability-alertmanager -n open-cluster-management-observability --timeout=300s
@@ -193,11 +193,11 @@ metadata:
   name: monitoring
 spec:
   monitoring:
-    incidents:
+    clusterHealthAnalyzer:
       enabled: true
     perses:
       enabled: true
-    acm:    
+    acm:
       enabled: true
       alertmanager:
         url: 'https://alertmanager.open-cluster-management-observability.svc:9095'

--- a/web/cypress/fixtures/coo/acm-uiplugin.yaml
+++ b/web/cypress/fixtures/coo/acm-uiplugin.yaml
@@ -4,11 +4,11 @@ metadata:
   name: monitoring
 spec:
   monitoring:
-    incidents:
+    clusterHealthAnalyzer:
       enabled: true
     perses:
       enabled: true
-    acm:    
+    acm:
       enabled: true
       alertmanager:
         url: 'https://alertmanager.open-cluster-management-observability.svc:9095'

--- a/web/cypress/fixtures/coo/monitoring-ui-plugin.yaml
+++ b/web/cypress/fixtures/coo/monitoring-ui-plugin.yaml
@@ -13,5 +13,5 @@ spec:
         url: 'https://rbac-query-proxy.open-cluster-management-observability.svc:8443'
     perses:
       enabled: true
-    incidents:
+    clusterHealthAnalyzer:
       enabled: true

--- a/web/cypress/support/test-tags.d.ts
+++ b/web/cypress/support/test-tags.d.ts
@@ -6,7 +6,7 @@ type HighLevelComponentTag =
   | '@virtualization'
   | '@alerts'
   | '@metrics'
-  | '@dashboards';
+  | '@dashboards'
   | '@cluster-health-analyzer';
 
 type SpecificFeatureTag = `@${string}-${string}`;

--- a/web/cypress/support/test-tags.d.ts
+++ b/web/cypress/support/test-tags.d.ts
@@ -2,12 +2,12 @@ type BasicTag = '@smoke' | '@demo' | '@flaky' | '@xfail' | '@slow';
 
 type HighLevelComponentTag =
   | '@monitoring'
-  | '@incidents'
   | '@coo'
   | '@virtualization'
   | '@alerts'
   | '@metrics'
   | '@dashboards';
+  | '@cluster-health-analyzer';
 
 type SpecificFeatureTag = `@${string}-${string}`;
 

--- a/web/package.json
+++ b/web/package.json
@@ -40,14 +40,13 @@
     "test-cypress-coo": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@coo --@flaky --@demo --@xfail'",
     "test-cypress-coo-bvt": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@coo+@smoke --@demo --@xfail'",
     "test-cypress-virtualization": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@virtualization --@flaky --@demo --@xfail'",
-    "test-cypress-incidents": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@incidents --@flaky --@demo --@xfail'",
-    "test-cypress-incidents-e2e": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@incidents+@e2e-real --@flaky --@demo --@xfail'",
     "test-cypress-smoke": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@smoke --@flaky --@demo --@xfail'",
     "test-cypress-fast": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@smoke --@slow --@demo --@flaky --@xfail'",
     "test-cypress-perses-dev": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@perses-dev --@demo --@xfail'",
     "test-cypress-perses": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@perses --@smoke --@flaky --@demo --@xfail'",
     "test-cypress-perses-ivt": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@perses-ivt --@smoke --@flaky --@demo --@xfail'",
-    "test-cypress-acm": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@acm --@smoke --@flaky --@demo --@xfail'",
+    "test-cypress-incidents": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@cluster-health-analyzer --@flaky --@xfail'",
+    "test-cypress-incidents-e2e": "node --max-old-space-size=4096 ./node_modules/.bin/cypress run --browser chrome --headless --env grepTags='@cluster-health-analyzer --@flaky --@xfail'",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "dependencies": {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Reclassified the Incidents feature and related automated tests as **Cluster Health Analyzer** across feature options, documentation, and test filtering.
  * Updated test commands and tags while preserving existing scenarios and coverage.
* **Maintenance**
  * Removed the retired Incidents option from server declarations, command-line help, and feature-specific configuration.
  * Added token-related files to repository ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->