### PR TITLE
OCPBUGS-98772: Bump linkify-it to 5.0.1 to fix CVE-2026-48801

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9610,12 +9610,22 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/listr2": {
@@ -14043,9 +14053,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {

--- a/web/package.json
+++ b/web/package.json
@@ -115,6 +115,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "overrides": {
+    "linkify-it": "^5.0.1",
     "webpack": "^5.76.0",
     "tough-cookie": "^4.1.3",
     "sanitize-html": "^2.12.1",


### PR DESCRIPTION
## CVE Remediation

**CVE-2026-48801**: linkify-it has O(N²) algorithmic complexity in `LinkifyIt.prototype.match` for inputs containing many fuzzy links or emails, enabling denial-of-service via a tens-of-KB request body.

**Fix**: Bump `linkify-it` from 2.2.0 to 5.0.2 (>=5.0.1) via npm overrides. `linkify-it` is a transitive dependency of `react-linkify@0.2.2`, and no version of `react-linkify` depends on `linkify-it >= 5.x`, so an npm override is the only viable approach. The project already uses overrides for webpack, qs, lodash, etc.

### Package changes
- `linkify-it`: 2.2.0 → 5.0.2
- `uc.micro`: 1.0.6 → 2.1.0 (transitive dep of linkify-it 5.x)

### Verification
- ✅ ESLint (`npm run lint`): passed
- ✅ TypeScript type-check (`npm run lint:tsc`): passed
- ✅ Webpack production build (`npm run build`): passed

### References
- Jira: https://redhat.atlassian.net/browse/OCPBUGS-98772
- CVE: https://www.cve.org/CVERecord?id=CVE-2026-48801
- GHSA: https://github.com/markdown-it/linkify-it/security/advisories/GHSA-22p9-wv53-3rq4
- Fix commit: https://github.com/markdown-it/linkify-it/commit/6be6d15e0641bf1daeaa977d500cabc743166159