### PR TITLE
OCPBUGS-74461: CVE-2025-13465 openshift4/ose-monitoring-plugin-rhel9: prototype pollution in _.unset and _.omit functions [openshift-4.18]

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,7 +31,7 @@
         "i18next": "^21.8.14",
         "i18next-http-backend": "^2.2.0",
         "immutable": "^3.8.3",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.17.23",
         "murmurhash-js": "1.0.x",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -9683,15 +9683,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
     "i18next": "^21.8.14",
     "i18next-http-backend": "^2.2.0",
     "immutable": "^3.8.3",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "murmurhash-js": "1.0.x",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -122,6 +122,7 @@
     "cross-spawn": "^7.0.5",
     "qs": "^6.14.1",
     "http-errors": "2.0.1",
+    "lodash": "^4.17.23",
     "sass": {
       "immutable": "^4.3.7"
     }


### PR DESCRIPTION
OCPBUGS-74461: lodash bump: fix for CVE-2025-13465

Bump lodash and lodash-es to >=4.17.23 to fix prototype pollution
vulnerability in _.unset and _.omit (CVE-2025-13465, CVSS 6.9).

CVE-2025-13465 allows crafted paths like `__proto__.toString` to
delete methods from global prototypes via lodash's `_.unset` and
`_.omit` functions, leading to application crashes (DoS) or
security bypasses. Affected versions: 4.0.0 through 4.17.22.

Changes:
- Updated lodash-es direct dependency from ^4.17.21 to ^4.17.23
- Added lodash ^4.17.23 override for transitive copies
- Both resolve to 4.18.1 in the lockfile

Context:
- release-4.16 and release-4.17 were already fixed via later
  yarn-to-npm migrations (March 2026) which resolved lodash to
  post-fix versions
- release-4.19 was fixed by a broad dependency refresh (271dfb3,
  Feb 2026) that incidentally pulled in 4.17.23
- release-4.18 was the only branch still vulnerable because its
  yarn-to-npm migration occurred in September 2024, before lodash
  4.17.23 was published, and no subsequent npm install refreshed
  the transitive resolution
