### PR TITLE
OCPBUGS-98768: Bump linkify-it to fix CVE-2026-48801

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "braces": "^3.0.3",
     "follow-redirects": "^1.15.6",
     "cross-spawn": "^7.0.5",
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.0",
+    "linkify-it": "^5.0.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,12 +4094,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+linkify-it@^2.0.3, linkify-it@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 listr2@^3.8.3:
   version "3.14.0"
@@ -6069,10 +6069,10 @@ typescript@^5.0.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-uc.micro@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## CVE-2026-48801: linkify-it Denial of Service via algorithmic complexity

### Summary
Bumps transitive dependency `linkify-it` from 2.2.0 to 5.0.2 via yarn selective dependency resolution to fix CVE-2026-48801.

### CVE Details
- **CVE-2026-48801** (CVSS 7.5 Moderate): `LinkifyIt.prototype.match` has O(N²) algorithmic complexity for inputs containing many fuzzy links or emails. Fixed in linkify-it 5.0.1.
- **Advisory**: [GHSA-22p9-wv53-3rq4](https://github.com/markdown-it/linkify-it/security/advisories/GHSA-22p9-wv53-3rq4)
- **Fix commit**: [6be6d15](https://github.com/markdown-it/linkify-it/commit/6be6d15e0641bf1daeaa977d500cabc743166159)

### Changes
- Added `"linkify-it": "^5.0.1"` to `resolutions` block in `package.json` (yarn selective dependency resolution)
- Regenerated `yarn.lock` — linkify-it 2.2.0 → 5.0.2, uc.micro 1.0.6 → 2.1.0

### Dependency path
`react-linkify@0.2.2` → `linkify-it@^2.0.3` (resolved to 5.0.2 via resolution override)

### Verification
- yarn install: ✅
- linkify-it smoke test (.match() API): ✅
- react-linkify interop test: ✅
- eslint lint: ✅

### Jira
- [OCPBUGS-98768](https://redhat.atlassian.net/browse/OCPBUGS-98768)