### PR TITLE
OCPBUGS-98773: Bump linkify-it to 5.0.1 to fix CVE-2026-48801

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18773,12 +18773,22 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/listr2": {
@@ -24910,9 +24920,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -185,7 +185,8 @@
     },
     "ws": "^8.21.0",
     "form-data": "^4.0.6",
-    "dompurify": "^3.4.11"
+    "dompurify": "^3.4.11",
+    "linkify-it": "5.0.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## CVE Fix: CVE-2026-48801

Bumps `linkify-it` from 2.2.0 to 5.0.1 to remediate CVE-2026-48801 (Denial of Service via algorithmic complexity vulnerability).

### Details

`linkify-it` is a transitive dependency pulled in by `react-linkify@0.2.2`. Since `react-linkify` pins `linkify-it@^2.0.3`, the fix uses an npm `overrides` entry (consistent with existing CVE fix patterns in this repo) to force resolution to 5.0.1.

- **CVSS 3.x Score**: 7.5 (Moderate)
- **Fix**: linkify-it 5.0.1 (https://github.com/markdown-it/linkify-it/security/advisories/GHSA-22p9-wv53-3rq4)

### Jira

- [OCPBUGS-98773](https://redhat.atlassian.net/browse/OCPBUGS-98773)

### Tests

- Unit tests: 5 suites, 125 tests — all passing
- Lint: 0 errors (1 pre-existing warning, unrelated)