### PR TITLE
OU-1471: don't throw when listing globaldatasource for fallback

### DIFF
--- a/web/src/features/perses-dashboards/utils/datasource-api.ts
+++ b/web/src/features/perses-dashboards/utils/datasource-api.ts
@@ -93,6 +93,6 @@ export class OcpDatasourceApi implements DatasourceApi {
   }
 
   listGlobalDatasources(pluginKind?: string): Promise<GlobalDatasourceResource[]> {
-    return fetchGlobalDatasourceList(pluginKind);
+    return fetchGlobalDatasourceList(pluginKind).catch(() => []);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard reliability by handling global data source loading failures gracefully.
  * Displays an empty data source list instead of showing an error when loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->