### PR TITLE
OCPBUGS-98783: Bump linkify-it to fix CVE-2026-48801

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18773,12 +18773,22 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/listr2": {
@@ -24910,9 +24920,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -186,7 +186,8 @@
     },
     "ws": "^8.21.0",
     "form-data": "^4.0.6",
-    "dompurify": "^3.4.11"
+    "dompurify": "^3.4.11",
+    "linkify-it": "^5.0.1"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
## Summary

Bumps `linkify-it` from 2.2.0 to 5.0.2 to remediate CVE-2026-48801 (ReDoS / O(N²) algorithmic complexity in `LinkifyIt.prototype.match`).

## CVE Details

- **CVE-2026-48801** (CVSS 7.5 Moderate): linkify-it prior to 5.0.1 has O(N²) algorithmic complexity for inputs containing many fuzzy links or emails, enabling Denial of Service via crafted input.
- **Fix**: linkify-it >= 5.0.1
- **Advisory**: [GHSA-22p9-wv53-3rq4](https://github.com/markdown-it/linkify-it/security/advisories/GHSA-22p9-wv53-3rq4)

## Changes

- Added `"linkify-it": "^5.0.1"` to the `overrides` block in `web/package.json` to force resolution of the transitive dependency (pulled in by `react-linkify@0.2.2`) to the patched version.
- Regenerated `web/package-lock.json`.

## Compatibility

The core API (`new LinkifyIt()`, `.match()`, `.test()`) is unchanged across v2→v5. The v5 package ships dual CJS/ESM exports, so `react-linkify`'s `require('linkify-it')` continues to resolve correctly. All tests pass.

## Jira

- [OCPBUGS-98783](https://redhat.atlassian.net/browse/OCPBUGS-98783)