### PR TITLE
OCPBUGS-98777: Bump linkify-it to 5.0.2 to fix CVE-2026-48801

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8165,12 +8165,22 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/listr2": {
@@ -12390,9 +12400,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {

--- a/web/package.json
+++ b/web/package.json
@@ -103,7 +103,8 @@
     "braces": "^3.0.3",
     "cross-spawn": "^7.0.5",
     "qs": "^6.14.1",
-    "fast-uri": "3.1.3"
+    "fast-uri": "3.1.3",
+    "linkify-it": "^5.0.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary

Bumps the transitive npm dependency `linkify-it` from 2.2.0 to 5.0.2 via npm overrides to fix CVE-2026-48801 (DoS via algorithmic complexity in `LinkifyIt.prototype.match`).

## CVE Details

- **CVE-2026-48801**: linkify-it versions prior to 5.0.1 have O(N²) algorithmic complexity for inputs containing many fuzzy links or emails, enabling denial of service. Fixed in 5.0.1+.
- **GHSA**: [GHSA-22p9-wv53-3rq4](https://github.com/markdown-it/linkify-it/security/advisories/GHSA-22p9-wv53-3rq4)
- **Severity**: Moderate (CVSS 7.5)

## Changes

- Added `"linkify-it": "^5.0.1"` to the existing `overrides` block in `web/package.json`
- Regenerated `web/package-lock.json` — linkify-it resolved to 5.0.2, uc.micro bumped 1.0.6 → 2.1.0

## Dependency chain

`web/package.json` → `react-linkify@0.2.2` (direct dep) → `linkify-it ^2.0.3` → overridden to `5.0.2`

## Testing

- `npm run lint` ✅ passed
- `npm run build` ✅ passed (webpack production build)

## Jira

- [OCPBUGS-98777](https://redhat.atlassian.net/browse/OCPBUGS-98777)