### PR TITLE
CNV-87531: k8s: add Prometheus query layer and GET /alerts

### DIFF
--- a/docs/alert-rule-classification.md
+++ b/docs/alert-rule-classification.md
@@ -51,7 +51,7 @@ Location: `pkg/alertcomponent/matcher.go`
 
 2) Fallback:
    - If the computed component is empty or "Others", we set:
-     - `component = other`
+     - `component = "Others"`
      - `layer` derived from source:
        - `openshift_io_alert_source=platform` → `cluster`
        - `openshift_io_prometheus_rule_namespace=openshift-monitoring` → `cluster`

--- a/internal/managementrouter/alerts_get.go
+++ b/internal/managementrouter/alerts_get.go
@@ -1,0 +1,109 @@
+package managementrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+)
+
+type GetAlertsResponse struct {
+	Data     GetAlertsResponseData `json:"data"`
+	Warnings []string              `json:"warnings,omitempty"`
+}
+
+type GetAlertsResponseData struct {
+	Alerts []k8s.PrometheusAlert `json:"alerts"`
+}
+
+func (hr *httpRouter) GetAlerts(w http.ResponseWriter, req *http.Request) {
+	state, labels, err := parseStateAndLabels(req.URL.Query())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx := req.Context()
+
+	alerts, err := hr.managementClient.GetAlerts(ctx, k8s.GetAlertsRequest{
+		Labels: labels,
+		State:  state,
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(GetAlertsResponse{
+		Data: GetAlertsResponseData{
+			Alerts: alerts,
+		},
+		Warnings: hr.alertWarnings(ctx),
+	}); err != nil {
+		log.WithError(err).Warn("failed to encode alerts response")
+	}
+}
+
+func (hr *httpRouter) alertWarnings(ctx context.Context) []string {
+	health, ok := hr.alertingHealth(ctx)
+	if !ok {
+		return nil
+	}
+
+	warnings := []string{}
+	if health.UserWorkloadEnabled && health.UserWorkload != nil {
+		warnings = append(warnings, buildRouteWarnings(health.UserWorkload.Prometheus, k8s.UserWorkloadRouteName, "user workload Prometheus")...)
+		warnings = append(warnings, buildRouteWarnings(health.UserWorkload.Alertmanager, k8s.UserWorkloadAlertmanagerRouteName, "user workload Alertmanager")...)
+	}
+
+	return warnings
+}
+
+//nolint:unused // used by the rules listing handler in a subsequent branch
+func (hr *httpRouter) rulesWarnings(ctx context.Context) []string {
+	health, ok := hr.alertingHealth(ctx)
+	if !ok {
+		return nil
+	}
+
+	if health.UserWorkloadEnabled && health.UserWorkload != nil {
+		return buildRouteWarnings(health.UserWorkload.Prometheus, k8s.UserWorkloadRouteName, "user workload Prometheus")
+	}
+
+	return nil
+}
+
+func (hr *httpRouter) alertingHealth(ctx context.Context) (k8s.AlertingHealth, bool) {
+	if hr.managementClient == nil {
+		return k8s.AlertingHealth{}, false
+	}
+
+	health, err := hr.managementClient.GetAlertingHealth(ctx)
+	if err != nil {
+		log.WithError(err).Warn("alerting health unavailable")
+		return k8s.AlertingHealth{}, false
+	}
+
+	return health, true
+}
+
+func buildRouteWarnings(route k8s.AlertingRouteHealth, expectedName string, friendlyName string) []string {
+	if route.Name != "" && route.Name != expectedName {
+		return nil
+	}
+	if route.FallbackReachable {
+		return nil
+	}
+
+	switch route.Status {
+	case k8s.RouteNotFound:
+		return []string{friendlyName + " route is missing"}
+	case k8s.RouteUnreachable:
+		return []string{friendlyName + " route is unreachable"}
+	default:
+		return nil
+	}
+}

--- a/internal/managementrouter/alerts_get.go
+++ b/internal/managementrouter/alerts_get.go
@@ -1,0 +1,96 @@
+package managementrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+)
+
+type GetAlertsResponse struct {
+	Data     GetAlertsResponseData `json:"data"`
+	Warnings []string              `json:"warnings,omitempty"`
+}
+
+type GetAlertsResponseData struct {
+	Alerts []k8s.PrometheusAlert `json:"alerts"`
+}
+
+func (hr *httpRouter) GetAlerts(w http.ResponseWriter, req *http.Request) {
+	state, labels, err := parseStateAndLabels(req.URL.Query())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx := req.Context()
+
+	alerts, warnings, err := hr.managementClient.EnrichAlerts(ctx, k8s.GetAlertsRequest{
+		Labels: labels,
+		State:  state,
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(GetAlertsResponse{
+		Data: GetAlertsResponseData{
+			Alerts: alerts,
+		},
+		Warnings: warnings,
+	}); err != nil {
+		log.WithError(err).Warn("failed to encode alerts response")
+	}
+}
+
+//nolint:unused // used by the rules listing handler in a subsequent branch
+func (hr *httpRouter) rulesWarnings(ctx context.Context) []string {
+	health, ok := hr.alertingHealth(ctx)
+	if !ok {
+		return nil
+	}
+
+	if health.UserWorkloadEnabled && health.UserWorkload != nil {
+		return buildRouteWarnings(health.UserWorkload.Prometheus, k8s.UserWorkloadRouteName, "user workload Prometheus")
+	}
+
+	return nil
+}
+
+//nolint:unused // called by rulesWarnings, used in a subsequent branch
+func (hr *httpRouter) alertingHealth(ctx context.Context) (k8s.AlertingHealth, bool) {
+	if hr.managementClient == nil {
+		return k8s.AlertingHealth{}, false
+	}
+
+	health, err := hr.managementClient.GetAlertingHealth(ctx)
+	if err != nil {
+		log.WithError(err).Warn("alerting health unavailable")
+		return k8s.AlertingHealth{}, false
+	}
+
+	return health, true
+}
+
+//nolint:unused // called by rulesWarnings, used in a subsequent branch
+func buildRouteWarnings(route k8s.AlertingRouteHealth, expectedName string, friendlyName string) []string {
+	if route.Name != "" && route.Name != expectedName {
+		return nil
+	}
+	if route.FallbackReachable {
+		return nil
+	}
+
+	switch route.Status {
+	case k8s.RouteNotFound:
+		return []string{friendlyName + " route is missing"}
+	case k8s.RouteUnreachable:
+		return []string{friendlyName + " route is unreachable"}
+	default:
+		return nil
+	}
+}

--- a/internal/managementrouter/alerts_get_test.go
+++ b/internal/managementrouter/alerts_get_test.go
@@ -1,0 +1,380 @@
+package managementrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/model/relabel"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/monitoring-plugin/internal/managementrouter"
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/management"
+	"github.com/openshift/monitoring-plugin/pkg/management/testutils"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+// agFixture holds mocks and the router for GetAlerts handler tests.
+type agFixture struct {
+	router               http.Handler
+	mockK8s              *testutils.MockClient
+	mockPrometheusAlerts *testutils.MockPrometheusAlertsInterface
+}
+
+func newAGFixture(t *testing.T) *agFixture {
+	t.Helper()
+	f := &agFixture{
+		mockPrometheusAlerts: &testutils.MockPrometheusAlertsInterface{},
+	}
+	f.mockK8s = &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return f.mockPrometheusAlerts
+		},
+	}
+	f.rebuild()
+	return f
+}
+
+func (f *agFixture) rebuild() {
+	mgmt := management.New(context.Background(), f.mockK8s)
+	f.router = managementrouter.New(mgmt)
+}
+
+func (f *agFixture) get(t *testing.T, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeAlertsResp(t *testing.T, w *httptest.ResponseRecorder) managementrouter.GetAlertsResponse {
+	t.Helper()
+	var resp managementrouter.GetAlertsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func TestGetAlerts_ParsesFlatQueryParams(t *testing.T) {
+	f := newAGFixture(t)
+	var captured k8s.GetAlertsRequest
+	f.mockPrometheusAlerts.GetAlertsFunc = func(_ context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+		captured = req
+		return []k8s.PrometheusAlert{}, nil
+	}
+
+	w := f.get(t, "/api/v1/alerting/alerts?namespace=ns1&severity=critical&state=firing&team=sre")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if captured.State != "firing" {
+		t.Errorf("expected state=firing, got %q", captured.State)
+	}
+	if captured.Labels["namespace"] != "ns1" {
+		t.Errorf("expected namespace=ns1, got %q", captured.Labels["namespace"])
+	}
+	if captured.Labels["severity"] != "critical" {
+		t.Errorf("expected severity=critical, got %q", captured.Labels["severity"])
+	}
+	if captured.Labels["team"] != "sre" {
+		t.Errorf("expected team=sre, got %q", captured.Labels["team"])
+	}
+}
+
+func TestGetAlerts_ReturnsAllAlerts(t *testing.T) {
+	f := newAGFixture(t)
+	testAlerts := []k8s.PrometheusAlert{
+		{
+			Labels:      map[string]string{managementlabels.AlertNameLabel: "HighCPUUsage", "severity": "warning", "namespace": "default"},
+			Annotations: map[string]string{"description": "CPU usage is high"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+		{
+			Labels:      map[string]string{managementlabels.AlertNameLabel: "LowMemory", "severity": "critical", "namespace": "monitoring"},
+			Annotations: map[string]string{"description": "Memory is running low"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts(testAlerts)
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(resp.Data.Alerts))
+	}
+	if resp.Data.Alerts[0].Labels[managementlabels.AlertNameLabel] != "HighCPUUsage" {
+		t.Errorf("alert[0] name mismatch: %s", resp.Data.Alerts[0].Labels[managementlabels.AlertNameLabel])
+	}
+	if resp.Data.Alerts[1].Labels[managementlabels.AlertNameLabel] != "LowMemory" {
+		t.Errorf("alert[1] name mismatch: %s", resp.Data.Alerts[1].Labels[managementlabels.AlertNameLabel])
+	}
+}
+
+func TestGetAlerts_WarningsWhenUserWorkloadRoutesMissing(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockK8s.AlertingHealthFunc = func(_ context.Context) (k8s.AlertingHealth, error) {
+		return k8s.AlertingHealth{
+			UserWorkloadEnabled: true,
+			UserWorkload: &k8s.AlertingStackHealth{
+				Prometheus:   k8s.AlertingRouteHealth{Status: k8s.RouteNotFound},
+				Alertmanager: k8s.AlertingRouteHealth{Status: k8s.RouteNotFound},
+			},
+		}, nil
+	}
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	resp := decodeAlertsResp(t, w)
+
+	warnSet := make(map[string]bool)
+	for _, w := range resp.Warnings {
+		warnSet[w] = true
+	}
+	if !warnSet["user workload Prometheus route is missing"] {
+		t.Errorf("expected Prometheus route warning, got: %v", resp.Warnings)
+	}
+	if !warnSet["user workload Alertmanager route is missing"] {
+		t.Errorf("expected Alertmanager route warning, got: %v", resp.Warnings)
+	}
+}
+
+func TestGetAlerts_SuppressesWarningsWhenFallbacksHealthy(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockK8s.AlertingHealthFunc = func(_ context.Context) (k8s.AlertingHealth, error) {
+		return k8s.AlertingHealth{
+			UserWorkloadEnabled: true,
+			UserWorkload: &k8s.AlertingStackHealth{
+				Prometheus:   k8s.AlertingRouteHealth{Status: k8s.RouteUnreachable, FallbackReachable: true},
+				Alertmanager: k8s.AlertingRouteHealth{Status: k8s.RouteUnreachable, FallbackReachable: true},
+			},
+		}, nil
+	}
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Warnings) != 0 {
+		t.Errorf("expected no warnings, got: %v", resp.Warnings)
+	}
+}
+
+func TestGetAlerts_ReturnsEmptyWhenNoAlerts(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{})
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 0 {
+		t.Errorf("expected empty alerts, got %d", len(resp.Data.Alerts))
+	}
+}
+
+func TestGetAlerts_Returns500OnError(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.GetAlertsFunc = func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+		return nil, fmt.Errorf("connection error")
+	}
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "An unexpected error occurred") {
+		t.Errorf("expected error message, got: %s", body)
+	}
+}
+
+func TestGetAlerts_ForwardsBearerToken(t *testing.T) {
+	f := newAGFixture(t)
+	var capturedCtx context.Context
+	f.mockPrometheusAlerts.GetAlertsFunc = func(ctx context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+		capturedCtx = ctx
+		return []k8s.PrometheusAlert{}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerting/alerts", nil)
+	req.Header.Set("Authorization", "Bearer test-token-abc123")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if token := k8s.BearerTokenFromContext(capturedCtx); token != "test-token-abc123" {
+		t.Errorf("expected token test-token-abc123, got %q", token)
+	}
+}
+
+func TestGetAlerts_MissingAuthHeaderReturns401(t *testing.T) {
+	f := newAGFixture(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerting/alerts", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestGetAlerts_EnrichesAlertWithRuleId(t *testing.T) {
+	f := newAGFixture(t)
+	baseRule := monitoringv1.Rule{
+		Alert:  "HighCPU",
+		Expr:   intstr.FromString("node_cpu > 0.9"),
+		Labels: map[string]string{"severity": "critical"},
+	}
+	ruleId := alertrule.GetAlertingRuleId(&baseRule)
+
+	relabeledRule := monitoringv1.Rule{
+		Alert: "HighCPU",
+		Expr:  intstr.FromString("node_cpu > 0.9"),
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel:        "HighCPU",
+			"severity":                             "critical",
+			k8s.AlertRuleLabelId:                   ruleId,
+			k8s.PrometheusRuleLabelNamespace:       "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:            "cluster-cpu-rules",
+			managementlabels.AlertingRuleLabelName: "my-alerting-rule",
+		},
+	}
+
+	f.mockK8s.RelabeledRulesFunc = func() k8s.RelabeledRulesInterface {
+		return &testutils.MockRelabeledRulesInterface{
+			ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{relabeledRule} },
+			GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+				if id == ruleId {
+					return relabeledRule, true
+				}
+				return monitoringv1.Rule{}, false
+			},
+			ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+		}
+	}
+	f.mockK8s.NamespaceFunc = func() k8s.NamespaceInterface {
+		return &testutils.MockNamespaceInterface{
+			IsClusterMonitoringNamespaceFunc: func(name string) bool { return name == "openshift-monitoring" },
+		}
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{
+		{
+			Labels: map[string]string{
+				managementlabels.AlertNameLabel: "HighCPU",
+				"severity":                      "critical",
+				k8s.AlertSourceLabel:            k8s.AlertSourcePlatform,
+				k8s.AlertBackendLabel:           "alertmanager",
+			},
+			Annotations: map[string]string{"summary": "CPU is high"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+	})
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(resp.Data.Alerts))
+	}
+	alert := resp.Data.Alerts[0]
+	if alert.AlertRuleId != ruleId {
+		t.Errorf("expected ruleId %s, got %s", ruleId, alert.AlertRuleId)
+	}
+	if alert.AlertComponent == "" {
+		t.Error("expected non-empty AlertComponent")
+	}
+	if alert.AlertLayer == "" {
+		t.Error("expected non-empty AlertLayer")
+	}
+}
+
+func TestGetAlerts_EnrichesWithoutAlertingRuleCR(t *testing.T) {
+	f := newAGFixture(t)
+	baseRule := monitoringv1.Rule{
+		Alert:  "KubePodCrashLooping",
+		Expr:   intstr.FromString("rate(kube_pod_restart_total[5m]) > 0"),
+		Labels: map[string]string{"severity": "warning"},
+	}
+	ruleId := alertrule.GetAlertingRuleId(&baseRule)
+
+	relabeledRule := monitoringv1.Rule{
+		Alert: "KubePodCrashLooping",
+		Expr:  intstr.FromString("rate(kube_pod_restart_total[5m]) > 0"),
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel:  "KubePodCrashLooping",
+			"severity":                       "warning",
+			k8s.AlertRuleLabelId:             ruleId,
+			k8s.PrometheusRuleLabelNamespace: "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:      "kube-state-metrics",
+		},
+	}
+
+	f.mockK8s.RelabeledRulesFunc = func() k8s.RelabeledRulesInterface {
+		return &testutils.MockRelabeledRulesInterface{
+			ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{relabeledRule} },
+			GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+				if id == ruleId {
+					return relabeledRule, true
+				}
+				return monitoringv1.Rule{}, false
+			},
+			ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+		}
+	}
+	f.mockK8s.NamespaceFunc = func() k8s.NamespaceInterface {
+		return &testutils.MockNamespaceInterface{
+			IsClusterMonitoringNamespaceFunc: func(name string) bool { return name == "openshift-monitoring" },
+		}
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{
+		{
+			Labels: map[string]string{
+				managementlabels.AlertNameLabel: "KubePodCrashLooping",
+				"severity":                      "warning",
+				k8s.AlertSourceLabel:            k8s.AlertSourcePlatform,
+				k8s.AlertBackendLabel:           "alertmanager",
+			},
+			State:    "firing",
+			ActiveAt: time.Now(),
+		},
+	})
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(resp.Data.Alerts))
+	}
+	if resp.Data.Alerts[0].AlertRuleId != ruleId {
+		t.Errorf("expected ruleId %s, got %s", ruleId, resp.Data.Alerts[0].AlertRuleId)
+	}
+}

--- a/internal/managementrouter/alerts_get_test.go
+++ b/internal/managementrouter/alerts_get_test.go
@@ -1,0 +1,364 @@
+package managementrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/model/relabel"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/monitoring-plugin/internal/managementrouter"
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/management"
+	"github.com/openshift/monitoring-plugin/pkg/management/testutils"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+// agFixture holds mocks and the router for GetAlerts handler tests.
+type agFixture struct {
+	router               http.Handler
+	mockK8s              *testutils.MockClient
+	mockPrometheusAlerts *testutils.MockPrometheusAlertsInterface
+}
+
+func newAGFixture(t *testing.T) *agFixture {
+	t.Helper()
+	f := &agFixture{
+		mockPrometheusAlerts: &testutils.MockPrometheusAlertsInterface{},
+	}
+	f.mockK8s = &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return f.mockPrometheusAlerts
+		},
+	}
+	f.rebuild()
+	return f
+}
+
+func (f *agFixture) rebuild() {
+	mgmt := management.New(context.Background(), f.mockK8s)
+	f.router = managementrouter.New(mgmt)
+}
+
+func (f *agFixture) get(t *testing.T, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeAlertsResp(t *testing.T, w *httptest.ResponseRecorder) managementrouter.GetAlertsResponse {
+	t.Helper()
+	var resp managementrouter.GetAlertsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func TestGetAlerts_ParsesFlatQueryParams(t *testing.T) {
+	f := newAGFixture(t)
+	var captured k8s.GetAlertsRequest
+	f.mockPrometheusAlerts.FetchAlertsFunc = func(_ context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+		captured = req
+		return []k8s.PrometheusAlert{}, nil, nil
+	}
+
+	w := f.get(t, "/api/v1/alerting/alerts?namespace=ns1&severity=critical&state=firing&team=sre")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if captured.State != "firing" {
+		t.Errorf("expected state=firing, got %q", captured.State)
+	}
+	if captured.Labels["namespace"] != "ns1" {
+		t.Errorf("expected namespace=ns1, got %q", captured.Labels["namespace"])
+	}
+	if captured.Labels["severity"] != "critical" {
+		t.Errorf("expected severity=critical, got %q", captured.Labels["severity"])
+	}
+	if captured.Labels["team"] != "sre" {
+		t.Errorf("expected team=sre, got %q", captured.Labels["team"])
+	}
+}
+
+func TestGetAlerts_ReturnsAllAlerts(t *testing.T) {
+	f := newAGFixture(t)
+	testAlerts := []k8s.PrometheusAlert{
+		{
+			Labels:      map[string]string{managementlabels.AlertNameLabel: "HighCPUUsage", "severity": "warning", "namespace": "default"},
+			Annotations: map[string]string{"description": "CPU usage is high"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+		{
+			Labels:      map[string]string{managementlabels.AlertNameLabel: "LowMemory", "severity": "critical", "namespace": "monitoring"},
+			Annotations: map[string]string{"description": "Memory is running low"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts(testAlerts)
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(resp.Data.Alerts))
+	}
+	if resp.Data.Alerts[0].Labels[managementlabels.AlertNameLabel] != "HighCPUUsage" {
+		t.Errorf("alert[0] name mismatch: %s", resp.Data.Alerts[0].Labels[managementlabels.AlertNameLabel])
+	}
+	if resp.Data.Alerts[1].Labels[managementlabels.AlertNameLabel] != "LowMemory" {
+		t.Errorf("alert[1] name mismatch: %s", resp.Data.Alerts[1].Labels[managementlabels.AlertNameLabel])
+	}
+}
+
+func TestGetAlerts_WarningsSurfacedFromFetchAlerts(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.FetchAlertsFunc = func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+		return []k8s.PrometheusAlert{}, []string{
+			"failed to get user workload alerts: connection refused",
+		}, nil
+	}
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	resp := decodeAlertsResp(t, w)
+
+	if len(resp.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(resp.Warnings), resp.Warnings)
+	}
+	if resp.Warnings[0] != "failed to get user workload alerts: connection refused" {
+		t.Errorf("unexpected warning: %s", resp.Warnings[0])
+	}
+}
+
+func TestGetAlerts_NoWarningsWhenAllEndpointsSucceed(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{})
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Warnings) != 0 {
+		t.Errorf("expected no warnings, got: %v", resp.Warnings)
+	}
+}
+
+func TestGetAlerts_ReturnsEmptyWhenNoAlerts(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{})
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 0 {
+		t.Errorf("expected empty alerts, got %d", len(resp.Data.Alerts))
+	}
+}
+
+func TestGetAlerts_Returns500OnError(t *testing.T) {
+	f := newAGFixture(t)
+	f.mockPrometheusAlerts.FetchAlertsFunc = func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+		return nil, nil, fmt.Errorf("connection error")
+	}
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "An unexpected error occurred") {
+		t.Errorf("expected error message, got: %s", body)
+	}
+}
+
+func TestGetAlerts_ForwardsBearerToken(t *testing.T) {
+	f := newAGFixture(t)
+	var capturedCtx context.Context
+	f.mockPrometheusAlerts.FetchAlertsFunc = func(ctx context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+		capturedCtx = ctx
+		return []k8s.PrometheusAlert{}, nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerting/alerts", nil)
+	req.Header.Set("Authorization", "Bearer test-token-abc123")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if token := k8s.BearerTokenFromContext(capturedCtx); token != "test-token-abc123" {
+		t.Errorf("expected token test-token-abc123, got %q", token)
+	}
+}
+
+func TestGetAlerts_MissingAuthHeaderReturns401(t *testing.T) {
+	f := newAGFixture(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerting/alerts", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestGetAlerts_EnrichesAlertWithRuleId(t *testing.T) {
+	f := newAGFixture(t)
+	baseRule := monitoringv1.Rule{
+		Alert:  "HighCPU",
+		Expr:   intstr.FromString("node_cpu > 0.9"),
+		Labels: map[string]string{"severity": "critical"},
+	}
+	ruleId := alertrule.GetAlertingRuleId(&baseRule)
+
+	relabeledRule := monitoringv1.Rule{
+		Alert: "HighCPU",
+		Expr:  intstr.FromString("node_cpu > 0.9"),
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel:        "HighCPU",
+			"severity":                             "critical",
+			k8s.AlertRuleLabelId:                   ruleId,
+			k8s.PrometheusRuleLabelNamespace:       "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:            "cluster-cpu-rules",
+			managementlabels.AlertingRuleLabelName: "my-alerting-rule",
+		},
+	}
+
+	f.mockK8s.RelabeledRulesFunc = func() k8s.RelabeledRulesInterface {
+		return &testutils.MockRelabeledRulesInterface{
+			ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{relabeledRule} },
+			GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+				if id == ruleId {
+					return relabeledRule, true
+				}
+				return monitoringv1.Rule{}, false
+			},
+			ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+		}
+	}
+	f.mockK8s.NamespaceFunc = func() k8s.NamespaceInterface {
+		return &testutils.MockNamespaceInterface{
+			IsClusterMonitoringNamespaceFunc: func(name string) bool { return name == "openshift-monitoring" },
+		}
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{
+		{
+			Labels: map[string]string{
+				managementlabels.AlertNameLabel: "HighCPU",
+				"severity":                      "critical",
+				k8s.AlertSourceLabel:            k8s.AlertSourcePlatform,
+				k8s.AlertBackendLabel:           "alertmanager",
+			},
+			Annotations: map[string]string{"summary": "CPU is high"},
+			State:       "firing",
+			ActiveAt:    time.Now(),
+		},
+	})
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(resp.Data.Alerts))
+	}
+	alert := resp.Data.Alerts[0]
+	if alert.AlertRuleId != ruleId {
+		t.Errorf("expected ruleId %s, got %s", ruleId, alert.AlertRuleId)
+	}
+	if alert.AlertComponent == "" {
+		t.Error("expected non-empty AlertComponent")
+	}
+	if alert.AlertLayer == "" {
+		t.Error("expected non-empty AlertLayer")
+	}
+}
+
+func TestGetAlerts_EnrichesWithoutAlertingRuleCR(t *testing.T) {
+	f := newAGFixture(t)
+	baseRule := monitoringv1.Rule{
+		Alert:  "KubePodCrashLooping",
+		Expr:   intstr.FromString("rate(kube_pod_restart_total[5m]) > 0"),
+		Labels: map[string]string{"severity": "warning"},
+	}
+	ruleId := alertrule.GetAlertingRuleId(&baseRule)
+
+	relabeledRule := monitoringv1.Rule{
+		Alert: "KubePodCrashLooping",
+		Expr:  intstr.FromString("rate(kube_pod_restart_total[5m]) > 0"),
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel:  "KubePodCrashLooping",
+			"severity":                       "warning",
+			k8s.AlertRuleLabelId:             ruleId,
+			k8s.PrometheusRuleLabelNamespace: "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:      "kube-state-metrics",
+		},
+	}
+
+	f.mockK8s.RelabeledRulesFunc = func() k8s.RelabeledRulesInterface {
+		return &testutils.MockRelabeledRulesInterface{
+			ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{relabeledRule} },
+			GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+				if id == ruleId {
+					return relabeledRule, true
+				}
+				return monitoringv1.Rule{}, false
+			},
+			ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+		}
+	}
+	f.mockK8s.NamespaceFunc = func() k8s.NamespaceInterface {
+		return &testutils.MockNamespaceInterface{
+			IsClusterMonitoringNamespaceFunc: func(name string) bool { return name == "openshift-monitoring" },
+		}
+	}
+	f.mockPrometheusAlerts.SetActiveAlerts([]k8s.PrometheusAlert{
+		{
+			Labels: map[string]string{
+				managementlabels.AlertNameLabel: "KubePodCrashLooping",
+				"severity":                      "warning",
+				k8s.AlertSourceLabel:            k8s.AlertSourcePlatform,
+				k8s.AlertBackendLabel:           "alertmanager",
+			},
+			State:    "firing",
+			ActiveAt: time.Now(),
+		},
+	})
+	f.rebuild()
+
+	w := f.get(t, "/api/v1/alerting/alerts")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	resp := decodeAlertsResp(t, w)
+	if len(resp.Data.Alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(resp.Data.Alerts))
+	}
+	if resp.Data.Alerts[0].AlertRuleId != ruleId {
+		t.Errorf("expected ruleId %s, got %s", ruleId, resp.Data.Alerts[0].AlertRuleId)
+	}
+}

--- a/internal/managementrouter/query_filters.go
+++ b/internal/managementrouter/query_filters.go
@@ -1,0 +1,35 @@
+package managementrouter
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+var validStates = map[string]bool{
+	"":         true,
+	"pending":  true,
+	"firing":   true,
+	"silenced": true,
+}
+
+// parseStateAndLabels returns the optional state filter and label matches.
+// Any query param other than "state" is treated as a label match.
+// Returns an error if the state value is not one of the known states.
+func parseStateAndLabels(q url.Values) (string, map[string]string, error) {
+	state := strings.ToLower(strings.TrimSpace(q.Get("state")))
+	if !validStates[state] {
+		return "", nil, fmt.Errorf("invalid state filter %q: must be one of pending, firing, silenced", q.Get("state"))
+	}
+
+	labels := make(map[string]string)
+	for key, vals := range q {
+		if key == "state" {
+			continue
+		}
+		if len(vals) > 0 && strings.TrimSpace(vals[0]) != "" {
+			labels[strings.TrimSpace(key)] = strings.TrimSpace(vals[0])
+		}
+	}
+	return state, labels, nil
+}

--- a/internal/managementrouter/query_filters.go
+++ b/internal/managementrouter/query_filters.go
@@ -1,0 +1,38 @@
+package managementrouter
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+var validStates = map[string]bool{
+	"pending":  true,
+	"firing":   true,
+	"silenced": true,
+}
+
+// parseStateAndLabels returns the optional state filter and label matches.
+// Any query param other than "state" is treated as a label match.
+// Returns an error if the state value is not one of the known states.
+func parseStateAndLabels(q url.Values) (string, map[string]string, error) {
+	state := strings.ToLower(strings.TrimSpace(q.Get("state")))
+	if state != "" && !validStates[state] {
+		return "", nil, fmt.Errorf("invalid state filter %q: must be one of pending, firing, silenced", state)
+	}
+
+	labels := make(map[string]string)
+	for key, vals := range q {
+		if key == "state" {
+			continue
+		}
+		if len(vals) == 0 || strings.TrimSpace(vals[0]) == "" {
+			continue
+		}
+		if len(vals) > 1 {
+			return "", nil, fmt.Errorf("multiple values for label filter %q: only a single value is supported", key)
+		}
+		labels[strings.TrimSpace(key)] = strings.TrimSpace(vals[0])
+	}
+	return state, labels, nil
+}

--- a/internal/managementrouter/router.go
+++ b/internal/managementrouter/router.go
@@ -43,6 +43,9 @@ func New(managementClient management.Client) *mux.Router {
 		BaseURL:    "/api/v1/alerting",
 		BaseRouter: r,
 	})
+	// GET /alerts is not yet in the OpenAPI spec; registered manually
+	// until its branch adds the spec entry and generated bindings.
+	r.HandleFunc("/api/v1/alerting/alerts", hr.GetAlerts).Methods(http.MethodGet)
 
 	return r
 }

--- a/pkg/alertcomponent/matcher.go
+++ b/pkg/alertcomponent/matcher.go
@@ -1,0 +1,381 @@
+package alertcomponent
+
+import (
+	"regexp"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+const (
+	labelNamespace = "namespace"
+	labelSeverity  = "severity"
+)
+
+func ns(values ...string) LabelsMatcher {
+	return NewLabelsMatcher(labelNamespace, NewStringValuesMatcher(values...))
+}
+
+func alertNames(values ...string) LabelsMatcher {
+	return NewLabelsMatcher(managementlabels.AlertNameLabel, NewStringValuesMatcher(values...))
+}
+
+func regexAlertNames(regexes ...*regexp.Regexp) LabelsMatcher {
+	return NewLabelsMatcher(managementlabels.AlertNameLabel, NewRegexValuesMatcher(regexes...))
+}
+
+func labelValues(key string, values ...string) LabelsMatcher {
+	return NewLabelsMatcher(key, NewStringValuesMatcher(values...))
+}
+
+func comp(component string, ms ...LabelsMatcher) componentMatcher {
+	return componentMatcher{component: component, matchers: ms}
+}
+
+// LabelsMatcher represents a matcher definition for a set of labels.
+// It matches if all of the label matchers match the labels.
+type LabelsMatcher interface {
+	Matches(labels model.LabelSet) (match bool, keys []model.LabelName)
+	Equals(other LabelsMatcher) bool
+}
+
+func NewLabelsMatcher(key string, matcher ValueMatcher) LabelsMatcher {
+	return labelMatcher{key: key, matcher: matcher}
+}
+
+func NewStringValuesMatcher(keys ...string) ValueMatcher {
+	return stringMatcher(keys)
+}
+
+func NewRegexValuesMatcher(regexes ...*regexp.Regexp) ValueMatcher {
+	return regexpMatcher(regexes)
+}
+
+// labelMatcher represents a matcher definition for a label.
+type labelMatcher struct {
+	key     string
+	matcher ValueMatcher
+}
+
+// Matches implements the LabelsMatcher interface.
+func (l labelMatcher) Matches(labels model.LabelSet) (bool, []model.LabelName) {
+	if l.matcher.Matches(string(labels[model.LabelName(l.key)])) {
+		return true, []model.LabelName{model.LabelName(l.key)}
+	}
+	return false, nil
+}
+
+// Equals implements the LabelsMatcher interface.
+func (l labelMatcher) Equals(other LabelsMatcher) bool {
+	ol, ok := other.(labelMatcher)
+	if !ok {
+		return false
+	}
+	return l.key == ol.key && l.matcher.Equals(ol.matcher)
+}
+
+// ValueMatcher represents a matcher for a specific value.
+//
+// Multiple implementations are provided for different types of matchers.
+type ValueMatcher interface {
+	Matches(value string) bool
+	Equals(other ValueMatcher) bool
+}
+
+// stringMatcher is a matcher for a list of strings.
+//
+// It matches if the value is in the list of strings.
+type stringMatcher []string
+
+func (s stringMatcher) Matches(value string) bool {
+	for _, v := range s {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+// Equals implements the ValueMatcher interface.
+func (s stringMatcher) Equals(other ValueMatcher) bool {
+	o, ok := other.(stringMatcher)
+	if !ok {
+		return false
+	}
+	return equalsNoOrder(s, o)
+}
+
+// regexpMatcher is a matcher for a list of regular expressions.
+//
+// It matches if the value matches any of the regular expressions.
+type regexpMatcher []*regexp.Regexp
+
+func (r regexpMatcher) Matches(value string) bool {
+	for _, re := range r {
+		if re.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Equals implements the ValueMatcher interface.
+func (r regexpMatcher) Equals(other ValueMatcher) bool {
+	o, ok := other.(regexpMatcher)
+	if !ok {
+		return false
+	}
+	s1 := make([]string, 0, len(r))
+	for _, re := range r {
+		s1 = append(s1, re.String())
+	}
+	s2 := make([]string, 0, len(o))
+	for _, re := range o {
+		s2 = append(s2, re.String())
+	}
+	return equalsNoOrder(s1, s2)
+}
+
+func equalsNoOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	seen := make(map[string]int, len(a))
+	for _, v := range a {
+		seen[v]++
+	}
+	for _, v := range b {
+		if seen[v] == 0 {
+			return false
+		}
+		seen[v]--
+	}
+	return true
+}
+
+// componentMatcher represents a matcher definition for a component.
+//
+// It matches if any of the label matchers match the labels.
+type componentMatcher struct {
+	component string
+	matchers  []LabelsMatcher
+}
+
+// findComponent tries to determine a component for given labels using the provided matchers.
+//
+// It returns the component and the keys that matched.
+// If no match is found, it returns an empty component and nil keys.
+func findComponent(compMatchers []componentMatcher, labels model.LabelSet) (
+	component string, keys []model.LabelName) {
+	for _, compMatcher := range compMatchers {
+		for _, labelsMatcher := range compMatcher.matchers {
+			if matches, keys := labelsMatcher.Matches(labels); matches {
+				return compMatcher.component, keys
+			}
+		}
+	}
+	return "", nil
+}
+
+// componentMatcherFn is a function that tries matching provided labels to a component.
+// It returns the layer, component and the keys from the labels that were used for matching.
+// If no match is found, it returns an empty layer, component and nil keys.
+type componentMatcherFn func(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName)
+
+func evalMatcherFns(fns []componentMatcherFn, labels model.LabelSet) (
+	layer, comp string, labelsSubset model.LabelSet) {
+	for _, fn := range fns {
+		if layer, comp, keys := fn(labels); layer != "" {
+			return string(layer), string(comp), getLabelsSubset(labels, keys...)
+		}
+	}
+	return "Others", "Others", getLabelsSubset(labels)
+}
+
+// getLabelsSubset returns a subset of the labels with given keys.
+func getLabelsSubset(m model.LabelSet, keys ...model.LabelName) model.LabelSet {
+	keys = append([]model.LabelName{
+		model.LabelName(labelNamespace),
+		model.LabelName(managementlabels.AlertNameLabel),
+		model.LabelName(labelSeverity),
+	}, keys...)
+	return getMapSubset(m, keys...)
+}
+
+// getMapSubset returns a subset of the labels with given keys.
+func getMapSubset(m model.LabelSet, keys ...model.LabelName) model.LabelSet {
+	subset := make(model.LabelSet, len(keys))
+	for _, key := range keys {
+		if val, ok := m[key]; ok {
+			subset[key] = val
+		}
+	}
+	return subset
+}
+
+var (
+	nodeAlerts []model.LabelValue = []model.LabelValue{
+		"NodeClockNotSynchronising",
+		"KubeNodeNotReady",
+		"KubeNodeUnreachable",
+		"NodeSystemSaturation",
+		"NodeFilesystemSpaceFillingUp",
+		"NodeFilesystemAlmostOutOfSpace",
+		"NodeMemoryMajorPagesFaults",
+		"NodeNetworkTransmitErrs",
+		"NodeTextFileCollectorScrapeError",
+		"NodeFilesystemFilesFillingUp",
+		"NodeNetworkReceiveErrs",
+		"NodeClockSkewDetected",
+		"NodeFilesystemAlmostOutOfFiles",
+		"NodeWithoutOVNKubeNodePodRunning",
+		"InfraNodesNeedResizingSRE",
+		"NodeHighNumberConntrackEntriesUsed",
+		"NodeMemHigh",
+		"NodeNetworkInterfaceFlapping",
+		"NodeWithoutSDNPod",
+		"NodeCpuHigh",
+		"CriticalNodeNotReady",
+		"NodeFileDescriptorLimit",
+		"MCCPoolAlert",
+		"MCCDrainError",
+		"MCDRebootError",
+		"MCDPivotError",
+	}
+
+	coreMatchers = []componentMatcher{
+		comp("etcd", ns("openshift-etcd", "openshift-etcd-operator")),
+		comp("kube-apiserver", ns("openshift-kube-apiserver", "openshift-kube-apiserver-operator")),
+		comp("kube-controller-manager", ns("openshift-kube-controller-manager", "openshift-kube-controller-manager-operator", "kube-system")),
+		comp("kube-scheduler", ns("openshift-kube-scheduler", "openshift-kube-scheduler-operator")),
+		comp("machine-approver", ns("openshift-cluster-machine-approver", "openshift-machine-approver-operator")),
+		comp("machine-config",
+			ns("openshift-machine-config-operator"),
+			alertNames(
+				"HighOverallControlPlaneMemory",
+				"ExtremelyHighIndividualControlPlaneMemory",
+				"MissingMachineConfig",
+				"MCCBootImageUpdateError",
+				"KubeletHealthState",
+				"SystemMemoryExceedsReservation",
+			),
+		),
+		comp("version",
+			ns("openshift-cluster-version", "openshift-version-operator"),
+			alertNames("ClusterNotUpgradeable", "UpdateAvailable"),
+		),
+		comp("dns", ns("openshift-dns", "openshift-dns-operator")),
+		comp("authentication", ns("openshift-authentication", "openshift-oauth-apiserver", "openshift-authentication-operator")),
+		comp("cert-manager", ns("openshift-cert-manager", "openshift-cert-manager-operator")),
+		comp("cloud-controller-manager", ns("openshift-cloud-controller-manager", "openshift-cloud-controller-manager-operator")),
+		comp("cloud-credential", ns("openshift-cloud-credential-operator")),
+		comp("cluster-api", ns("openshift-cluster-api", "openshift-cluster-api-operator")),
+		comp("config-operator", ns("openshift-config-operator")),
+		comp("kube-storage-version-migrator", ns("openshift-kube-storage-version-migrator", "openshift-kube-storage-version-migrator-operator")),
+		comp("image-registry", ns("openshift-image-registry", "openshift-image-registry-operator")),
+		comp("ingress", ns("openshift-ingress", "openshift-route-controller-manager", "openshift-ingress-canary", "openshift-ingress-operator")),
+		comp("console", ns("openshift-console", "openshift-console-operator")),
+		comp("insights", ns("openshift-insights", "openshift-insights-operator")),
+		comp("machine-api", ns("openshift-machine-api", "openshift-machine-api-operator")),
+		comp("monitoring", ns("openshift-monitoring", "openshift-monitoring-operator")),
+		comp("network", ns("openshift-network-operator", "openshift-ovn-kubernetes", "openshift-multus", "openshift-network-diagnostics", "openshift-sdn")),
+		comp("node-tuning", ns("openshift-cluster-node-tuning-operator", "openshift-node-tuning-operator")),
+		comp("openshift-apiserver", ns("openshift-apiserver", "openshift-apiserver-operator")),
+		comp("openshift-controller-manager", ns("openshift-controller-manager", "openshift-controller-manager-operator")),
+		comp("openshift-samples", ns("openshift-cluster-samples-operator", "openshift-samples-operator")),
+		comp("operator-lifecycle-manager", ns("openshift-operator-lifecycle-manager")),
+		comp("service-ca", ns("openshift-service-ca", "openshift-service-ca-operator")),
+		comp("storage", ns("openshift-storage", "openshift-cluster-csi-drivers", "openshift-cluster-storage-operator", "openshift-storage-operator")),
+		comp("vertical-pod-autoscaler", ns("openshift-vertical-pod-autoscaler", "openshift-vertical-pod-autoscaler-operator")),
+		comp("marketplace", ns("openshift-marketplace", "openshift-marketplace-operator")),
+	}
+
+	workloadMatchers = []componentMatcher{
+		comp("openshift-compliance", ns("openshift-compliance")),
+		comp("openshift-file-integrity", ns("openshift-file-integrity")),
+		comp("openshift-logging", ns("openshift-logging")),
+		comp("openshift-user-workload-monitoring", ns("openshift-user-workload-monitoring")),
+		comp("openshift-gitops", ns("openshift-gitops", "openshift-gitops-operator")),
+		comp("openshift-operators", ns("openshift-operators")),
+		comp("openshift-local-storage", ns("openshift-local-storage")),
+		comp("quay", labelValues("container", "quay-app", "quay-mirror", "quay-app-upgrade")),
+		comp("Argo", regexAlertNames(regexp.MustCompile("^Argo"))),
+	}
+)
+
+var cvoAlerts = []model.LabelValue{"ClusterOperatorDown", "ClusterOperatorDegraded"}
+
+func cvoAlertsMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	for _, v := range cvoAlerts {
+		if labels[managementlabels.AlertNameLabel] == v {
+			component := labels["name"]
+			if component == "" {
+				component = "version"
+			}
+			return "cluster", component, nil
+		}
+	}
+	return "", "", nil
+}
+
+func kubevirtOperatorMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	if labels["kubernetes_operator_part_of"] != "kubevirt" {
+		return "", "", nil
+	}
+	if labels["kubernetes_operator_component"] == "cnv-observability" {
+		return "", "", nil
+	}
+	if labels["operator_health_impact"] == "none" && labels["kubernetes_operator_component"] == "kubevirt" {
+		return "namespace", "OpenShift Virtualization Virtual Machine", []model.LabelName{
+			"kubernetes_operator_part_of",
+			"kubernetes_operator_component",
+			"operator_health_impact",
+		}
+	}
+	return "cluster", "OpenShift Virtualization Operator", []model.LabelName{
+		"kubernetes_operator_part_of",
+		"kubernetes_operator_component",
+		"operator_health_impact",
+	}
+}
+
+func computeMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	for _, nodeAlert := range nodeAlerts {
+		if labels[managementlabels.AlertNameLabel] == nodeAlert {
+			component := "compute"
+			return "cluster", model.LabelValue(component), nil
+		}
+	}
+	return "", "", nil
+}
+
+func coreMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	// Try matching against core components.
+	if component, keys := findComponent(coreMatchers, labels); component != "" {
+		return "cluster", model.LabelValue(component), keys
+	}
+	return "", "", nil
+}
+
+func workloadMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	// Try matching against workload components.
+	if component, keys := findComponent(workloadMatchers, labels); component != "" {
+		return "namespace", model.LabelValue(component), keys
+	}
+	return "", "", nil
+}
+
+// DetermineComponent determines the component for a given set of labels.
+// It returns the layer and component strings.
+func DetermineComponent(labels model.LabelSet) (layer, component string) {
+	layer, component, _ = evalMatcherFns([]componentMatcherFn{
+		cvoAlertsMatcher,
+		kubevirtOperatorMatcher,
+		computeMatcher,
+		coreMatcher,
+		workloadMatcher,
+	}, labels)
+	return layer, component
+}

--- a/pkg/alertcomponent/matcher.go
+++ b/pkg/alertcomponent/matcher.go
@@ -1,0 +1,377 @@
+package alertcomponent
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+const (
+	labelNamespace = "namespace"
+	labelSeverity  = "severity"
+
+	// ClusterMonitoringNamespace is the namespace for the platform monitoring stack.
+	ClusterMonitoringNamespace = "openshift-monitoring"
+	// UserWorkloadMonitoringNamespace is the namespace for user workload monitoring.
+	UserWorkloadMonitoringNamespace = "openshift-user-workload-monitoring"
+)
+
+func namespaceMatcher(values ...string) LabelsMatcher {
+	return NewLabelsMatcher(labelNamespace, NewStringValuesMatcher(values...))
+}
+
+func alertNameMatcher(values ...string) LabelsMatcher {
+	return NewLabelsMatcher(managementlabels.AlertNameLabel, NewStringValuesMatcher(values...))
+}
+
+func regexAlertNameMatcher(regexes ...*regexp.Regexp) LabelsMatcher {
+	return NewLabelsMatcher(managementlabels.AlertNameLabel, NewRegexValuesMatcher(regexes...))
+}
+
+func labelValueMatcher(key string, values ...string) LabelsMatcher {
+	return NewLabelsMatcher(key, NewStringValuesMatcher(values...))
+}
+
+func componentRule(component string, ms ...LabelsMatcher) componentMatcher {
+	return componentMatcher{component: component, matchers: ms}
+}
+
+// LabelsMatcher represents a matcher definition for a set of labels.
+// It matches if all of the label matchers match the labels.
+type LabelsMatcher interface {
+	Matches(labels model.LabelSet) (match bool, keys []model.LabelName)
+	Equals(other LabelsMatcher) bool
+}
+
+func NewLabelsMatcher(key string, matcher ValueMatcher) LabelsMatcher {
+	return labelMatcher{key: key, matcher: matcher}
+}
+
+func NewStringValuesMatcher(keys ...string) ValueMatcher {
+	return stringMatcher(keys)
+}
+
+func NewRegexValuesMatcher(regexes ...*regexp.Regexp) ValueMatcher {
+	return regexpMatcher(regexes)
+}
+
+// labelMatcher represents a matcher definition for a label.
+type labelMatcher struct {
+	key     string
+	matcher ValueMatcher
+}
+
+// Matches implements the LabelsMatcher interface.
+func (l labelMatcher) Matches(labels model.LabelSet) (bool, []model.LabelName) {
+	if l.matcher.Matches(string(labels[model.LabelName(l.key)])) {
+		return true, []model.LabelName{model.LabelName(l.key)}
+	}
+	return false, nil
+}
+
+// Equals implements the LabelsMatcher interface.
+func (l labelMatcher) Equals(other LabelsMatcher) bool {
+	ol, ok := other.(labelMatcher)
+	if !ok {
+		return false
+	}
+	return l.key == ol.key && l.matcher.Equals(ol.matcher)
+}
+
+// ValueMatcher represents a matcher for a specific value.
+//
+// Multiple implementations are provided for different types of matchers.
+type ValueMatcher interface {
+	Matches(value string) bool
+	Equals(other ValueMatcher) bool
+}
+
+// stringMatcher is a matcher for a list of strings.
+//
+// It matches if the value is in the list of strings.
+type stringMatcher []string
+
+func (s stringMatcher) Matches(value string) bool {
+	return slices.Contains(s, value)
+}
+
+// Equals implements the ValueMatcher interface.
+func (s stringMatcher) Equals(other ValueMatcher) bool {
+	o, ok := other.(stringMatcher)
+	if !ok {
+		return false
+	}
+	return equalsNoOrder(s, o)
+}
+
+// regexpMatcher is a matcher for a list of regular expressions.
+//
+// It matches if the value matches any of the regular expressions.
+type regexpMatcher []*regexp.Regexp
+
+func (r regexpMatcher) Matches(value string) bool {
+	for _, re := range r {
+		if re.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Equals implements the ValueMatcher interface.
+func (r regexpMatcher) Equals(other ValueMatcher) bool {
+	o, ok := other.(regexpMatcher)
+	if !ok {
+		return false
+	}
+	s1 := make([]string, 0, len(r))
+	for _, re := range r {
+		s1 = append(s1, re.String())
+	}
+	s2 := make([]string, 0, len(o))
+	for _, re := range o {
+		s2 = append(s2, re.String())
+	}
+	return equalsNoOrder(s1, s2)
+}
+
+func equalsNoOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	seen := make(map[string]int, len(a))
+	for _, v := range a {
+		seen[v]++
+	}
+	for _, v := range b {
+		if seen[v] == 0 {
+			return false
+		}
+		seen[v]--
+	}
+	return true
+}
+
+// componentMatcher represents a matcher definition for a component.
+//
+// It matches if any of the label matchers match the labels.
+type componentMatcher struct {
+	component string
+	matchers  []LabelsMatcher
+}
+
+// findComponent tries to determine a component for given labels using the provided matchers.
+//
+// It returns the component and the keys that matched.
+// If no match is found, it returns an empty component and nil keys.
+func findComponent(compMatchers []componentMatcher, labels model.LabelSet) (
+	component string, keys []model.LabelName) {
+	for _, compMatcher := range compMatchers {
+		for _, labelsMatcher := range compMatcher.matchers {
+			if matches, keys := labelsMatcher.Matches(labels); matches {
+				return compMatcher.component, keys
+			}
+		}
+	}
+	return "", nil
+}
+
+// componentMatcherFn is a function that tries matching provided labels to a component.
+// It returns the layer, component and the keys from the labels that were used for matching.
+// If no match is found, it returns an empty layer, component and nil keys.
+type componentMatcherFn func(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName)
+
+func evalMatcherFns(fns []componentMatcherFn, labels model.LabelSet) (
+	layer, comp string, labelsSubset model.LabelSet) {
+	for _, fn := range fns {
+		if layer, comp, keys := fn(labels); layer != "" {
+			return string(layer), string(comp), getLabelsSubset(labels, keys...)
+		}
+	}
+	return "Others", "Others", getLabelsSubset(labels)
+}
+
+// getLabelsSubset returns a subset of the labels with given keys.
+func getLabelsSubset(m model.LabelSet, keys ...model.LabelName) model.LabelSet {
+	keys = append([]model.LabelName{
+		model.LabelName(labelNamespace),
+		model.LabelName(managementlabels.AlertNameLabel),
+		model.LabelName(labelSeverity),
+	}, keys...)
+	return getMapSubset(m, keys...)
+}
+
+// getMapSubset returns a subset of the labels with given keys.
+func getMapSubset(m model.LabelSet, keys ...model.LabelName) model.LabelSet {
+	subset := make(model.LabelSet, len(keys))
+	for _, key := range keys {
+		if val, ok := m[key]; ok {
+			subset[key] = val
+		}
+	}
+	return subset
+}
+
+var (
+	nodeAlerts []model.LabelValue = []model.LabelValue{
+		"NodeClockNotSynchronising",
+		"KubeNodeNotReady",
+		"KubeNodeUnreachable",
+		"NodeSystemSaturation",
+		"NodeFilesystemSpaceFillingUp",
+		"NodeFilesystemAlmostOutOfSpace",
+		"NodeMemoryMajorPagesFaults",
+		"NodeNetworkTransmitErrs",
+		"NodeTextFileCollectorScrapeError",
+		"NodeFilesystemFilesFillingUp",
+		"NodeNetworkReceiveErrs",
+		"NodeClockSkewDetected",
+		"NodeFilesystemAlmostOutOfFiles",
+		"NodeWithoutOVNKubeNodePodRunning",
+		"InfraNodesNeedResizingSRE",
+		"NodeHighNumberConntrackEntriesUsed",
+		"NodeMemHigh",
+		"NodeNetworkInterfaceFlapping",
+		"NodeWithoutSDNPod",
+		"NodeCpuHigh",
+		"CriticalNodeNotReady",
+		"NodeFileDescriptorLimit",
+		"MCCPoolAlert",
+		"MCCDrainError",
+		"MCDRebootError",
+		"MCDPivotError",
+	}
+
+	coreMatchers = []componentMatcher{
+		componentRule("etcd", namespaceMatcher("openshift-etcd", "openshift-etcd-operator")),
+		componentRule("kube-apiserver", namespaceMatcher("openshift-kube-apiserver", "openshift-kube-apiserver-operator")),
+		componentRule("kube-controller-manager", namespaceMatcher("openshift-kube-controller-manager", "openshift-kube-controller-manager-operator", "kube-system")),
+		componentRule("kube-scheduler", namespaceMatcher("openshift-kube-scheduler", "openshift-kube-scheduler-operator")),
+		componentRule("machine-approver", namespaceMatcher("openshift-cluster-machine-approver", "openshift-machine-approver-operator")),
+		componentRule("machine-config",
+			namespaceMatcher("openshift-machine-config-operator"),
+			alertNameMatcher(
+				"HighOverallControlPlaneMemory",
+				"ExtremelyHighIndividualControlPlaneMemory",
+				"MissingMachineConfig",
+				"MCCBootImageUpdateError",
+				"KubeletHealthState",
+				"SystemMemoryExceedsReservation",
+			),
+		),
+		componentRule("version",
+			namespaceMatcher("openshift-cluster-version", "openshift-version-operator"),
+			alertNameMatcher("ClusterNotUpgradeable", "UpdateAvailable"),
+		),
+		componentRule("dns", namespaceMatcher("openshift-dns", "openshift-dns-operator")),
+		componentRule("authentication", namespaceMatcher("openshift-authentication", "openshift-oauth-apiserver", "openshift-authentication-operator")),
+		componentRule("cert-manager", namespaceMatcher("openshift-cert-manager", "openshift-cert-manager-operator")),
+		componentRule("cloud-controller-manager", namespaceMatcher("openshift-cloud-controller-manager", "openshift-cloud-controller-manager-operator")),
+		componentRule("cloud-credential", namespaceMatcher("openshift-cloud-credential-operator")),
+		componentRule("cluster-api", namespaceMatcher("openshift-cluster-api", "openshift-cluster-api-operator")),
+		componentRule("config-operator", namespaceMatcher("openshift-config-operator")),
+		componentRule("kube-storage-version-migrator", namespaceMatcher("openshift-kube-storage-version-migrator", "openshift-kube-storage-version-migrator-operator")),
+		componentRule("image-registry", namespaceMatcher("openshift-image-registry", "openshift-image-registry-operator")),
+		componentRule("ingress", namespaceMatcher("openshift-ingress", "openshift-route-controller-manager", "openshift-ingress-canary", "openshift-ingress-operator")),
+		componentRule("console", namespaceMatcher("openshift-console", "openshift-console-operator")),
+		componentRule("insights", namespaceMatcher("openshift-insights", "openshift-insights-operator")),
+		componentRule("machine-api", namespaceMatcher("openshift-machine-api", "openshift-machine-api-operator")),
+		componentRule("monitoring", namespaceMatcher(ClusterMonitoringNamespace, "openshift-monitoring-operator")),
+		componentRule("network", namespaceMatcher("openshift-network-operator", "openshift-ovn-kubernetes", "openshift-multus", "openshift-network-diagnostics", "openshift-sdn")),
+		componentRule("node-tuning", namespaceMatcher("openshift-cluster-node-tuning-operator", "openshift-node-tuning-operator")),
+		componentRule("openshift-apiserver", namespaceMatcher("openshift-apiserver", "openshift-apiserver-operator")),
+		componentRule("openshift-controller-manager", namespaceMatcher("openshift-controller-manager", "openshift-controller-manager-operator")),
+		componentRule("openshift-samples", namespaceMatcher("openshift-cluster-samples-operator", "openshift-samples-operator")),
+		componentRule("operator-lifecycle-manager", namespaceMatcher("openshift-operator-lifecycle-manager")),
+		componentRule("service-ca", namespaceMatcher("openshift-service-ca", "openshift-service-ca-operator")),
+		componentRule("storage", namespaceMatcher("openshift-storage", "openshift-cluster-csi-drivers", "openshift-cluster-storage-operator", "openshift-storage-operator")),
+		componentRule("vertical-pod-autoscaler", namespaceMatcher("openshift-vertical-pod-autoscaler", "openshift-vertical-pod-autoscaler-operator")),
+		componentRule("marketplace", namespaceMatcher("openshift-marketplace", "openshift-marketplace-operator")),
+	}
+
+	workloadMatchers = []componentMatcher{
+		componentRule("openshift-compliance", namespaceMatcher("openshift-compliance")),
+		componentRule("openshift-file-integrity", namespaceMatcher("openshift-file-integrity")),
+		componentRule("openshift-logging", namespaceMatcher("openshift-logging")),
+		componentRule("openshift-user-workload-monitoring", namespaceMatcher(UserWorkloadMonitoringNamespace)),
+		componentRule("openshift-gitops", namespaceMatcher("openshift-gitops", "openshift-gitops-operator")),
+		componentRule("openshift-operators", namespaceMatcher("openshift-operators")),
+		componentRule("openshift-local-storage", namespaceMatcher("openshift-local-storage")),
+		componentRule("quay", labelValueMatcher("container", "quay-app", "quay-mirror", "quay-app-upgrade")),
+		componentRule("Argo", regexAlertNameMatcher(regexp.MustCompile("^Argo"))),
+	}
+)
+
+var cvoAlerts = []model.LabelValue{"ClusterOperatorDown", "ClusterOperatorDegraded"}
+
+func cvoAlertsMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	if slices.Contains(cvoAlerts, labels[managementlabels.AlertNameLabel]) {
+		component := labels["name"]
+		if component == "" {
+			component = "version"
+		}
+		return "cluster", component, nil
+	}
+	return "", "", nil
+}
+
+func kubevirtOperatorMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	if labels["kubernetes_operator_part_of"] != "kubevirt" {
+		return "", "", nil
+	}
+	if labels["kubernetes_operator_component"] == "cnv-observability" {
+		return "", "", nil
+	}
+	if labels["operator_health_impact"] == "none" && labels["kubernetes_operator_component"] == "kubevirt" {
+		return "namespace", "OpenShift Virtualization Virtual Machine", []model.LabelName{
+			"kubernetes_operator_part_of",
+			"kubernetes_operator_component",
+			"operator_health_impact",
+		}
+	}
+	return "cluster", "OpenShift Virtualization Operator", []model.LabelName{
+		"kubernetes_operator_part_of",
+		"kubernetes_operator_component",
+		"operator_health_impact",
+	}
+}
+
+func computeMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	if slices.Contains(nodeAlerts, labels[managementlabels.AlertNameLabel]) {
+		return "cluster", "compute", nil
+	}
+	return "", "", nil
+}
+
+func coreMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	// Try matching against core components.
+	if component, keys := findComponent(coreMatchers, labels); component != "" {
+		return "cluster", model.LabelValue(component), keys
+	}
+	return "", "", nil
+}
+
+func workloadMatcher(labels model.LabelSet) (layer, comp model.LabelValue, keys []model.LabelName) {
+	// Try matching against workload components.
+	if component, keys := findComponent(workloadMatchers, labels); component != "" {
+		return "namespace", model.LabelValue(component), keys
+	}
+	return "", "", nil
+}
+
+// DetermineComponent determines the component for a given set of labels.
+// It returns the layer and component strings.
+func DetermineComponent(labels model.LabelSet) (layer, component string) {
+	layer, component, _ = evalMatcherFns([]componentMatcherFn{
+		cvoAlertsMatcher,
+		kubevirtOperatorMatcher,
+		computeMatcher,
+		coreMatcher,
+		workloadMatcher,
+	}, labels)
+	return layer, component
+}

--- a/pkg/alertcomponent/matcher_test.go
+++ b/pkg/alertcomponent/matcher_test.go
@@ -1,0 +1,400 @@
+package alertcomponent
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+func TestDetermineComponent_CoreComponents(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        model.LabelSet
+		wantLayer     string
+		wantComponent string
+	}{
+		{
+			name: "etcd namespace",
+			labels: model.LabelSet{
+				"namespace": "openshift-etcd",
+				model.LabelName(managementlabels.AlertNameLabel): "etcdMembersDown",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "etcd",
+		},
+		{
+			name: "kube-apiserver operator namespace",
+			labels: model.LabelSet{
+				"namespace": "openshift-kube-apiserver-operator",
+				model.LabelName(managementlabels.AlertNameLabel): "SomeAlert",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "kube-apiserver",
+		},
+		{
+			name: "monitoring namespace",
+			labels: model.LabelSet{
+				"namespace": "openshift-monitoring",
+				model.LabelName(managementlabels.AlertNameLabel): "PrometheusDown",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "monitoring",
+		},
+		{
+			name: "monitoring-operator namespace",
+			labels: model.LabelSet{
+				"namespace": "openshift-monitoring-operator",
+				model.LabelName(managementlabels.AlertNameLabel): "SomeAlert",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "monitoring",
+		},
+		{
+			name: "machine-config by alert name",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "KubeletHealthState",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "machine-config",
+		},
+		{
+			name: "version by alert name",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "ClusterNotUpgradeable",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "version",
+		},
+		{
+			name: "ingress namespace",
+			labels: model.LabelSet{
+				"namespace": "openshift-ingress",
+				model.LabelName(managementlabels.AlertNameLabel): "IngressDown",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "ingress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, component := DetermineComponent(tt.labels)
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if component != tt.wantComponent {
+				t.Errorf("component = %q, want %q", component, tt.wantComponent)
+			}
+		})
+	}
+}
+
+func TestDetermineComponent_WorkloadComponents(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        model.LabelSet
+		wantLayer     string
+		wantComponent string
+	}{
+		{
+			name: "openshift-logging",
+			labels: model.LabelSet{
+				"namespace": "openshift-logging",
+				model.LabelName(managementlabels.AlertNameLabel): "FluentdDown",
+			},
+			wantLayer:     "namespace",
+			wantComponent: "openshift-logging",
+		},
+		{
+			name: "user workload monitoring",
+			labels: model.LabelSet{
+				"namespace": UserWorkloadMonitoringNamespace,
+				model.LabelName(managementlabels.AlertNameLabel): "SomeAlert",
+			},
+			wantLayer:     "namespace",
+			wantComponent: "openshift-user-workload-monitoring",
+		},
+		{
+			name: "quay by container label",
+			labels: model.LabelSet{
+				"container": "quay-app",
+				model.LabelName(managementlabels.AlertNameLabel): "QuayDown",
+			},
+			wantLayer:     "namespace",
+			wantComponent: "quay",
+		},
+		{
+			name: "Argo alert name regex",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "ArgoWorkflowFailed",
+			},
+			wantLayer:     "namespace",
+			wantComponent: "Argo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, component := DetermineComponent(tt.labels)
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if component != tt.wantComponent {
+				t.Errorf("component = %q, want %q", component, tt.wantComponent)
+			}
+		})
+	}
+}
+
+func TestDetermineComponent_CVO(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        model.LabelSet
+		wantLayer     string
+		wantComponent string
+	}{
+		{
+			name: "ClusterOperatorDown with name",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "ClusterOperatorDown",
+				"name": "etcd",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "etcd",
+		},
+		{
+			name: "ClusterOperatorDegraded with name",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "ClusterOperatorDegraded",
+				"name": "monitoring",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "monitoring",
+		},
+		{
+			name: "ClusterOperatorDown without name falls back to version",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "ClusterOperatorDown",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, component := DetermineComponent(tt.labels)
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if component != tt.wantComponent {
+				t.Errorf("component = %q, want %q", component, tt.wantComponent)
+			}
+		})
+	}
+}
+
+func TestDetermineComponent_KubevirtOperator(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        model.LabelSet
+		wantLayer     string
+		wantComponent string
+	}{
+		{
+			name: "kubevirt VM alert",
+			labels: model.LabelSet{
+				"kubernetes_operator_part_of":                    "kubevirt",
+				"kubernetes_operator_component":                  "kubevirt",
+				"operator_health_impact":                         "none",
+				model.LabelName(managementlabels.AlertNameLabel): "VMDown",
+			},
+			wantLayer:     "namespace",
+			wantComponent: "OpenShift Virtualization Virtual Machine",
+		},
+		{
+			name: "kubevirt operator alert",
+			labels: model.LabelSet{
+				"kubernetes_operator_part_of":                    "kubevirt",
+				"kubernetes_operator_component":                  "virt-operator",
+				"operator_health_impact":                         "critical",
+				model.LabelName(managementlabels.AlertNameLabel): "VirtOperatorDown",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "OpenShift Virtualization Operator",
+		},
+		{
+			name: "cnv-observability skipped",
+			labels: model.LabelSet{
+				"kubernetes_operator_part_of":                    "kubevirt",
+				"kubernetes_operator_component":                  "cnv-observability",
+				"namespace":                                      "openshift-monitoring",
+				model.LabelName(managementlabels.AlertNameLabel): "MonitoringAlert",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "monitoring",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, component := DetermineComponent(tt.labels)
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if component != tt.wantComponent {
+				t.Errorf("component = %q, want %q", component, tt.wantComponent)
+			}
+		})
+	}
+}
+
+func TestDetermineComponent_Compute(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        model.LabelSet
+		wantLayer     string
+		wantComponent string
+	}{
+		{
+			name: "node alert",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "KubeNodeNotReady",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "compute",
+		},
+		{
+			name: "node filesystem alert",
+			labels: model.LabelSet{
+				model.LabelName(managementlabels.AlertNameLabel): "NodeFilesystemSpaceFillingUp",
+			},
+			wantLayer:     "cluster",
+			wantComponent: "compute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, component := DetermineComponent(tt.labels)
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if component != tt.wantComponent {
+				t.Errorf("component = %q, want %q", component, tt.wantComponent)
+			}
+		})
+	}
+}
+
+func TestDetermineComponent_Fallback(t *testing.T) {
+	labels := model.LabelSet{
+		model.LabelName(managementlabels.AlertNameLabel): "CustomAlert",
+		"namespace": "my-app",
+	}
+	layer, component := DetermineComponent(labels)
+	if layer != "Others" {
+		t.Errorf("layer = %q, want %q", layer, "Others")
+	}
+	if component != "Others" {
+		t.Errorf("component = %q, want %q", component, "Others")
+	}
+}
+
+func TestStringMatcher(t *testing.T) {
+	m := NewStringValuesMatcher("a", "b", "c")
+
+	if !m.Matches("a") {
+		t.Error("expected 'a' to match")
+	}
+	if !m.Matches("c") {
+		t.Error("expected 'c' to match")
+	}
+	if m.Matches("d") {
+		t.Error("expected 'd' not to match")
+	}
+	if m.Matches("") {
+		t.Error("expected empty string not to match")
+	}
+}
+
+func TestRegexpMatcher(t *testing.T) {
+	m := NewRegexValuesMatcher(regexp.MustCompile("^Argo"), regexp.MustCompile("^Kube"))
+
+	if !m.Matches("ArgoWorkflow") {
+		t.Error("expected 'ArgoWorkflow' to match")
+	}
+	if !m.Matches("KubeNodeNotReady") {
+		t.Error("expected 'KubeNodeNotReady' to match")
+	}
+	if m.Matches("PrometheusDown") {
+		t.Error("expected 'PrometheusDown' not to match")
+	}
+}
+
+func TestLabelsMatcher(t *testing.T) {
+	m := NewLabelsMatcher("namespace", NewStringValuesMatcher("openshift-etcd", "openshift-monitoring"))
+
+	match, keys := m.Matches(model.LabelSet{"namespace": "openshift-etcd"})
+	if !match {
+		t.Error("expected match for openshift-etcd")
+	}
+	if len(keys) != 1 || keys[0] != "namespace" {
+		t.Errorf("unexpected keys: %v", keys)
+	}
+
+	match, _ = m.Matches(model.LabelSet{"namespace": "default"})
+	if match {
+		t.Error("expected no match for default namespace")
+	}
+
+	match, _ = m.Matches(model.LabelSet{})
+	if match {
+		t.Error("expected no match for empty labels")
+	}
+}
+
+func TestEqualsNoOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"same order", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"different order", []string{"b", "a"}, []string{"a", "b"}, true},
+		{"different length", []string{"a"}, []string{"a", "b"}, false},
+		{"different values", []string{"a", "c"}, []string{"a", "b"}, false},
+		{"empty slices", []string{}, []string{}, true},
+		{"duplicates", []string{"a", "a"}, []string{"a", "a"}, true},
+		{"mismatched duplicates", []string{"a", "a"}, []string{"a", "b"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalsNoOrder(tt.a, tt.b); got != tt.want {
+				t.Errorf("equalsNoOrder(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValueMatcherEquals(t *testing.T) {
+	s1 := NewStringValuesMatcher("a", "b")
+	s2 := NewStringValuesMatcher("b", "a")
+	s3 := NewStringValuesMatcher("a", "c")
+
+	if !s1.Equals(s2) {
+		t.Error("expected s1 to equal s2 (order-independent)")
+	}
+	if s1.Equals(s3) {
+		t.Error("expected s1 not to equal s3")
+	}
+
+	r1 := NewRegexValuesMatcher(regexp.MustCompile("^Argo"))
+	if s1.Equals(r1) {
+		t.Error("expected string matcher not to equal regexp matcher")
+	}
+}

--- a/pkg/k8s/alerting_health.go
+++ b/pkg/k8s/alerting_health.go
@@ -1,0 +1,127 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	clusterMonitoringConfigMap = "cluster-monitoring-config"
+	clusterMonitoringConfigKey = "config.yaml"
+)
+
+type clusterMonitoringConfig struct {
+	EnableUserWorkload bool `yaml:"enableUserWorkload"`
+}
+
+// clusterMonitoringConfigManager watches the cluster-monitoring-config ConfigMap
+// via an informer and caches the parsed enableUserWorkload value so that
+// AlertingHealth never needs a live API call.
+type clusterMonitoringConfigManager struct {
+	informer cache.SharedIndexInformer
+
+	mu      sync.RWMutex
+	enabled bool
+	err     error
+}
+
+func newClusterMonitoringConfigManager(ctx context.Context, clientset *kubernetes.Clientset) (*clusterMonitoringConfigManager, error) {
+	informer := cache.NewSharedIndexInformer(
+		cache.NewListWatchFromClient(
+			clientset.CoreV1().RESTClient(),
+			"configmaps",
+			ClusterMonitoringNamespace,
+			fields.OneTermEqualSelector("metadata.name", clusterMonitoringConfigMap),
+		),
+		&corev1.ConfigMap{},
+		0,
+		cache.Indexers{},
+	)
+
+	m := &clusterMonitoringConfigManager{
+		informer: informer,
+	}
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			m.handleUpdate(cm)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			cm, ok := newObj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			m.handleUpdate(cm)
+		},
+		DeleteFunc: func(_ interface{}) {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.enabled = false
+			m.err = nil
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler to cluster-monitoring-config informer: %w", err)
+	}
+
+	go informer.Run(ctx.Done())
+
+	if !cache.WaitForNamedCacheSync("ClusterMonitoringConfig informer", ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("failed to sync ClusterMonitoringConfig informer")
+	}
+
+	return m, nil
+}
+
+func (m *clusterMonitoringConfigManager) handleUpdate(cm *corev1.ConfigMap) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	raw, ok := cm.Data[clusterMonitoringConfigKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		m.enabled = false
+		m.err = nil
+		return
+	}
+
+	var cfg clusterMonitoringConfig
+	if err := yaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		m.enabled = false
+		m.err = fmt.Errorf("parse cluster monitoring config.yaml: %w", err)
+		return
+	}
+
+	m.enabled = cfg.EnableUserWorkload
+	m.err = nil
+}
+
+func (m *clusterMonitoringConfigManager) userWorkloadEnabled() (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.enabled, m.err
+}
+
+// AlertingHealth returns alerting route health and UWM enablement status.
+func (c *client) AlertingHealth(ctx context.Context) (AlertingHealth, error) {
+	health := c.prometheusAlerts.alertingHealth(ctx)
+
+	enabled, err := c.clusterMonitoringConfig.userWorkloadEnabled()
+	if err != nil {
+		return health, fmt.Errorf("failed to determine user workload enablement: %w", err)
+	}
+	health.UserWorkloadEnabled = enabled
+
+	return health, nil
+}

--- a/pkg/k8s/alerting_health.go
+++ b/pkg/k8s/alerting_health.go
@@ -1,0 +1,131 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	clusterMonitoringConfigMap = "cluster-monitoring-config"
+	clusterMonitoringConfigKey = "config.yaml"
+)
+
+type clusterMonitoringConfig struct {
+	EnableUserWorkload bool `yaml:"enableUserWorkload"`
+}
+
+// clusterMonitoringConfigManager watches the cluster-monitoring-config ConfigMap
+// via an informer and caches the parsed enableUserWorkload value so that
+// AlertingHealth never needs a live API call.
+type clusterMonitoringConfigManager struct {
+	informer cache.SharedIndexInformer
+
+	mu      sync.RWMutex
+	enabled bool
+	err     error
+}
+
+func newClusterMonitoringConfigManager(ctx context.Context, clientset *kubernetes.Clientset) (*clusterMonitoringConfigManager, error) {
+	informer := cache.NewSharedIndexInformer(
+		cache.NewListWatchFromClient(
+			clientset.CoreV1().RESTClient(),
+			"configmaps",
+			ClusterMonitoringNamespace,
+			fields.OneTermEqualSelector("metadata.name", clusterMonitoringConfigMap),
+		),
+		&corev1.ConfigMap{},
+		0,
+		cache.Indexers{},
+	)
+
+	m := &clusterMonitoringConfigManager{
+		informer: informer,
+	}
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			m.handleUpdate(cm)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			cm, ok := newObj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			m.handleUpdate(cm)
+		},
+		DeleteFunc: func(_ interface{}) {
+			m.handleDelete()
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler to cluster-monitoring-config informer: %w", err)
+	}
+
+	go informer.Run(ctx.Done())
+
+	if !cache.WaitForNamedCacheSync("ClusterMonitoringConfig informer", ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("failed to sync ClusterMonitoringConfig informer")
+	}
+
+	return m, nil
+}
+
+func (m *clusterMonitoringConfigManager) handleDelete() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.enabled = false
+	m.err = nil
+}
+
+func (m *clusterMonitoringConfigManager) handleUpdate(cm *corev1.ConfigMap) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	raw, ok := cm.Data[clusterMonitoringConfigKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		m.enabled = false
+		m.err = nil
+		return
+	}
+
+	var cfg clusterMonitoringConfig
+	if err := yaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		m.enabled = false
+		m.err = fmt.Errorf("parse cluster monitoring config.yaml: %w", err)
+		return
+	}
+
+	m.enabled = cfg.EnableUserWorkload
+	m.err = nil
+}
+
+func (m *clusterMonitoringConfigManager) userWorkloadEnabled() (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.enabled, m.err
+}
+
+// AlertingHealth returns alerting route health and UWM enablement status.
+func (c *client) AlertingHealth(ctx context.Context) (AlertingHealth, error) {
+	health := c.prometheusAlerts.alertingHealth(ctx)
+
+	enabled, err := c.clusterMonitoringConfig.userWorkloadEnabled()
+	if err != nil {
+		return health, fmt.Errorf("failed to determine user workload enablement: %w", err)
+	}
+	health.UserWorkloadEnabled = enabled
+
+	return health, nil
+}

--- a/pkg/k8s/alerting_health_test.go
+++ b/pkg/k8s/alerting_health_test.go
@@ -1,0 +1,171 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestConfigManager() *clusterMonitoringConfigManager {
+	return &clusterMonitoringConfigManager{}
+}
+
+func configMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterMonitoringConfigMap,
+			Namespace: ClusterMonitoringNamespace,
+		},
+		Data: data,
+	}
+}
+
+func TestHandleUpdate_EnableUserWorkload(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: true",
+	}))
+
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected userWorkloadEnabled=true")
+	}
+}
+
+func TestHandleUpdate_DisableUserWorkload(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: false",
+	}))
+
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false")
+	}
+}
+
+func TestHandleUpdate_MissingConfigKey(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		"other-key": "irrelevant",
+	}))
+
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false when config key is missing")
+	}
+}
+
+func TestHandleUpdate_EmptyConfigValue(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "   ",
+	}))
+
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false when config value is blank")
+	}
+}
+
+func TestHandleUpdate_InvalidYAML(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "{{invalid yaml",
+	}))
+
+	enabled, err := m.userWorkloadEnabled()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false on parse error")
+	}
+}
+
+func TestHandleUpdate_DeleteResetsEnabled(t *testing.T) {
+	m := newTestConfigManager()
+
+	// First enable UWM.
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: true",
+	}))
+	if enabled, _ := m.userWorkloadEnabled(); !enabled {
+		t.Fatal("precondition: expected enabled=true after setting it")
+	}
+
+	// Simulate ConfigMap deletion via the delete handler.
+	m.handleDelete()
+
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false after deletion")
+	}
+}
+
+func TestHandleUpdate_TransitionsEnabledToDisabled(t *testing.T) {
+	m := newTestConfigManager()
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: true",
+	}))
+	if enabled, _ := m.userWorkloadEnabled(); !enabled {
+		t.Fatal("precondition: expected enabled=true")
+	}
+
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: false",
+	}))
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected userWorkloadEnabled=false after update")
+	}
+}
+
+func TestHandleUpdate_ErrorClearedByValidUpdate(t *testing.T) {
+	m := newTestConfigManager()
+
+	// First inject a parse error.
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "{{bad yaml",
+	}))
+	if _, err := m.userWorkloadEnabled(); err == nil {
+		t.Fatal("precondition: expected error after bad YAML")
+	}
+
+	// Now send a valid config.
+	m.handleUpdate(configMap(map[string]string{
+		clusterMonitoringConfigKey: "enableUserWorkload: true",
+	}))
+	enabled, err := m.userWorkloadEnabled()
+	if err != nil {
+		t.Fatalf("expected no error after valid update, got: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected userWorkloadEnabled=true")
+	}
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	osmv1client "github.com/openshift/client-go/monitoring/clientset/versioned"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	monitoringv1client "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -21,11 +22,14 @@ type client struct {
 	osmv1clientset        *osmv1client.Clientset
 	config                *rest.Config
 
+	prometheusAlerts *prometheusAlerts
+
 	prometheusRuleManager     *prometheusRuleManager
 	alertRelabelConfigManager *alertRelabelConfigManager
 	alertingRuleManager       *alertingRuleManager
 	namespaceManager          *namespaceManager
 	relabeledRulesManager     *relabeledRulesManager
+	clusterMonitoringConfig   *clusterMonitoringConfigManager
 }
 
 func NewClient(ctx context.Context, config *rest.Config) (Client, error) {
@@ -44,6 +48,11 @@ func NewClient(ctx context.Context, config *rest.Config) (Client, error) {
 		return nil, fmt.Errorf("failed to create osmv1 clientset: %w", err)
 	}
 
+	routeClientset, err := routeclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create route clientset: %w", err)
+	}
+
 	c := &client{
 		clientset:             clientset,
 		monitoringv1clientset: monitoringv1clientset,
@@ -55,6 +64,8 @@ func NewClient(ctx context.Context, config *rest.Config) (Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PrometheusRule manager: %w", err)
 	}
+
+	c.prometheusAlerts = newPrometheusAlerts(routeClientset, clientset.CoreV1(), config, c.prometheusRuleManager)
 
 	c.alertRelabelConfigManager, err = newAlertRelabelConfigManager(ctx, osmv1clientset, config)
 	if err != nil {
@@ -71,6 +82,11 @@ func NewClient(ctx context.Context, config *rest.Config) (Client, error) {
 		return nil, fmt.Errorf("failed to create namespace manager: %w", err)
 	}
 
+	c.clusterMonitoringConfig, err = newClusterMonitoringConfigManager(ctx, clientset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cluster monitoring config manager: %w", err)
+	}
+
 	c.relabeledRulesManager, err = newRelabeledRulesManager(ctx, c.namespaceManager, c.alertRelabelConfigManager, monitoringv1clientset, clientset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create relabeled rules config manager: %w", err)
@@ -85,6 +101,10 @@ func (c *client) TestConnection(_ context.Context) error {
 		return fmt.Errorf("failed to connect to cluster: %w", err)
 	}
 	return nil
+}
+
+func (c *client) PrometheusAlerts() PrometheusAlertsInterface {
+	return c.prometheusAlerts
 }
 
 func (c *client) PrometheusRules() PrometheusRuleInterface {

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -1,5 +1,31 @@
 package k8s
 
 const (
-	ClusterMonitoringNamespace = "openshift-monitoring"
+	ClusterMonitoringNamespace      = "openshift-monitoring"
+	UserWorkloadMonitoringNamespace = "openshift-user-workload-monitoring"
+
+	PlatformRouteName                 = "prometheus-k8s"
+	PlatformAlertmanagerRouteName     = "alertmanager-main"
+	UserWorkloadRouteName             = "prometheus-user-workload"
+	UserWorkloadAlertmanagerRouteName = "alertmanager-user-workload"
+	PrometheusAlertsPath              = "/v1/alerts"
+	PrometheusRulesPath               = "/v1/rules"
+	AlertmanagerAlertsPath            = "/api/v2/alerts"
+	UserWorkloadAlertmanagerPort      = 9095
+	UserWorkloadPrometheusServiceName = "prometheus-user-workload-web"
+	UserWorkloadPrometheusPort        = 9090
+
+	ThanosQuerierServiceName             = "thanos-querier"
+	DefaultThanosQuerierTenancyRulesPort = 9093
+	ThanosQuerierTenancyAlertsPath       = "/api/v1/alerts"
+	ThanosQuerierTenancyRulesPath        = "/api/v1/rules"
+	ServiceCAPath                        = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
+	AlertSourceLabel    = "openshift_io_alert_source"
+	AlertSourcePlatform = "platform"
+	AlertSourceUser     = "user"
+	AlertBackendLabel   = "openshift_io_alert_backend"
+	AlertBackendAM      = "alertmanager"
+	AlertBackendProm    = "prometheus"
+	AlertBackendThanos  = "thanos"
 )

--- a/pkg/k8s/prometheus_alerts.go
+++ b/pkg/k8s/prometheus_alerts.go
@@ -1,0 +1,949 @@
+package k8s
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+var prometheusLog = logrus.WithField("module", "k8s-prometheus")
+
+const (
+	namespaceCacheTTL      = 30 * time.Second
+	serviceHealthTimeout   = 5 * time.Second
+	serviceRequestTimeout  = 10 * time.Second
+	maxTenancyProbeTargets = 3
+)
+
+type namespaceCache struct {
+	mu        sync.Mutex
+	expiresAt time.Time
+	ttl       time.Duration
+	value     []string
+}
+
+func newNamespaceCache(ttl time.Duration) *namespaceCache {
+	return &namespaceCache{ttl: ttl}
+}
+
+func (c *namespaceCache) get() ([]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.expiresAt.IsZero() || time.Now().After(c.expiresAt) {
+		return nil, false
+	}
+	return copyStringSlice(c.value), true
+}
+
+func (c *namespaceCache) set(namespaces []string) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.value = copyStringSlice(namespaces)
+	c.expiresAt = time.Now().Add(c.ttl)
+}
+
+type prometheusAlerts struct {
+	routeClient routeclient.Interface
+	coreClient  corev1client.CoreV1Interface
+	config      *rest.Config
+	ruleManager PrometheusRuleInterface
+	nsCache     *namespaceCache
+}
+
+// GetAlertsRequest holds parameters for filtering alerts
+type GetAlertsRequest struct {
+	// Labels filters alerts by labels
+	Labels map[string]string
+	// State filters alerts by state: "firing", "pending", "silenced", or "" for all states
+	State string
+}
+
+type PrometheusAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	State       string            `json:"state"`
+	ActiveAt    time.Time         `json:"activeAt"`
+	Value       string            `json:"value"`
+
+	AlertRuleId    string `json:"alertRuleId,omitempty"`
+	AlertComponent string `json:"alertComponent,omitempty"`
+	AlertLayer     string `json:"alertLayer,omitempty"`
+}
+
+type prometheusAlertsData struct {
+	Alerts []PrometheusAlert `json:"alerts"`
+}
+
+type prometheusAlertsResponse struct {
+	Status string               `json:"status"`
+	Data   prometheusAlertsData `json:"data"`
+}
+
+type prometheusRulesData struct {
+	Groups []PrometheusRuleGroup `json:"groups"`
+}
+
+type prometheusRulesResponse struct {
+	Status string              `json:"status"`
+	Data   prometheusRulesData `json:"data"`
+}
+
+type alertmanagerAlertStatus struct {
+	State string `json:"state"`
+}
+
+type alertmanagerAlert struct {
+	Labels       map[string]string       `json:"labels"`
+	Annotations  map[string]string       `json:"annotations"`
+	StartsAt     time.Time               `json:"startsAt"`
+	EndsAt       time.Time               `json:"endsAt"`
+	GeneratorURL string                  `json:"generatorURL"`
+	Status       alertmanagerAlertStatus `json:"status"`
+}
+
+func newPrometheusAlerts(routeClient routeclient.Interface, coreClient corev1client.CoreV1Interface, config *rest.Config, ruleManager PrometheusRuleInterface) *prometheusAlerts {
+	return &prometheusAlerts{
+		routeClient: routeClient,
+		coreClient:  coreClient,
+		config:      config,
+		ruleManager: ruleManager,
+		nsCache:     newNamespaceCache(namespaceCacheTTL),
+	}
+}
+
+func (pa *prometheusAlerts) GetAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, error) {
+	platformAlerts, err := pa.getAlertsForSource(ctx, ClusterMonitoringNamespace, PlatformRouteName, PlatformAlertmanagerRouteName, AlertSourcePlatform)
+	if err != nil {
+		// Namespace-scoped callers (Thanos tenancy) often lack platform
+		// Prometheus access. Soft-fail so tenancy results are still returned.
+		if namespaceFromLabels(req.Labels) == "" {
+			return nil, err
+		}
+		prometheusLog.Warnf("failed to get platform alerts (continuing with namespace filter): %v", err)
+	}
+
+	userAlerts, err := pa.getUserWorkloadAlerts(ctx, req)
+	if err != nil {
+		prometheusLog.Warnf("failed to get user workload alerts: %v", err)
+	}
+
+	mergedAlerts := append(platformAlerts, userAlerts...)
+
+	out := make([]PrometheusAlert, 0, len(mergedAlerts))
+	for _, a := range mergedAlerts {
+		// Filter alerts based on state if provided
+		if !matchesAlertState(req.State, a.State) {
+			continue
+		}
+
+		// Filter alerts based on labels if provided
+		if !labelsMatch(&req, &a) {
+			continue
+		}
+
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func matchesAlertState(requestedState string, alertState string) bool {
+	if requestedState == "" {
+		return true
+	}
+	if requestedState == "firing" {
+		return alertState == "firing" || alertState == "silenced"
+	}
+	return alertState == requestedState
+}
+
+func (pa *prometheusAlerts) GetRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error) {
+	platformRules, err := pa.getRulesViaProxy(ctx, ClusterMonitoringNamespace, PlatformRouteName, AlertSourcePlatform)
+	if err != nil {
+		// Namespace-scoped callers (Thanos tenancy) often lack platform
+		// Prometheus access. Soft-fail so tenancy results are still returned.
+		if namespaceFromLabels(req.Labels) == "" {
+			return nil, err
+		}
+		prometheusLog.Warnf("failed to get platform rules (continuing with namespace filter): %v", err)
+	}
+
+	userRules, err := pa.getUserWorkloadRules(ctx, req)
+	if err != nil {
+		prometheusLog.Warnf("failed to get user workload rules: %v", err)
+	}
+
+	groups := append(platformRules, userRules...)
+
+	matchers, err := compileRuleLabelMatchers(req)
+	if err != nil {
+		return nil, err
+	}
+	if len(matchers) == 0 {
+		return groups, nil
+	}
+
+	return filterRuleGroupsByLabelMatchers(groups, matchers), nil
+}
+
+func (pa *prometheusAlerts) alertingHealth(ctx context.Context) AlertingHealth {
+	userPrometheus := pa.routeHealth(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, PrometheusRulesPath)
+	if userPrometheus.Status != RouteReachable {
+		if ok := pa.thanosTenancyReachable(ctx, ThanosQuerierTenancyAlertsPath); ok {
+			userPrometheus.FallbackReachable = true
+		}
+	}
+
+	userAlertmanager := pa.routeHealth(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, AlertmanagerAlertsPath)
+	if userAlertmanager.Status != RouteReachable {
+		if ok := pa.serviceReachable(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, UserWorkloadAlertmanagerPort, AlertmanagerAlertsPath); ok {
+			userAlertmanager.FallbackReachable = true
+		}
+	}
+
+	platformStack := pa.stackHealth(ctx, ClusterMonitoringNamespace, PlatformRouteName, PlatformAlertmanagerRouteName)
+	userWorkloadStack := AlertingStackHealth{
+		Prometheus:   userPrometheus,
+		Alertmanager: userAlertmanager,
+	}
+
+	return AlertingHealth{
+		Platform:     &platformStack,
+		UserWorkload: &userWorkloadStack,
+	}
+}
+
+func (pa *prometheusAlerts) stackHealth(ctx context.Context, namespace string, promRouteName string, amRouteName string) AlertingStackHealth {
+	return AlertingStackHealth{
+		Prometheus:   pa.routeHealth(ctx, namespace, promRouteName, PrometheusRulesPath),
+		Alertmanager: pa.routeHealth(ctx, namespace, amRouteName, AlertmanagerAlertsPath),
+	}
+}
+
+func (pa *prometheusAlerts) routeHealth(ctx context.Context, namespace string, routeName string, path string) AlertingRouteHealth {
+	health := AlertingRouteHealth{
+		Name:      routeName,
+		Namespace: namespace,
+	}
+
+	if pa.routeClient == nil {
+		health.Error = "route client is not configured"
+		return health
+	}
+
+	route, err := pa.routeClient.RouteV1().Routes(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			health.Status = RouteNotFound
+			health.Error = err.Error()
+			return health
+		}
+		health.Error = err.Error()
+		return health
+	}
+
+	url := buildRouteURL(route.Spec.Host, route.Spec.Path, path)
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		health.Status = RouteUnreachable
+		health.Error = err.Error()
+		return health
+	}
+
+	if _, err := pa.executeRequest(ctx, client, url); err != nil {
+		health.Status = RouteUnreachable
+		health.Error = err.Error()
+		return health
+	}
+
+	health.Status = RouteReachable
+	return health
+}
+
+func (pa *prometheusAlerts) getAlertsForSource(ctx context.Context, namespace string, promRouteName string, amRouteName string, source string) ([]PrometheusAlert, error) {
+	amAlerts, amErr := pa.getAlertmanagerAlerts(ctx, namespace, amRouteName, source)
+	promAlerts, promErr := pa.getAlertsViaProxy(ctx, namespace, promRouteName, source)
+
+	if amErr == nil {
+		pending := filterAlertsByState(promAlerts, "pending")
+		return append(amAlerts, pending...), nil
+	}
+
+	if promErr != nil {
+		return nil, promErr
+	}
+
+	return promAlerts, nil
+}
+
+func (pa *prometheusAlerts) getUserWorkloadAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, error) {
+	if shouldPreferUserAlertmanager(req.State) {
+		alerts, err := pa.getUserWorkloadAlertsViaAlertmanager(ctx)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via alertmanager: %v", err)
+	}
+
+	namespace := namespaceFromLabels(req.Labels)
+	if namespace != "" {
+		alerts, err := pa.getAlertsViaThanosTenancy(ctx, namespace, AlertSourceUser)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via thanos tenancy: %v", err)
+	}
+
+	userNamespaces := pa.userRuleNamespaces(ctx)
+	if len(userNamespaces) > 0 {
+		alerts, err := pa.getAlertsViaThanosTenancyNamespaces(ctx, userNamespaces, AlertSourceUser)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via thanos tenancy namespaces: %v", err)
+	}
+
+	return pa.getAlertsForSource(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, UserWorkloadAlertmanagerRouteName, AlertSourceUser)
+}
+
+func shouldPreferUserAlertmanager(state string) bool {
+	return state == "firing" || state == "silenced"
+}
+
+func (pa *prometheusAlerts) getUserWorkloadAlertsViaAlertmanager(ctx context.Context) ([]PrometheusAlert, error) {
+	alerts, err := pa.getAlertmanagerAlerts(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, AlertSourceUser)
+	if err != nil {
+		alerts, err = pa.getAlertmanagerAlertsViaService(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, UserWorkloadAlertmanagerPort, AlertSourceUser)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pending, err := pa.getAlertsViaProxy(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, AlertSourceUser)
+	if err != nil {
+		pending, err = pa.getPrometheusAlertsViaService(ctx, UserWorkloadMonitoringNamespace, UserWorkloadPrometheusServiceName, UserWorkloadPrometheusPort, AlertSourceUser)
+		if err != nil {
+			return alerts, nil
+		}
+	}
+
+	return append(alerts, filterAlertsByState(pending, "pending")...), nil
+}
+
+func (pa *prometheusAlerts) getPrometheusAlertsViaService(ctx context.Context, namespace string, serviceName string, port int32, source string) ([]PrometheusAlert, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		timeoutCtx, cancel := context.WithTimeout(ctx, serviceRequestTimeout)
+		defer cancel()
+		ctx = timeoutCtx
+	}
+
+	raw, err := pa.getServiceResponse(ctx, namespace, serviceName, port, PrometheusAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendProm)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertmanagerAlertsViaService(ctx context.Context, namespace string, serviceName string, port int32, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getServiceResponse(ctx, namespace, serviceName, port, AlertmanagerAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	converted, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	applyAlertMetadata(converted, source, AlertBackendAM)
+	if len(converted) == 0 {
+		return []PrometheusAlert{}, nil
+	}
+	return converted, nil
+}
+
+// parseAlertmanagerResponse unmarshals a raw Alertmanager GET /api/v2/alerts
+// response and converts it to PrometheusAlert structs. No routing labels are
+// added — callers that need them should call applyAlertMetadata.
+func parseAlertmanagerResponse(raw []byte) ([]PrometheusAlert, error) {
+	var amAlerts []alertmanagerAlert
+	if err := json.Unmarshal(raw, &amAlerts); err != nil {
+		return nil, fmt.Errorf("decode alertmanager response: %w", err)
+	}
+
+	converted := make([]PrometheusAlert, 0, len(amAlerts))
+	for _, alert := range amAlerts {
+		state := mapAlertmanagerState(alert.Status.State)
+		if state == "" {
+			continue
+		}
+		converted = append(converted, PrometheusAlert{
+			Labels:      alert.Labels,
+			Annotations: alert.Annotations,
+			State:       state,
+			ActiveAt:    alert.StartsAt,
+		})
+	}
+	return converted, nil
+}
+
+func (pa *prometheusAlerts) serviceReachable(ctx context.Context, namespace string, serviceName string, port int32, path string) bool {
+	healthCtx, cancel := context.WithTimeout(ctx, serviceHealthTimeout)
+	defer cancel()
+
+	_, err := pa.getServiceResponse(healthCtx, namespace, serviceName, port, path)
+	return err == nil
+}
+
+func (pa *prometheusAlerts) getServiceResponse(ctx context.Context, namespace string, serviceName string, port int32, path string) ([]byte, error) {
+	baseURL := fmt.Sprintf("https://%s.%s.svc:%d", serviceName, namespace, port)
+	requestURL := fmt.Sprintf("%s%s", baseURL, path)
+
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, requestURL)
+}
+
+func (pa *prometheusAlerts) thanosTenancyReachable(ctx context.Context, path string) bool {
+	namespaces := pa.userRuleNamespaces(ctx)
+	if len(namespaces) == 0 {
+		return false
+	}
+
+	limit := maxTenancyProbeTargets
+	if limit <= 0 || limit > len(namespaces) {
+		limit = len(namespaces)
+	}
+
+	for i := 0; i < limit; i++ {
+		healthCtx, cancel := context.WithTimeout(ctx, serviceHealthTimeout)
+		_, err := pa.getThanosTenancyResponse(healthCtx, path, namespaces[i])
+		cancel()
+
+		if err == nil {
+			return true
+		}
+		if isTenancyExpectedError(err) {
+			continue
+		}
+		return false
+	}
+
+	return false
+}
+
+// isTenancyExpectedError returns true for errors that are expected when probing
+// Thanos tenancy endpoints across user namespaces — e.g. the namespace has no
+// rules (404), the SA lacks access (401/403), or the namespace is not yet
+// instrumented. These are skipped; only a network/server error aborts the probe.
+func isTenancyExpectedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status 401") ||
+		strings.Contains(msg, "status 403") ||
+		strings.Contains(msg, "status 404") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "not found")
+}
+
+func (pa *prometheusAlerts) getAlertsViaProxy(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, PrometheusAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendProm)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertsViaThanosTenancy(ctx context.Context, namespace string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getThanosTenancyResponse(ctx, ThanosQuerierTenancyAlertsPath, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode thanos response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("thanos API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendThanos)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertmanagerAlerts(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, AlertmanagerAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	converted, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	applyAlertMetadata(converted, source, AlertBackendAM)
+	if len(converted) == 0 {
+		return []PrometheusAlert{}, nil
+	}
+	return converted, nil
+}
+
+func (pa *prometheusAlerts) getUserWorkloadRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error) {
+	namespace := namespaceFromLabels(req.Labels)
+	if namespace != "" {
+		rules, err := pa.getRulesViaThanosTenancy(ctx, namespace, AlertSourceUser)
+		if err == nil {
+			return rules, nil
+		}
+		prometheusLog.Warnf("failed to get user workload rules via thanos tenancy: %v", err)
+	}
+
+	userNamespaces := pa.userRuleNamespaces(ctx)
+	if len(userNamespaces) > 0 {
+		groups, err := pa.getRulesViaThanosTenancyNamespaces(ctx, userNamespaces, AlertSourceUser)
+		if err == nil {
+			return groups, nil
+		}
+		prometheusLog.Warnf("failed to get user workload rules via thanos tenancy namespaces: %v", err)
+	}
+
+	return pa.getRulesViaProxy(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, AlertSourceUser)
+}
+
+func (pa *prometheusAlerts) userRuleNamespaces(ctx context.Context) []string {
+	if cached, ok := pa.nsCache.get(); ok {
+		return cached
+	}
+
+	if pa.ruleManager == nil {
+		namespaces := pa.allNonPlatformNamespaces(ctx)
+		pa.nsCache.set(namespaces)
+		return namespaces
+	}
+
+	prometheusRules, err := pa.ruleManager.List()
+	if err != nil {
+		prometheusLog.WithError(err).Warn("failed to list PrometheusRules for user namespace discovery")
+		namespaces := pa.allNonPlatformNamespaces(ctx)
+		pa.nsCache.set(namespaces)
+		return namespaces
+	}
+
+	namespaces := map[string]struct{}{}
+	for _, pr := range prometheusRules {
+		if pr.Namespace == "" {
+			continue
+		}
+		if pr.Namespace == ClusterMonitoringNamespace || pr.Namespace == UserWorkloadMonitoringNamespace {
+			continue
+		}
+		namespaces[pr.Namespace] = struct{}{}
+	}
+
+	out := make([]string, 0, len(namespaces))
+	for ns := range namespaces {
+		out = append(out, ns)
+	}
+	pa.nsCache.set(out)
+	return out
+}
+
+func (pa *prometheusAlerts) allNonPlatformNamespaces(ctx context.Context) []string {
+	if pa.coreClient == nil {
+		return nil
+	}
+
+	namespaceList, err := pa.coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		prometheusLog.WithError(err).Warn("failed to list namespaces for user namespace discovery")
+		return nil
+	}
+
+	out := make([]string, 0, len(namespaceList.Items))
+	for _, ns := range namespaceList.Items {
+		if ns.Name == ClusterMonitoringNamespace || ns.Name == UserWorkloadMonitoringNamespace {
+			continue
+		}
+		out = append(out, ns.Name)
+	}
+	return out
+}
+
+// fanOutThanosTenancy calls fetch for each namespace, accumulates results, and
+// returns combined results (or the last error if nothing succeeded).
+func fanOutThanosTenancy[T any](namespaces []string, fetch func(string) ([]T, error)) ([]T, error) {
+	var out []T
+	var lastErr error
+	for _, namespace := range namespaces {
+		results, err := fetch(namespace)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		out = append(out, results...)
+	}
+	if len(out) > 0 {
+		return out, nil
+	}
+	return out, lastErr
+}
+
+func (pa *prometheusAlerts) getAlertsViaThanosTenancyNamespaces(ctx context.Context, namespaces []string, source string) ([]PrometheusAlert, error) {
+	return fanOutThanosTenancy(namespaces, func(ns string) ([]PrometheusAlert, error) {
+		return pa.getAlertsViaThanosTenancy(ctx, ns, source)
+	})
+}
+
+func (pa *prometheusAlerts) getRulesViaThanosTenancyNamespaces(ctx context.Context, namespaces []string, source string) ([]PrometheusRuleGroup, error) {
+	return fanOutThanosTenancy(namespaces, func(ns string) ([]PrometheusRuleGroup, error) {
+		return pa.getRulesViaThanosTenancy(ctx, ns, source)
+	})
+}
+
+func (pa *prometheusAlerts) getRulesViaProxy(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusRuleGroup, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, PrometheusRulesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesResp prometheusRulesResponse
+	if err := json.Unmarshal(raw, &rulesResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if rulesResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", rulesResp.Status)
+	}
+
+	applyRuleSource(rulesResp.Data.Groups, source)
+	return rulesResp.Data.Groups, nil
+}
+
+func (pa *prometheusAlerts) getRulesViaThanosTenancy(ctx context.Context, namespace string, source string) ([]PrometheusRuleGroup, error) {
+	raw, err := pa.getThanosTenancyResponse(ctx, ThanosQuerierTenancyRulesPath, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesResp prometheusRulesResponse
+	if err := json.Unmarshal(raw, &rulesResp); err != nil {
+		return nil, fmt.Errorf("decode thanos response: %w", err)
+	}
+
+	if rulesResp.Status != "success" {
+		return nil, fmt.Errorf("thanos API returned non-success status: %s", rulesResp.Status)
+	}
+
+	applyRuleSource(rulesResp.Data.Groups, source)
+	return rulesResp.Data.Groups, nil
+}
+
+func (pa *prometheusAlerts) getPrometheusResponse(ctx context.Context, namespace string, routeName string, path string) ([]byte, error) {
+	url, err := pa.buildPrometheusURL(ctx, namespace, routeName, path)
+	if err != nil {
+		return nil, err
+	}
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, url)
+}
+
+func (pa *prometheusAlerts) getThanosTenancyResponse(ctx context.Context, path string, namespace string) ([]byte, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required for thanos tenancy requests")
+	}
+
+	baseURL := fmt.Sprintf("https://%s.%s.svc:%d", ThanosQuerierServiceName, ClusterMonitoringNamespace, DefaultThanosQuerierTenancyRulesPort)
+	requestURL := fmt.Sprintf("%s%s?namespace=%s", baseURL, path, url.QueryEscape(namespace))
+
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, requestURL)
+}
+
+func (pa *prometheusAlerts) buildPrometheusURL(ctx context.Context, namespace string, routeName string, path string) (string, error) {
+	route, err := pa.fetchPrometheusRoute(ctx, namespace, routeName)
+	if err != nil {
+		return "", err
+	}
+
+	return buildRouteURL(route.Spec.Host, route.Spec.Path, path), nil
+}
+
+func (pa *prometheusAlerts) fetchPrometheusRoute(ctx context.Context, namespace string, routeName string) (*routev1.Route, error) {
+	if pa.routeClient == nil {
+		return nil, fmt.Errorf("route client is not configured")
+	}
+
+	route, err := pa.routeClient.RouteV1().Routes(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get prometheus route: %w", err)
+	}
+
+	return route, nil
+}
+
+func applyAlertMetadata(alerts []PrometheusAlert, source, backend string) {
+	for i := range alerts {
+		if alerts[i].Labels == nil {
+			alerts[i].Labels = map[string]string{}
+		}
+		alerts[i].Labels[AlertSourceLabel] = source
+		alerts[i].Labels[AlertBackendLabel] = backend
+	}
+}
+
+func applyRuleSource(groups []PrometheusRuleGroup, source string) {
+	for gi := range groups {
+		for ri := range groups[gi].Rules {
+			rule := &groups[gi].Rules[ri]
+			if rule.Labels == nil {
+				rule.Labels = map[string]string{}
+			}
+			rule.Labels[AlertSourceLabel] = source
+			for ai := range rule.Alerts {
+				if rule.Alerts[ai].Labels == nil {
+					rule.Alerts[ai].Labels = map[string]string{}
+				}
+				rule.Alerts[ai].Labels[AlertSourceLabel] = source
+			}
+		}
+	}
+}
+
+func filterAlertsByState(alerts []PrometheusAlert, state string) []PrometheusAlert {
+	out := make([]PrometheusAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		if alert.State == state {
+			out = append(out, alert)
+		}
+	}
+	return out
+}
+
+func mapAlertmanagerState(state string) string {
+	if state == "active" {
+		return "firing"
+	}
+	if state == "suppressed" {
+		return "silenced"
+	}
+	return ""
+}
+
+func buildRouteURL(host string, routePath string, requestPath string) string {
+	basePath := strings.TrimSuffix(routePath, "/")
+	if basePath == "" {
+		return fmt.Sprintf("https://%s%s", host, requestPath)
+	}
+	if requestPath == basePath || strings.HasPrefix(requestPath, basePath+"/") {
+		return fmt.Sprintf("https://%s%s", host, requestPath)
+	}
+	return fmt.Sprintf("https://%s%s%s", host, basePath, requestPath)
+}
+
+func namespaceFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	return strings.TrimSpace(labels["namespace"])
+}
+
+func (pa *prometheusAlerts) createHTTPClient() (*http.Client, error) {
+	tlsConfig, err := pa.buildTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
+func (pa *prometheusAlerts) buildTLSConfig() (*tls.Config, error) {
+	caCertPool, err := pa.loadCACertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    caCertPool,
+	}, nil
+}
+
+func (pa *prometheusAlerts) loadCACertPool() (*x509.CertPool, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	if len(pa.config.CAData) > 0 {
+		caCertPool.AppendCertsFromPEM(pa.config.CAData)
+		return caCertPool, nil
+	}
+
+	if pa.config.CAFile != "" {
+		caCert, err := os.ReadFile(pa.config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA cert file: %w", err)
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
+	// OpenShift service CA bundle for in-cluster service certs.
+	if serviceCA, err := os.ReadFile(ServiceCAPath); err == nil {
+		caCertPool.AppendCertsFromPEM(serviceCA)
+	}
+
+	return caCertPool, nil
+}
+
+func copyStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func (pa *prometheusAlerts) executeRequest(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := pa.createAuthenticatedRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.performRequest(client, req)
+}
+
+func (pa *prometheusAlerts) createAuthenticatedRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	token := BearerTokenFromContext(ctx)
+	if token == "" {
+		var err error
+		token, err = pa.loadBearerToken()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req, nil
+}
+
+func (pa *prometheusAlerts) loadBearerToken() (string, error) {
+	if pa.config.BearerToken != "" {
+		return pa.config.BearerToken, nil
+	}
+
+	if pa.config.BearerTokenFile == "" {
+		return "", fmt.Errorf("no bearer token or token file configured")
+	}
+
+	tokenBytes, err := os.ReadFile(pa.config.BearerTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("load bearer token file: %w", err)
+	}
+
+	return strings.TrimSpace(string(tokenBytes)), nil
+}
+
+func (pa *prometheusAlerts) performRequest(client *http.Client, req *http.Request) ([]byte, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func labelsMatch(req *GetAlertsRequest, alert *PrometheusAlert) bool {
+	for key, value := range req.Labels {
+		if alertValue, exists := alert.Labels[key]; !exists || alertValue != value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/k8s/prometheus_alerts.go
+++ b/pkg/k8s/prometheus_alerts.go
@@ -1,0 +1,930 @@
+package k8s
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+var prometheusLog = logrus.WithField("module", "k8s-prometheus")
+
+const (
+	namespaceCacheTTL      = 30 * time.Second
+	serviceHealthTimeout   = 5 * time.Second
+	serviceRequestTimeout  = 10 * time.Second
+	maxTenancyProbeTargets = 3
+)
+
+type namespaceCache struct {
+	mu        sync.Mutex
+	expiresAt time.Time
+	ttl       time.Duration
+	value     []string
+}
+
+func newNamespaceCache(ttl time.Duration) *namespaceCache {
+	return &namespaceCache{ttl: ttl}
+}
+
+func (c *namespaceCache) get() ([]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.expiresAt.IsZero() || time.Now().After(c.expiresAt) {
+		return nil, false
+	}
+	return copyStringSlice(c.value), true
+}
+
+func (c *namespaceCache) set(namespaces []string) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.value = copyStringSlice(namespaces)
+	c.expiresAt = time.Now().Add(c.ttl)
+}
+
+type prometheusAlerts struct {
+	routeClient routeclient.Interface
+	coreClient  corev1client.CoreV1Interface
+	config      *rest.Config
+	ruleManager PrometheusRuleInterface
+	nsCache     *namespaceCache
+}
+
+// GetAlertsRequest holds parameters for filtering alerts
+type GetAlertsRequest struct {
+	// Labels filters alerts by labels
+	Labels map[string]string
+	// State filters alerts by state: "firing", "pending", "silenced", or "" for all states
+	State string
+}
+
+type PrometheusAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	State       string            `json:"state"`
+	ActiveAt    time.Time         `json:"activeAt"`
+	Value       string            `json:"value"`
+
+	AlertRuleId    string `json:"alertRuleId,omitempty"`
+	AlertComponent string `json:"alertComponent,omitempty"`
+	AlertLayer     string `json:"alertLayer,omitempty"`
+}
+
+type prometheusAlertsData struct {
+	Alerts []PrometheusAlert `json:"alerts"`
+}
+
+type prometheusAlertsResponse struct {
+	Status string               `json:"status"`
+	Data   prometheusAlertsData `json:"data"`
+}
+
+type prometheusRulesData struct {
+	Groups []PrometheusRuleGroup `json:"groups"`
+}
+
+type prometheusRulesResponse struct {
+	Status string              `json:"status"`
+	Data   prometheusRulesData `json:"data"`
+}
+
+type alertmanagerAlertStatus struct {
+	State string `json:"state"`
+}
+
+type alertmanagerAlert struct {
+	Labels       map[string]string       `json:"labels"`
+	Annotations  map[string]string       `json:"annotations"`
+	StartsAt     time.Time               `json:"startsAt"`
+	EndsAt       time.Time               `json:"endsAt"`
+	GeneratorURL string                  `json:"generatorURL"`
+	Status       alertmanagerAlertStatus `json:"status"`
+}
+
+func newPrometheusAlerts(routeClient routeclient.Interface, coreClient corev1client.CoreV1Interface, config *rest.Config, ruleManager PrometheusRuleInterface) *prometheusAlerts {
+	return &prometheusAlerts{
+		routeClient: routeClient,
+		coreClient:  coreClient,
+		config:      config,
+		ruleManager: ruleManager,
+		nsCache:     newNamespaceCache(namespaceCacheTTL),
+	}
+}
+
+func (pa *prometheusAlerts) FetchAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, []string, error) {
+	var warnings []string
+
+	platformAlerts, err := pa.getAlertsForSource(ctx, ClusterMonitoringNamespace, PlatformRouteName, PlatformAlertmanagerRouteName, AlertSourcePlatform)
+	if err != nil {
+		// Namespace-scoped callers (Thanos tenancy) often lack platform
+		// Prometheus access. Soft-fail so tenancy results are still returned.
+		if namespaceFromLabels(req.Labels) == "" {
+			return nil, nil, err
+		}
+		warnings = append(warnings, fmt.Sprintf("failed to get platform alerts: %v", err))
+	}
+
+	userAlerts, err := pa.getUserWorkloadAlerts(ctx, req)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("failed to get user workload alerts: %v", err))
+	}
+
+	mergedAlerts := append(platformAlerts, userAlerts...)
+
+	out := make([]PrometheusAlert, 0, len(mergedAlerts))
+	for _, a := range mergedAlerts {
+		if !matchesAlertState(req.State, a.State) {
+			continue
+		}
+		if !labelsMatch(&req, &a) {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, warnings, nil
+}
+
+func (pa *prometheusAlerts) GetRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error) {
+	platformRules, err := pa.getRulesViaProxy(ctx, ClusterMonitoringNamespace, PlatformRouteName, AlertSourcePlatform)
+	if err != nil {
+		// Namespace-scoped callers (Thanos tenancy) often lack platform
+		// Prometheus access. Soft-fail so tenancy results are still returned.
+		if namespaceFromLabels(req.Labels) == "" {
+			return nil, err
+		}
+		prometheusLog.Warnf("failed to get platform rules (continuing with namespace filter): %v", err)
+	}
+
+	userRules, err := pa.getUserWorkloadRules(ctx, req)
+	if err != nil {
+		prometheusLog.Warnf("failed to get user workload rules: %v", err)
+	}
+
+	groups := append(platformRules, userRules...)
+
+	matchers, err := compileRuleLabelMatchers(req)
+	if err != nil {
+		return nil, err
+	}
+	if len(matchers) == 0 {
+		return groups, nil
+	}
+
+	return filterRuleGroupsByLabelMatchers(groups, matchers), nil
+}
+
+func (pa *prometheusAlerts) alertingHealth(ctx context.Context) AlertingHealth {
+	userPrometheus := pa.routeHealth(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, PrometheusRulesPath)
+	if userPrometheus.Status != RouteReachable {
+		if ok := pa.thanosTenancyReachable(ctx, ThanosQuerierTenancyAlertsPath); ok {
+			userPrometheus.FallbackReachable = true
+		}
+	}
+
+	userAlertmanager := pa.routeHealth(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, AlertmanagerAlertsPath)
+	if userAlertmanager.Status != RouteReachable {
+		if ok := pa.serviceReachable(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, UserWorkloadAlertmanagerPort, AlertmanagerAlertsPath); ok {
+			userAlertmanager.FallbackReachable = true
+		}
+	}
+
+	platformStack := pa.stackHealth(ctx, ClusterMonitoringNamespace, PlatformRouteName, PlatformAlertmanagerRouteName)
+	userWorkloadStack := AlertingStackHealth{
+		Prometheus:   userPrometheus,
+		Alertmanager: userAlertmanager,
+	}
+
+	return AlertingHealth{
+		Platform:     &platformStack,
+		UserWorkload: &userWorkloadStack,
+	}
+}
+
+func (pa *prometheusAlerts) stackHealth(ctx context.Context, namespace string, promRouteName string, amRouteName string) AlertingStackHealth {
+	return AlertingStackHealth{
+		Prometheus:   pa.routeHealth(ctx, namespace, promRouteName, PrometheusRulesPath),
+		Alertmanager: pa.routeHealth(ctx, namespace, amRouteName, AlertmanagerAlertsPath),
+	}
+}
+
+func (pa *prometheusAlerts) routeHealth(ctx context.Context, namespace string, routeName string, path string) AlertingRouteHealth {
+	health := AlertingRouteHealth{
+		Name:      routeName,
+		Namespace: namespace,
+	}
+
+	if pa.routeClient == nil {
+		health.Status = RouteUnreachable
+		health.Error = "route client is not configured"
+		return health
+	}
+
+	route, err := pa.routeClient.RouteV1().Routes(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			health.Status = RouteNotFound
+			health.Error = err.Error()
+			return health
+		}
+		health.Status = RouteUnreachable
+		health.Error = err.Error()
+		return health
+	}
+
+	url := buildRouteURL(route.Spec.Host, route.Spec.Path, path)
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		health.Status = RouteUnreachable
+		health.Error = err.Error()
+		return health
+	}
+
+	if _, err := pa.executeRequest(ctx, client, url); err != nil {
+		health.Status = RouteUnreachable
+		health.Error = err.Error()
+		return health
+	}
+
+	health.Status = RouteReachable
+	return health
+}
+
+func (pa *prometheusAlerts) getAlertsForSource(ctx context.Context, namespace string, promRouteName string, amRouteName string, source string) ([]PrometheusAlert, error) {
+	amAlerts, amErr := pa.getAlertmanagerAlerts(ctx, namespace, amRouteName, source)
+	promAlerts, promErr := pa.getAlertsViaProxy(ctx, namespace, promRouteName, source)
+
+	if amErr == nil {
+		pending := filterAlertsByState(promAlerts, "pending")
+		return append(amAlerts, pending...), nil
+	}
+
+	if promErr != nil {
+		return nil, fmt.Errorf("alertmanager: %w; prometheus: %w", amErr, promErr)
+	}
+
+	return promAlerts, nil
+}
+
+func (pa *prometheusAlerts) getUserWorkloadAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, error) {
+	if shouldPreferUserAlertmanager(req.State) {
+		alerts, err := pa.getUserWorkloadAlertsViaAlertmanager(ctx)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via alertmanager: %v", err)
+	}
+
+	namespace := namespaceFromLabels(req.Labels)
+	if namespace != "" {
+		alerts, err := pa.getAlertsViaThanosTenancy(ctx, namespace, AlertSourceUser)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via thanos tenancy: %v", err)
+	}
+
+	userNamespaces := pa.userRuleNamespaces(ctx)
+	if len(userNamespaces) > 0 {
+		alerts, err := pa.getAlertsViaThanosTenancyNamespaces(ctx, userNamespaces, AlertSourceUser)
+		if err == nil {
+			return alerts, nil
+		}
+		prometheusLog.Warnf("failed to get user workload alerts via thanos tenancy namespaces: %v", err)
+	}
+
+	return pa.getAlertsForSource(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, UserWorkloadAlertmanagerRouteName, AlertSourceUser)
+}
+
+func shouldPreferUserAlertmanager(state string) bool {
+	return state == "firing" || state == "silenced"
+}
+
+func (pa *prometheusAlerts) getUserWorkloadAlertsViaAlertmanager(ctx context.Context) ([]PrometheusAlert, error) {
+	alerts, err := pa.getAlertmanagerAlerts(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, AlertSourceUser)
+	if err != nil {
+		alerts, err = pa.getAlertmanagerAlertsViaService(ctx, UserWorkloadMonitoringNamespace, UserWorkloadAlertmanagerRouteName, UserWorkloadAlertmanagerPort, AlertSourceUser)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pending, err := pa.getAlertsViaProxy(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, AlertSourceUser)
+	if err != nil {
+		pending, err = pa.getPrometheusAlertsViaService(ctx, UserWorkloadMonitoringNamespace, UserWorkloadPrometheusServiceName, UserWorkloadPrometheusPort, AlertSourceUser)
+		if err != nil {
+			return alerts, nil
+		}
+	}
+
+	return append(alerts, filterAlertsByState(pending, "pending")...), nil
+}
+
+func (pa *prometheusAlerts) getPrometheusAlertsViaService(ctx context.Context, namespace string, serviceName string, port int32, source string) ([]PrometheusAlert, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		timeoutCtx, cancel := context.WithTimeout(ctx, serviceRequestTimeout)
+		defer cancel()
+		ctx = timeoutCtx
+	}
+
+	raw, err := pa.getServiceResponse(ctx, namespace, serviceName, port, PrometheusAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendProm)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertmanagerAlertsViaService(ctx context.Context, namespace string, serviceName string, port int32, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getServiceResponse(ctx, namespace, serviceName, port, AlertmanagerAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	converted, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	applyAlertMetadata(converted, source, AlertBackendAM)
+	if len(converted) == 0 {
+		return []PrometheusAlert{}, nil
+	}
+	return converted, nil
+}
+
+// parseAlertmanagerResponse unmarshals a raw Alertmanager GET /api/v2/alerts
+// response and converts it to PrometheusAlert structs. No routing labels are
+// added — callers that need them should call applyAlertMetadata.
+func parseAlertmanagerResponse(raw []byte) ([]PrometheusAlert, error) {
+	var amAlerts []alertmanagerAlert
+	if err := json.Unmarshal(raw, &amAlerts); err != nil {
+		return nil, fmt.Errorf("decode alertmanager response: %w", err)
+	}
+
+	converted := make([]PrometheusAlert, 0, len(amAlerts))
+	for _, alert := range amAlerts {
+		state := mapAlertmanagerState(alert.Status.State)
+		if state == "" {
+			continue
+		}
+		converted = append(converted, PrometheusAlert{
+			Labels:      alert.Labels,
+			Annotations: alert.Annotations,
+			State:       state,
+			ActiveAt:    alert.StartsAt,
+		})
+	}
+	return converted, nil
+}
+
+func (pa *prometheusAlerts) serviceReachable(ctx context.Context, namespace string, serviceName string, port int32, path string) bool {
+	healthCtx, cancel := context.WithTimeout(ctx, serviceHealthTimeout)
+	defer cancel()
+
+	_, err := pa.getServiceResponse(healthCtx, namespace, serviceName, port, path)
+	return err == nil
+}
+
+func (pa *prometheusAlerts) getServiceResponse(ctx context.Context, namespace string, serviceName string, port int32, path string) ([]byte, error) {
+	baseURL := fmt.Sprintf("https://%s.%s.svc:%d", serviceName, namespace, port)
+	requestURL := fmt.Sprintf("%s%s", baseURL, path)
+
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, requestURL)
+}
+
+func (pa *prometheusAlerts) thanosTenancyReachable(ctx context.Context, path string) bool {
+	namespaces := pa.userRuleNamespaces(ctx)
+	if len(namespaces) == 0 {
+		return false
+	}
+
+	limit := maxTenancyProbeTargets
+	if limit <= 0 || limit > len(namespaces) {
+		limit = len(namespaces)
+	}
+
+	for i := 0; i < limit; i++ {
+		healthCtx, cancel := context.WithTimeout(ctx, serviceHealthTimeout)
+		_, err := pa.getThanosTenancyResponse(healthCtx, path, namespaces[i])
+		cancel()
+
+		if err == nil {
+			return true
+		}
+		if isTenancyExpectedError(err) {
+			continue
+		}
+		return false
+	}
+
+	return false
+}
+
+// isTenancyExpectedError returns true for errors that are expected when probing
+// Thanos tenancy endpoints across user namespaces — e.g. the namespace has no
+// rules (404), the SA lacks access (401/403), or the namespace is not yet
+// instrumented. These are skipped; only a network/server error aborts the probe.
+func isTenancyExpectedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status 401") ||
+		strings.Contains(msg, "status 403") ||
+		strings.Contains(msg, "status 404") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "not found")
+}
+
+func (pa *prometheusAlerts) getAlertsViaProxy(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, PrometheusAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendProm)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertsViaThanosTenancy(ctx context.Context, namespace string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getThanosTenancyResponse(ctx, ThanosQuerierTenancyAlertsPath, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var alertsResp prometheusAlertsResponse
+	if err := json.Unmarshal(raw, &alertsResp); err != nil {
+		return nil, fmt.Errorf("decode thanos response: %w", err)
+	}
+
+	if alertsResp.Status != "success" {
+		return nil, fmt.Errorf("thanos API returned non-success status: %s", alertsResp.Status)
+	}
+
+	applyAlertMetadata(alertsResp.Data.Alerts, source, AlertBackendThanos)
+	return alertsResp.Data.Alerts, nil
+}
+
+func (pa *prometheusAlerts) getAlertmanagerAlerts(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusAlert, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, AlertmanagerAlertsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	converted, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	applyAlertMetadata(converted, source, AlertBackendAM)
+	if len(converted) == 0 {
+		return []PrometheusAlert{}, nil
+	}
+	return converted, nil
+}
+
+func (pa *prometheusAlerts) getUserWorkloadRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error) {
+	namespace := namespaceFromLabels(req.Labels)
+	if namespace != "" {
+		rules, err := pa.getRulesViaThanosTenancy(ctx, namespace, AlertSourceUser)
+		if err == nil {
+			return rules, nil
+		}
+		prometheusLog.Warnf("failed to get user workload rules via thanos tenancy: %v", err)
+	}
+
+	userNamespaces := pa.userRuleNamespaces(ctx)
+	if len(userNamespaces) > 0 {
+		groups, err := pa.getRulesViaThanosTenancyNamespaces(ctx, userNamespaces, AlertSourceUser)
+		if err == nil {
+			return groups, nil
+		}
+		prometheusLog.Warnf("failed to get user workload rules via thanos tenancy namespaces: %v", err)
+	}
+
+	return pa.getRulesViaProxy(ctx, UserWorkloadMonitoringNamespace, UserWorkloadRouteName, AlertSourceUser)
+}
+
+func (pa *prometheusAlerts) userRuleNamespaces(ctx context.Context) []string {
+	if cached, ok := pa.nsCache.get(); ok {
+		return cached
+	}
+
+	if pa.ruleManager == nil {
+		namespaces := pa.allNonPlatformNamespaces(ctx)
+		pa.nsCache.set(namespaces)
+		return namespaces
+	}
+
+	prometheusRules, err := pa.ruleManager.List()
+	if err != nil {
+		prometheusLog.WithError(err).Warn("failed to list PrometheusRules for user namespace discovery")
+		namespaces := pa.allNonPlatformNamespaces(ctx)
+		pa.nsCache.set(namespaces)
+		return namespaces
+	}
+
+	namespaces := map[string]struct{}{}
+	for _, pr := range prometheusRules {
+		if pr.Namespace == "" {
+			continue
+		}
+		if pr.Namespace == ClusterMonitoringNamespace || pr.Namespace == UserWorkloadMonitoringNamespace {
+			continue
+		}
+		namespaces[pr.Namespace] = struct{}{}
+	}
+
+	out := make([]string, 0, len(namespaces))
+	for ns := range namespaces {
+		out = append(out, ns)
+	}
+	pa.nsCache.set(out)
+	return out
+}
+
+func (pa *prometheusAlerts) allNonPlatformNamespaces(ctx context.Context) []string {
+	if pa.coreClient == nil {
+		return nil
+	}
+
+	namespaceList, err := pa.coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		prometheusLog.WithError(err).Warn("failed to list namespaces for user namespace discovery")
+		return nil
+	}
+
+	out := make([]string, 0, len(namespaceList.Items))
+	for _, ns := range namespaceList.Items {
+		if ns.Name == ClusterMonitoringNamespace || ns.Name == UserWorkloadMonitoringNamespace {
+			continue
+		}
+		out = append(out, ns.Name)
+	}
+	return out
+}
+
+// fanOutThanosTenancy calls fetch for each namespace, accumulates results, and
+// returns combined results (or the last error if nothing succeeded).
+func fanOutThanosTenancy[T any](namespaces []string, fetch func(string) ([]T, error)) ([]T, error) {
+	var out []T
+	var lastErr error
+	for _, namespace := range namespaces {
+		results, err := fetch(namespace)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		out = append(out, results...)
+	}
+	if len(out) > 0 {
+		return out, nil
+	}
+	return out, lastErr
+}
+
+func (pa *prometheusAlerts) getAlertsViaThanosTenancyNamespaces(ctx context.Context, namespaces []string, source string) ([]PrometheusAlert, error) {
+	return fanOutThanosTenancy(namespaces, func(ns string) ([]PrometheusAlert, error) {
+		return pa.getAlertsViaThanosTenancy(ctx, ns, source)
+	})
+}
+
+func (pa *prometheusAlerts) getRulesViaThanosTenancyNamespaces(ctx context.Context, namespaces []string, source string) ([]PrometheusRuleGroup, error) {
+	return fanOutThanosTenancy(namespaces, func(ns string) ([]PrometheusRuleGroup, error) {
+		return pa.getRulesViaThanosTenancy(ctx, ns, source)
+	})
+}
+
+func (pa *prometheusAlerts) getRulesViaProxy(ctx context.Context, namespace string, routeName string, source string) ([]PrometheusRuleGroup, error) {
+	raw, err := pa.getPrometheusResponse(ctx, namespace, routeName, PrometheusRulesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesResp prometheusRulesResponse
+	if err := json.Unmarshal(raw, &rulesResp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+
+	if rulesResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus API returned non-success status: %s", rulesResp.Status)
+	}
+
+	applyRuleSource(rulesResp.Data.Groups, source)
+	return rulesResp.Data.Groups, nil
+}
+
+func (pa *prometheusAlerts) getRulesViaThanosTenancy(ctx context.Context, namespace string, source string) ([]PrometheusRuleGroup, error) {
+	raw, err := pa.getThanosTenancyResponse(ctx, ThanosQuerierTenancyRulesPath, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesResp prometheusRulesResponse
+	if err := json.Unmarshal(raw, &rulesResp); err != nil {
+		return nil, fmt.Errorf("decode thanos response: %w", err)
+	}
+
+	if rulesResp.Status != "success" {
+		return nil, fmt.Errorf("thanos API returned non-success status: %s", rulesResp.Status)
+	}
+
+	applyRuleSource(rulesResp.Data.Groups, source)
+	return rulesResp.Data.Groups, nil
+}
+
+func (pa *prometheusAlerts) getPrometheusResponse(ctx context.Context, namespace string, routeName string, path string) ([]byte, error) {
+	url, err := pa.buildPrometheusURL(ctx, namespace, routeName, path)
+	if err != nil {
+		return nil, err
+	}
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, url)
+}
+
+func (pa *prometheusAlerts) getThanosTenancyResponse(ctx context.Context, path string, namespace string) ([]byte, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required for thanos tenancy requests")
+	}
+
+	baseURL := fmt.Sprintf("https://%s.%s.svc:%d", ThanosQuerierServiceName, ClusterMonitoringNamespace, DefaultThanosQuerierTenancyRulesPort)
+	requestURL := fmt.Sprintf("%s%s?namespace=%s", baseURL, path, url.QueryEscape(namespace))
+
+	client, err := pa.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.executeRequest(ctx, client, requestURL)
+}
+
+func (pa *prometheusAlerts) buildPrometheusURL(ctx context.Context, namespace string, routeName string, path string) (string, error) {
+	route, err := pa.fetchPrometheusRoute(ctx, namespace, routeName)
+	if err != nil {
+		return "", err
+	}
+
+	return buildRouteURL(route.Spec.Host, route.Spec.Path, path), nil
+}
+
+func (pa *prometheusAlerts) fetchPrometheusRoute(ctx context.Context, namespace string, routeName string) (*routev1.Route, error) {
+	if pa.routeClient == nil {
+		return nil, fmt.Errorf("route client is not configured")
+	}
+
+	route, err := pa.routeClient.RouteV1().Routes(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get prometheus route: %w", err)
+	}
+
+	return route, nil
+}
+
+func applyAlertMetadata(alerts []PrometheusAlert, source, backend string) {
+	for i := range alerts {
+		if alerts[i].Labels == nil {
+			alerts[i].Labels = map[string]string{}
+		}
+		alerts[i].Labels[AlertSourceLabel] = source
+		alerts[i].Labels[AlertBackendLabel] = backend
+	}
+}
+
+func applyRuleSource(groups []PrometheusRuleGroup, source string) {
+	for gi := range groups {
+		for ri := range groups[gi].Rules {
+			rule := &groups[gi].Rules[ri]
+			if rule.Labels == nil {
+				rule.Labels = map[string]string{}
+			}
+			rule.Labels[AlertSourceLabel] = source
+			for ai := range rule.Alerts {
+				if rule.Alerts[ai].Labels == nil {
+					rule.Alerts[ai].Labels = map[string]string{}
+				}
+				rule.Alerts[ai].Labels[AlertSourceLabel] = source
+			}
+		}
+	}
+}
+
+func filterAlertsByState(alerts []PrometheusAlert, state string) []PrometheusAlert {
+	out := make([]PrometheusAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		if alert.State == state {
+			out = append(out, alert)
+		}
+	}
+	return out
+}
+
+func mapAlertmanagerState(state string) string {
+	if state == "active" {
+		return "firing"
+	}
+	if state == "suppressed" {
+		return "silenced"
+	}
+	return ""
+}
+
+func buildRouteURL(host string, routePath string, requestPath string) string {
+	basePath := strings.TrimSuffix(routePath, "/")
+	if basePath == "" {
+		return fmt.Sprintf("https://%s%s", host, requestPath)
+	}
+	if requestPath == basePath || strings.HasPrefix(requestPath, basePath+"/") {
+		return fmt.Sprintf("https://%s%s", host, requestPath)
+	}
+	return fmt.Sprintf("https://%s%s%s", host, basePath, requestPath)
+}
+
+func namespaceFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	return strings.TrimSpace(labels["namespace"])
+}
+
+func (pa *prometheusAlerts) createHTTPClient() (*http.Client, error) {
+	tlsConfig, err := pa.buildTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Timeout: serviceRequestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
+func (pa *prometheusAlerts) buildTLSConfig() (*tls.Config, error) {
+	caCertPool, err := pa.loadCACertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    caCertPool,
+	}, nil
+}
+
+func (pa *prometheusAlerts) loadCACertPool() (*x509.CertPool, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	if len(pa.config.CAData) > 0 {
+		caCertPool.AppendCertsFromPEM(pa.config.CAData)
+		return caCertPool, nil
+	}
+
+	if pa.config.CAFile != "" {
+		caCert, err := os.ReadFile(pa.config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA cert file: %w", err)
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
+	// OpenShift service CA bundle for in-cluster service certs.
+	if serviceCA, err := os.ReadFile(ServiceCAPath); err == nil {
+		caCertPool.AppendCertsFromPEM(serviceCA)
+	}
+
+	return caCertPool, nil
+}
+
+func copyStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func (pa *prometheusAlerts) executeRequest(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := pa.createAuthenticatedRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return pa.performRequest(client, req)
+}
+
+func (pa *prometheusAlerts) createAuthenticatedRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	token := BearerTokenFromContext(ctx)
+	if token == "" {
+		var err error
+		token, err = pa.loadBearerToken()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req, nil
+}
+
+func (pa *prometheusAlerts) loadBearerToken() (string, error) {
+	if pa.config.BearerToken != "" {
+		return pa.config.BearerToken, nil
+	}
+
+	if pa.config.BearerTokenFile == "" {
+		return "", fmt.Errorf("no bearer token or token file configured")
+	}
+
+	tokenBytes, err := os.ReadFile(pa.config.BearerTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("load bearer token file: %w", err)
+	}
+
+	return strings.TrimSpace(string(tokenBytes)), nil
+}
+
+func (pa *prometheusAlerts) performRequest(client *http.Client, req *http.Request) ([]byte, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/pkg/k8s/prometheus_alerts_test.go
+++ b/pkg/k8s/prometheus_alerts_test.go
@@ -1,0 +1,331 @@
+package k8s
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// --- parseAlertmanagerResponse ---
+
+func TestParseAlertmanagerResponse_ValidAlerts(t *testing.T) {
+	raw, _ := json.Marshal([]alertmanagerAlert{
+		{
+			Labels:      map[string]string{"alertname": "TestAlert", "severity": "critical"},
+			Annotations: map[string]string{"summary": "test"},
+			StartsAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Status:      alertmanagerAlertStatus{State: "active"},
+		},
+		{
+			Labels: map[string]string{"alertname": "SilencedAlert"},
+			Status: alertmanagerAlertStatus{State: "suppressed"},
+		},
+	})
+
+	alerts, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(alerts))
+	}
+	if alerts[0].State != "firing" {
+		t.Errorf("expected state=firing for active alert, got %q", alerts[0].State)
+	}
+	if alerts[0].Labels["alertname"] != "TestAlert" {
+		t.Errorf("expected alertname=TestAlert, got %q", alerts[0].Labels["alertname"])
+	}
+	if alerts[1].State != "silenced" {
+		t.Errorf("expected state=silenced for suppressed alert, got %q", alerts[1].State)
+	}
+}
+
+func TestParseAlertmanagerResponse_UnknownStateSkipped(t *testing.T) {
+	raw, _ := json.Marshal([]alertmanagerAlert{
+		{
+			Labels: map[string]string{"alertname": "UnknownState"},
+			Status: alertmanagerAlertStatus{State: "unprocessed"},
+		},
+	})
+
+	alerts, err := parseAlertmanagerResponse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts for unknown state, got %d", len(alerts))
+	}
+}
+
+func TestParseAlertmanagerResponse_InvalidJSON(t *testing.T) {
+	_, err := parseAlertmanagerResponse([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseAlertmanagerResponse_EmptyArray(t *testing.T) {
+	alerts, err := parseAlertmanagerResponse([]byte("[]"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts, got %d", len(alerts))
+	}
+}
+
+// --- mapAlertmanagerState ---
+
+func TestMapAlertmanagerState(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"active", "firing"},
+		{"suppressed", "silenced"},
+		{"unprocessed", ""},
+		{"", ""},
+		{"unknown", ""},
+	}
+	for _, tc := range cases {
+		got := mapAlertmanagerState(tc.input)
+		if got != tc.want {
+			t.Errorf("mapAlertmanagerState(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- filterAlertsByState ---
+
+func TestFilterAlertsByState(t *testing.T) {
+	alerts := []PrometheusAlert{
+		{Labels: map[string]string{"alertname": "A"}, State: "firing"},
+		{Labels: map[string]string{"alertname": "B"}, State: "pending"},
+		{Labels: map[string]string{"alertname": "C"}, State: "firing"},
+		{Labels: map[string]string{"alertname": "D"}, State: "silenced"},
+	}
+
+	firing := filterAlertsByState(alerts, "firing")
+	if len(firing) != 2 {
+		t.Fatalf("expected 2 firing alerts, got %d", len(firing))
+	}
+
+	pending := filterAlertsByState(alerts, "pending")
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending alert, got %d", len(pending))
+	}
+	if pending[0].Labels["alertname"] != "B" {
+		t.Errorf("expected pending alert B, got %q", pending[0].Labels["alertname"])
+	}
+
+	none := filterAlertsByState(alerts, "resolved")
+	if len(none) != 0 {
+		t.Fatalf("expected 0 resolved alerts, got %d", len(none))
+	}
+}
+
+// --- buildRouteURL ---
+
+func TestBuildRouteURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		host        string
+		routePath   string
+		requestPath string
+		want        string
+	}{
+		{
+			name:        "no route path",
+			host:        "prometheus.example.com",
+			routePath:   "",
+			requestPath: "/api/v1/alerts",
+			want:        "https://prometheus.example.com/api/v1/alerts",
+		},
+		{
+			name:        "route path with trailing slash",
+			host:        "prometheus.example.com",
+			routePath:   "/prom/",
+			requestPath: "/api/v1/alerts",
+			want:        "https://prometheus.example.com/prom/api/v1/alerts",
+		},
+		{
+			name:        "request path already prefixed",
+			host:        "prometheus.example.com",
+			routePath:   "/api",
+			requestPath: "/api/v1/alerts",
+			want:        "https://prometheus.example.com/api/v1/alerts",
+		},
+		{
+			name:        "route path equals request path",
+			host:        "prometheus.example.com",
+			routePath:   "/api/v1/alerts",
+			requestPath: "/api/v1/alerts",
+			want:        "https://prometheus.example.com/api/v1/alerts",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildRouteURL(tc.host, tc.routePath, tc.requestPath)
+			if got != tc.want {
+				t.Errorf("buildRouteURL(%q, %q, %q) = %q, want %q", tc.host, tc.routePath, tc.requestPath, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- namespaceFromLabels ---
+
+func TestNamespaceFromLabels(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"nil labels", nil, ""},
+		{"missing namespace", map[string]string{"other": "val"}, ""},
+		{"present namespace", map[string]string{"namespace": "test-ns"}, "test-ns"},
+		{"whitespace-only namespace", map[string]string{"namespace": "  "}, ""},
+		{"padded namespace", map[string]string{"namespace": " ns-a "}, "ns-a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := namespaceFromLabels(tc.labels)
+			if got != tc.want {
+				t.Errorf("namespaceFromLabels(%v) = %q, want %q", tc.labels, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- applyAlertMetadata ---
+
+func TestApplyAlertMetadata(t *testing.T) {
+	alerts := []PrometheusAlert{
+		{Labels: map[string]string{"alertname": "A"}},
+		{Labels: nil},
+	}
+
+	applyAlertMetadata(alerts, AlertSourcePlatform, AlertBackendAM)
+
+	for i, a := range alerts {
+		if a.Labels[AlertSourceLabel] != AlertSourcePlatform {
+			t.Errorf("alert[%d] source = %q, want %q", i, a.Labels[AlertSourceLabel], AlertSourcePlatform)
+		}
+		if a.Labels[AlertBackendLabel] != AlertBackendAM {
+			t.Errorf("alert[%d] backend = %q, want %q", i, a.Labels[AlertBackendLabel], AlertBackendAM)
+		}
+	}
+}
+
+func TestApplyAlertMetadata_NilLabelsInitialized(t *testing.T) {
+	alerts := []PrometheusAlert{{Labels: nil}}
+	applyAlertMetadata(alerts, "src", "be")
+	if alerts[0].Labels == nil {
+		t.Fatal("expected labels to be initialized, got nil")
+	}
+}
+
+// --- shouldPreferUserAlertmanager ---
+
+func TestShouldPreferUserAlertmanager(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{"firing", true},
+		{"silenced", true},
+		{"pending", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := shouldPreferUserAlertmanager(tc.state)
+		if got != tc.want {
+			t.Errorf("shouldPreferUserAlertmanager(%q) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+}
+
+// --- matchesAlertState ---
+
+func TestMatchesAlertState(t *testing.T) {
+	cases := []struct {
+		requested string
+		alert     string
+		want      bool
+	}{
+		{"", "firing", true},
+		{"", "pending", true},
+		{"", "silenced", true},
+		{"firing", "firing", true},
+		{"firing", "silenced", true},
+		{"firing", "pending", false},
+		{"pending", "pending", true},
+		{"pending", "firing", false},
+		{"silenced", "silenced", true},
+		{"silenced", "firing", false},
+	}
+	for _, tc := range cases {
+		got := matchesAlertState(tc.requested, tc.alert)
+		if got != tc.want {
+			t.Errorf("matchesAlertState(%q, %q) = %v, want %v", tc.requested, tc.alert, got, tc.want)
+		}
+	}
+}
+
+// --- labelsMatch ---
+
+func TestLabelsMatch(t *testing.T) {
+	cases := []struct {
+		name  string
+		req   map[string]string
+		alert map[string]string
+		want  bool
+	}{
+		{
+			name:  "empty request matches everything",
+			req:   nil,
+			alert: map[string]string{"severity": "critical"},
+			want:  true,
+		},
+		{
+			name:  "exact match",
+			req:   map[string]string{"severity": "critical"},
+			alert: map[string]string{"severity": "critical", "alertname": "X"},
+			want:  true,
+		},
+		{
+			name:  "value mismatch",
+			req:   map[string]string{"severity": "warning"},
+			alert: map[string]string{"severity": "critical"},
+			want:  false,
+		},
+		{
+			name:  "label absent on alert",
+			req:   map[string]string{"team": "infra"},
+			alert: map[string]string{"severity": "critical"},
+			want:  false,
+		},
+		{
+			name:  "multiple labels all match",
+			req:   map[string]string{"severity": "critical", "namespace": "ns-a"},
+			alert: map[string]string{"severity": "critical", "namespace": "ns-a", "extra": "val"},
+			want:  true,
+		},
+		{
+			name:  "multiple labels partial mismatch",
+			req:   map[string]string{"severity": "critical", "namespace": "ns-b"},
+			alert: map[string]string{"severity": "critical", "namespace": "ns-a"},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &GetAlertsRequest{Labels: tc.req}
+			alert := &PrometheusAlert{Labels: tc.alert}
+			got := labelsMatch(req, alert)
+			if got != tc.want {
+				t.Errorf("labelsMatch(%v, %v) = %v, want %v", tc.req, tc.alert, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/k8s/rule_label_matchers.go
+++ b/pkg/k8s/rule_label_matchers.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const namespaceLabelKey = "namespace"
+
+func compileRuleLabelMatchers(req GetRulesRequest) ([]*labels.Matcher, error) {
+	var out []*labels.Matcher
+
+	for k, v := range req.Labels {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		if k == namespaceLabelKey {
+			continue
+		}
+		m, err := labels.NewMatcher(labels.MatchEqual, k, v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label matcher %q=%q: %w", k, v, err)
+		}
+		out = append(out, m)
+	}
+
+	for _, raw := range req.Matchers {
+		sel := strings.TrimSpace(raw)
+		if sel == "" {
+			continue
+		}
+		if !strings.HasPrefix(sel, "{") || !strings.HasSuffix(sel, "}") {
+			sel = "{" + sel + "}"
+		}
+		matchers, err := parser.ParseMetricSelector(sel)
+		if err != nil {
+			return nil, fmt.Errorf("invalid matcher %q: %w", raw, err)
+		}
+		out = append(out, matchers...)
+	}
+
+	return out, nil
+}
+
+func filterRuleGroupsByLabelMatchers(groups []PrometheusRuleGroup, matchers []*labels.Matcher) []PrometheusRuleGroup {
+	if len(matchers) == 0 || len(groups) == 0 {
+		return groups
+	}
+
+	out := make([]PrometheusRuleGroup, 0, len(groups))
+	for _, g := range groups {
+		kept := make([]PrometheusRule, 0, len(g.Rules))
+		for _, r := range g.Rules {
+			if ruleMatchesLabelMatchers(r, matchers) {
+				kept = append(kept, r)
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		g.Rules = kept
+		out = append(out, g)
+	}
+
+	return out
+}
+
+func ruleMatchesLabelMatchers(rule PrometheusRule, matchers []*labels.Matcher) bool {
+	if len(matchers) == 0 {
+		return true
+	}
+
+	for _, m := range matchers {
+		val, ok := rule.Labels[m.Name]
+		if !ok {
+			// Prometheus semantics: negative matchers match missing labels.
+			if m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp {
+				continue
+			}
+			return false
+		}
+		if !m.Matches(val) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/k8s/rule_label_matchers.go
+++ b/pkg/k8s/rule_label_matchers.go
@@ -1,0 +1,117 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const namespaceLabelKey = "namespace"
+
+func compileRuleLabelMatchers(req GetRulesRequest) ([]*labels.Matcher, error) {
+	var out []*labels.Matcher
+
+	for k, v := range req.Labels {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		if k == namespaceLabelKey {
+			continue
+		}
+		m, err := labels.NewMatcher(labels.MatchEqual, k, v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label matcher %q=%q: %w", k, v, err)
+		}
+		out = append(out, m)
+	}
+
+	for _, raw := range req.Matchers {
+		sel := strings.TrimSpace(raw)
+		if sel == "" {
+			continue
+		}
+		if !strings.HasPrefix(sel, "{") || !strings.HasSuffix(sel, "}") {
+			sel = "{" + sel + "}"
+		}
+		matchers, err := parser.ParseMetricSelector(sel)
+		if err != nil {
+			return nil, fmt.Errorf("invalid matcher %q: %w", raw, err)
+		}
+		out = append(out, matchers...)
+	}
+
+	return out, nil
+}
+
+func filterRuleGroupsByLabelMatchers(groups []PrometheusRuleGroup, matchers []*labels.Matcher) []PrometheusRuleGroup {
+	if len(matchers) == 0 || len(groups) == 0 {
+		return groups
+	}
+
+	out := make([]PrometheusRuleGroup, 0, len(groups))
+	for _, g := range groups {
+		kept := make([]PrometheusRule, 0, len(g.Rules))
+		for _, r := range g.Rules {
+			if ruleMatchesLabelMatchers(r, matchers) {
+				kept = append(kept, r)
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		g.Rules = kept
+		out = append(out, g)
+	}
+
+	return out
+}
+
+func ruleMatchesLabelMatchers(rule PrometheusRule, matchers []*labels.Matcher) bool {
+	if len(matchers) == 0 {
+		return true
+	}
+
+	for _, m := range matchers {
+		val, ok := rule.Labels[m.Name]
+		if !ok {
+			// Prometheus treats absent labels as "". Evaluate the matcher
+			// against "" so that negative matchers like missing!="" or
+			// missing!~".*" are correctly rejected.
+			if !m.Matches("") {
+				return false
+			}
+			continue
+		}
+		if !m.Matches(val) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesAlertState returns whether an alert state matches the requested filter.
+// An empty requestedState matches all states. "firing" matches both "firing" and
+// "silenced" alerts (Alertmanager silences are a sub-state of firing).
+func matchesAlertState(requestedState string, alertState string) bool {
+	if requestedState == "" {
+		return true
+	}
+	if requestedState == "firing" {
+		return alertState == "firing" || alertState == "silenced"
+	}
+	return alertState == requestedState
+}
+
+// labelsMatch returns true when every label in the request is present on the alert
+// with the same value.
+func labelsMatch(req *GetAlertsRequest, alert *PrometheusAlert) bool {
+	for key, value := range req.Labels {
+		if alertValue, exists := alert.Labels[key]; !exists || alertValue != value {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/k8s/rule_label_matchers_test.go
+++ b/pkg/k8s/rule_label_matchers_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import "testing"
+
+func TestCompileRuleLabelMatchers_IgnoresNamespaceLabel(t *testing.T) {
+	matchers, err := compileRuleLabelMatchers(GetRulesRequest{
+		Labels: map[string]string{
+			"namespace": "ns-a",
+			"severity":  "critical",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(matchers) != 1 {
+		t.Fatalf("expected 1 matcher (severity), got %d", len(matchers))
+	}
+	if matchers[0].Name != "severity" {
+		t.Fatalf("expected matcher for severity, got %q", matchers[0].Name)
+	}
+}
+
+func TestRuleMatchesLabelMatchers_PrometheusMissingLabelSemantics(t *testing.T) {
+	neg, err := compileRuleLabelMatchers(GetRulesRequest{
+		Matchers: []string{`missing!="x"`},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !ruleMatchesLabelMatchers(PrometheusRule{Labels: map[string]string{}}, neg) {
+		t.Fatalf("expected negative matcher to match missing label")
+	}
+
+	pos, err := compileRuleLabelMatchers(GetRulesRequest{
+		Matchers: []string{`missing="x"`},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ruleMatchesLabelMatchers(PrometheusRule{Labels: map[string]string{}}, pos) {
+		t.Fatalf("expected positive matcher not to match missing label")
+	}
+}
+
+func TestCompileRuleLabelMatchers_AcceptsSelectorBody(t *testing.T) {
+	matchers, err := compileRuleLabelMatchers(GetRulesRequest{
+		Matchers: []string{`severity=~"warning|critical"`},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(matchers) != 1 {
+		t.Fatalf("expected 1 matcher, got %d", len(matchers))
+	}
+	if matchers[0].Name != "severity" {
+		t.Fatalf("expected severity matcher, got %q", matchers[0].Name)
+	}
+}

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -21,6 +21,12 @@ type Client interface {
 	// TestConnection tests the connection to the Kubernetes cluster
 	TestConnection(ctx context.Context) error
 
+	// AlertingHealth returns alerting route and stack health details
+	AlertingHealth(ctx context.Context) (AlertingHealth, error)
+
+	// PrometheusAlerts retrieves active Prometheus alerts
+	PrometheusAlerts() PrometheusAlertsInterface
+
 	// PrometheusRules returns the PrometheusRule interface
 	PrometheusRules() PrometheusRuleInterface
 
@@ -35,6 +41,14 @@ type Client interface {
 
 	// Namespace returns the Namespace interface
 	Namespace() NamespaceInterface
+}
+
+// PrometheusAlertsInterface defines operations for managing PrometheusAlerts
+type PrometheusAlertsInterface interface {
+	// GetAlerts retrieves Prometheus alerts with optional state filtering
+	GetAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, error)
+	// GetRules retrieves Prometheus alerting rules and active alerts
+	GetRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error)
 }
 
 // PrometheusRuleInterface defines operations for managing PrometheusRules
@@ -102,6 +116,37 @@ type RelabeledRulesInterface interface {
 
 	// Config returns the list of alert relabel configs
 	Config() []*relabel.Config
+}
+
+// RouteStatus describes the availability state of a monitoring route.
+type RouteStatus string
+
+const (
+	RouteNotFound    RouteStatus = "notFound"
+	RouteUnreachable RouteStatus = "unreachable"
+	RouteReachable   RouteStatus = "reachable"
+)
+
+// AlertingRouteHealth describes route availability and reachability.
+type AlertingRouteHealth struct {
+	Name              string      `json:"name"`
+	Namespace         string      `json:"namespace"`
+	Status            RouteStatus `json:"status"`
+	FallbackReachable bool        `json:"fallbackReachable,omitempty"`
+	Error             string      `json:"error,omitempty"`
+}
+
+// AlertingStackHealth describes alerting health for a monitoring stack.
+type AlertingStackHealth struct {
+	Prometheus   AlertingRouteHealth `json:"prometheus"`
+	Alertmanager AlertingRouteHealth `json:"alertmanager"`
+}
+
+// AlertingHealth provides alerting health details for platform and user workload stacks.
+type AlertingHealth struct {
+	Platform            *AlertingStackHealth `json:"platform"`
+	UserWorkloadEnabled bool                 `json:"userWorkloadEnabled"`
+	UserWorkload        *AlertingStackHealth `json:"userWorkload"`
 }
 
 // NamespaceInterface defines operations for Namespaces

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -21,6 +21,12 @@ type Client interface {
 	// TestConnection tests the connection to the Kubernetes cluster
 	TestConnection(ctx context.Context) error
 
+	// AlertingHealth returns alerting route and stack health details
+	AlertingHealth(ctx context.Context) (AlertingHealth, error)
+
+	// PrometheusAlerts retrieves active Prometheus alerts
+	PrometheusAlerts() PrometheusAlertsInterface
+
 	// PrometheusRules returns the PrometheusRule interface
 	PrometheusRules() PrometheusRuleInterface
 
@@ -35,6 +41,15 @@ type Client interface {
 
 	// Namespace returns the Namespace interface
 	Namespace() NamespaceInterface
+}
+
+// PrometheusAlertsInterface defines operations for managing PrometheusAlerts
+type PrometheusAlertsInterface interface {
+	// FetchAlerts retrieves Prometheus alerts with optional state filtering.
+	// Non-fatal endpoint failures are returned as warnings rather than errors.
+	FetchAlerts(ctx context.Context, req GetAlertsRequest) ([]PrometheusAlert, []string, error)
+	// GetRules retrieves Prometheus alerting rules and active alerts
+	GetRules(ctx context.Context, req GetRulesRequest) ([]PrometheusRuleGroup, error)
 }
 
 // PrometheusRuleInterface defines operations for managing PrometheusRules
@@ -102,6 +117,37 @@ type RelabeledRulesInterface interface {
 
 	// Config returns the list of alert relabel configs
 	Config() []*relabel.Config
+}
+
+// RouteStatus describes the availability state of a monitoring route.
+type RouteStatus string
+
+const (
+	RouteNotFound    RouteStatus = "notFound"
+	RouteUnreachable RouteStatus = "unreachable"
+	RouteReachable   RouteStatus = "reachable"
+)
+
+// AlertingRouteHealth describes route availability and reachability.
+type AlertingRouteHealth struct {
+	Name              string      `json:"name"`
+	Namespace         string      `json:"namespace"`
+	Status            RouteStatus `json:"status"`
+	FallbackReachable bool        `json:"fallbackReachable,omitempty"`
+	Error             string      `json:"error,omitempty"`
+}
+
+// AlertingStackHealth describes alerting health for a monitoring stack.
+type AlertingStackHealth struct {
+	Prometheus   AlertingRouteHealth `json:"prometheus"`
+	Alertmanager AlertingRouteHealth `json:"alertmanager"`
+}
+
+// AlertingHealth provides alerting health details for platform and user workload stacks.
+type AlertingHealth struct {
+	Platform            *AlertingStackHealth `json:"platform"`
+	UserWorkloadEnabled bool                 `json:"userWorkloadEnabled"`
+	UserWorkload        *AlertingStackHealth `json:"userWorkload"`
 }
 
 // NamespaceInterface defines operations for Namespaces

--- a/pkg/management/get_alerting_health.go
+++ b/pkg/management/get_alerting_health.go
@@ -1,0 +1,21 @@
+package management
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+)
+
+const alertingHealthTimeout = 10 * time.Second
+
+// GetAlertingHealth retrieves alerting health details.
+func (c *client) GetAlertingHealth(ctx context.Context) (k8s.AlertingHealth, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		timeoutCtx, cancel := context.WithTimeout(ctx, alertingHealthTimeout)
+		defer cancel()
+		ctx = timeoutCtx
+	}
+
+	return c.k8sClient.AlertingHealth(ctx)
+}

--- a/pkg/management/get_alerts.go
+++ b/pkg/management/get_alerts.go
@@ -1,0 +1,308 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	"k8s.io/apimachinery/pkg/types"
+
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/alertcomponent"
+	"github.com/openshift/monitoring-plugin/pkg/classification"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+var cvoAlertNames = map[string]struct{}{
+	"ClusterOperatorDown":     {},
+	"ClusterOperatorDegraded": {},
+}
+
+func (c *client) GetAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+	alerts, err := c.k8sClient.PrometheusAlerts().GetAlerts(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get prometheus alerts: %w", err)
+	}
+
+	configs := c.k8sClient.RelabeledRules().Config()
+	rules := c.k8sClient.RelabeledRules().List(ctx)
+
+	result := make([]k8s.PrometheusAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		// Only apply relabel configs for platform alerts. User workload alerts
+		// already come from their own stack and should not be relabeled here.
+		if alert.Labels[k8s.AlertSourceLabel] != k8s.AlertSourceUser {
+			relabels, keep := relabel.Process(labels.FromMap(alert.Labels), configs...)
+			if !keep {
+				continue
+			}
+			alert.Labels = relabels.Map()
+		}
+
+		// Add calculated rule ID and source when not present (labels enrichment)
+		c.setRuleIDAndSourceIfMissing(ctx, &alert, rules)
+
+		// correlate alert -> base alert rule via subset matching against relabeled rules
+		alertRuleId := alert.Labels[k8s.AlertRuleLabelId]
+		component := ""
+		layer := ""
+
+		bestRule, corrId := correlateAlertToRule(alert.Labels, rules)
+		if corrId != "" {
+			alertRuleId = corrId
+		}
+		if bestRule == nil && alertRuleId != "" {
+			if rule, ok := c.k8sClient.RelabeledRules().Get(ctx, alertRuleId); ok {
+				bestRule = &rule
+			}
+		}
+
+		if bestRule != nil {
+			if src := c.deriveAlertSource(bestRule.Labels); src != "" {
+				alert.Labels[k8s.AlertSourceLabel] = src
+			}
+			component, layer = classifyFromRule(bestRule)
+		} else {
+			component, layer = classifyFromAlertLabels(alert.Labels)
+		}
+
+		if cvoComponent, cvoLayer, ok := classifyCvoAlert(alert.Labels); ok {
+			component = cvoComponent
+			layer = cvoLayer
+		}
+
+		// Dynamic classification: _from labels on the rule point to alert labels
+		// whose runtime values become the classification. Takes precedence over
+		// static classification labels.
+		if bestRule != nil {
+			component, layer = ApplyDynamicClassification(bestRule.Labels, alert.Labels, component, layer)
+		}
+
+		// keep label and optional enriched fields consistent
+		if alert.Labels[k8s.AlertRuleLabelId] == "" && alertRuleId != "" {
+			alert.Labels[k8s.AlertRuleLabelId] = alertRuleId
+		}
+		alert.AlertRuleId = alertRuleId
+
+		alert.AlertComponent = component
+		alert.AlertLayer = layer
+
+		delete(alert.Labels, managementlabels.ClassificationManagedByKey)
+
+		result = append(result, alert)
+	}
+
+	return result, nil
+}
+
+func (c *client) setRuleIDAndSourceIfMissing(ctx context.Context, alert *k8s.PrometheusAlert, rules []monitoringv1.Rule) {
+	if alert.Labels[k8s.AlertRuleLabelId] == "" {
+		for _, existing := range rules {
+			if existing.Alert != alert.Labels[managementlabels.AlertNameLabel] {
+				continue
+			}
+			if !ruleMatchesAlert(existing.Labels, alert.Labels) {
+				continue
+			}
+			rid := alertrule.GetAlertingRuleId(&existing)
+			alert.Labels[k8s.AlertRuleLabelId] = rid
+			if alert.Labels[k8s.AlertSourceLabel] == "" {
+				if src := c.deriveAlertSource(existing.Labels); src != "" {
+					alert.Labels[k8s.AlertSourceLabel] = src
+				}
+			}
+			break
+		}
+	}
+	if alert.Labels[k8s.AlertSourceLabel] != "" {
+		return
+	}
+	if rid := alert.Labels[k8s.AlertRuleLabelId]; rid != "" {
+		if existing, ok := c.k8sClient.RelabeledRules().Get(ctx, rid); ok {
+			if src := c.deriveAlertSource(existing.Labels); src != "" {
+				alert.Labels[k8s.AlertSourceLabel] = src
+			}
+		}
+	}
+}
+
+func ruleMatchesAlert(existingRuleLabels, alertLabels map[string]string) bool {
+	existingBusiness := filterBusinessLabels(existingRuleLabels)
+	for k, v := range existingBusiness {
+		lv, ok := alertLabels[k]
+		if !ok || lv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// correlateAlertToRule tries to find the base alert rule for the given alert labels
+// by subset-matching against relabeled rules.
+func correlateAlertToRule(alertLabels map[string]string, rules []monitoringv1.Rule) (*monitoringv1.Rule, string) {
+	// Determine best match: prefer rules with more labels (more specific)
+	var (
+		bestId         string
+		bestRule       *monitoringv1.Rule
+		bestLabelCount int
+	)
+	for i := range rules {
+		rule := &rules[i]
+		ruleLabels := sanitizeRuleLabels(rule.Labels)
+		if isSubset(ruleLabels, alertLabels) {
+			if len(ruleLabels) > bestLabelCount {
+				bestLabelCount = len(ruleLabels)
+				bestRule = rule
+				bestId = rule.Labels[k8s.AlertRuleLabelId]
+			}
+		}
+	}
+	if bestRule == nil {
+		return nil, ""
+	}
+	return bestRule, bestId
+}
+
+// sanitizeRuleLabels removes meta labels that will not be present on alerts
+func sanitizeRuleLabels(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if k == k8s.PrometheusRuleLabelNamespace || k == k8s.PrometheusRuleLabelName || k == k8s.AlertRuleLabelId {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// isSubset returns true if all key/value pairs in sub are present in sup
+func isSubset(sub map[string]string, sup map[string]string) bool {
+	for k, v := range sub {
+		if sv, ok := sup[k]; !ok || sv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *client) deriveAlertSource(ruleLabels map[string]string) string {
+	ns := ruleLabels[k8s.PrometheusRuleLabelNamespace]
+	name := ruleLabels[k8s.PrometheusRuleLabelName]
+	if ns == "" || name == "" {
+		return ""
+	}
+	if c.isPlatformManagedPrometheusRule(types.NamespacedName{Namespace: ns, Name: name}) {
+		return k8s.AlertSourcePlatform
+	}
+	return k8s.AlertSourceUser
+}
+
+func classifyFromRule(rule *monitoringv1.Rule) (string, string) {
+	lbls := model.LabelSet{}
+	for k, v := range rule.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	if _, ok := lbls["namespace"]; !ok {
+		if ns := rule.Labels[k8s.PrometheusRuleLabelNamespace]; ns != "" {
+			lbls["namespace"] = model.LabelValue(ns)
+		}
+	}
+	if rule.Alert != "" {
+		lbls[model.LabelName(managementlabels.AlertNameLabel)] = model.LabelValue(rule.Alert)
+	}
+
+	layer, component := alertcomponent.DetermineComponent(lbls)
+	if component == "" || component == "Others" {
+		component = "other"
+		layer = deriveLayerFromSource(rule.Labels)
+	}
+
+	component, layer = applyRuleScopedDefaults(rule.Labels, component, layer)
+	return component, layer
+}
+
+func classifyFromAlertLabels(alertLabels map[string]string) (string, string) {
+	lbls := model.LabelSet{}
+	for k, v := range alertLabels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	layer, component := alertcomponent.DetermineComponent(lbls)
+	if component == "" || component == "Others" {
+		component = "other"
+		layer = deriveLayerFromSource(alertLabels)
+	}
+	component, layer = applyRuleScopedDefaults(alertLabels, component, layer)
+	return component, layer
+}
+
+func deriveLayerFromSource(labels map[string]string) string {
+	if labels[k8s.AlertSourceLabel] == k8s.AlertSourcePlatform {
+		return "cluster"
+	}
+	if labels[k8s.PrometheusRuleLabelNamespace] == k8s.ClusterMonitoringNamespace {
+		return "cluster"
+	}
+	promSrc := labels["prometheus"]
+	if strings.HasPrefix(promSrc, "openshift-monitoring/") {
+		return "cluster"
+	}
+	return "namespace"
+}
+
+// applyRuleScopedDefaults applies static classification labels from the rule.
+func applyRuleScopedDefaults(ruleLabels map[string]string, component, layer string) (string, string) {
+	if ruleLabels == nil {
+		return component, layer
+	}
+	if v := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationComponentKey]); v != "" {
+		if classification.ValidateComponent(v) {
+			component = v
+		}
+	}
+	if v := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationLayerKey]); v != "" {
+		if classification.ValidateLayer(v) {
+			layer = strings.ToLower(strings.TrimSpace(v))
+		}
+	}
+	return component, layer
+}
+
+// applyDynamicClassification handles _from labels: the rule label points to an
+// alert label whose runtime value becomes the classification. _from takes
+// precedence over static classification labels.
+func ApplyDynamicClassification(ruleLabels, alertLabels map[string]string, component, layer string) (string, string) {
+	if ruleLabels == nil {
+		return component, layer
+	}
+	if from := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationComponentFromKey]); from != "" {
+		if classification.ValidatePromLabelName(from) {
+			if v := strings.TrimSpace(alertLabels[from]); v != "" && classification.ValidateComponent(v) {
+				component = v
+			}
+		}
+	}
+	if from := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationLayerFromKey]); from != "" {
+		if classification.ValidatePromLabelName(from) {
+			if v := strings.ToLower(strings.TrimSpace(alertLabels[from])); classification.ValidateLayer(v) {
+				layer = v
+			}
+		}
+	}
+	return component, layer
+}
+
+func classifyCvoAlert(alertLabels map[string]string) (string, string, bool) {
+	if _, ok := cvoAlertNames[alertLabels[managementlabels.AlertNameLabel]]; !ok {
+		return "", "", false
+	}
+	component := alertLabels["name"]
+	if component == "" {
+		component = "version"
+	}
+	return component, "cluster", true
+}

--- a/pkg/management/get_alerts.go
+++ b/pkg/management/get_alerts.go
@@ -1,0 +1,313 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	"k8s.io/apimachinery/pkg/types"
+
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/alertcomponent"
+	"github.com/openshift/monitoring-plugin/pkg/classification"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+var cvoAlertNames = map[string]struct{}{
+	"ClusterOperatorDown":     {},
+	"ClusterOperatorDegraded": {},
+}
+
+func (c *client) EnrichAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+	alerts, warnings, err := c.k8sClient.PrometheusAlerts().FetchAlerts(ctx, req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get prometheus alerts: %w", err)
+	}
+
+	configs := c.k8sClient.RelabeledRules().Config()
+	rules := c.k8sClient.RelabeledRules().List(ctx)
+
+	result := make([]k8s.PrometheusAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		// Only apply relabel configs for platform alerts. User workload alerts
+		// already come from their own stack and should not be relabeled here.
+		if alert.Labels[k8s.AlertSourceLabel] != k8s.AlertSourceUser {
+			relabels, keep := relabel.Process(labels.FromMap(alert.Labels), configs...)
+			if !keep {
+				continue
+			}
+			alert.Labels = relabels.Map()
+		}
+
+		// Add calculated rule ID and source when not present (labels enrichment)
+		c.setRuleIDAndSourceIfMissing(ctx, &alert, rules)
+
+		// correlate alert -> base alert rule via subset matching against relabeled rules
+		alertRuleId := alert.Labels[k8s.AlertRuleLabelId]
+		component := ""
+		layer := ""
+
+		bestRule, corrId := correlateAlertToRule(alert.Labels, rules)
+		if corrId != "" {
+			alertRuleId = corrId
+		}
+		if bestRule == nil && alertRuleId != "" {
+			if rule, ok := c.k8sClient.RelabeledRules().Get(ctx, alertRuleId); ok {
+				bestRule = &rule
+			}
+		}
+
+		if bestRule != nil {
+			if src := c.deriveAlertSource(bestRule.Labels); src != "" {
+				alert.Labels[k8s.AlertSourceLabel] = src
+			}
+			component, layer = classifyFromRule(bestRule)
+		} else {
+			component, layer = classifyFromAlertLabels(alert.Labels)
+		}
+
+		if cvoComponent, cvoLayer, ok := classifyCvoAlert(alert.Labels); ok {
+			component = cvoComponent
+			layer = cvoLayer
+		}
+
+		// Dynamic classification: _from labels on the rule point to alert labels
+		// whose runtime values become the classification. Takes precedence over
+		// static classification labels.
+		if bestRule != nil {
+			component, layer = ApplyDynamicClassification(bestRule.Labels, alert.Labels, component, layer)
+		}
+
+		// keep label and optional enriched fields consistent
+		if alert.Labels[k8s.AlertRuleLabelId] == "" && alertRuleId != "" {
+			alert.Labels[k8s.AlertRuleLabelId] = alertRuleId
+		}
+		alert.AlertRuleId = alertRuleId
+
+		alert.AlertComponent = component
+		alert.AlertLayer = layer
+
+		delete(alert.Labels, managementlabels.ClassificationManagedByKey)
+
+		result = append(result, alert)
+	}
+
+	return result, warnings, nil
+}
+
+func (c *client) setRuleIDAndSourceIfMissing(ctx context.Context, alert *k8s.PrometheusAlert, rules []monitoringv1.Rule) {
+	if alert.Labels[k8s.AlertRuleLabelId] == "" {
+		for _, existing := range rules {
+			if existing.Alert != alert.Labels[managementlabels.AlertNameLabel] {
+				continue
+			}
+			if !ruleMatchesAlert(existing.Labels, alert.Labels) {
+				continue
+			}
+			rid := alertrule.GetAlertingRuleId(&existing)
+			alert.Labels[k8s.AlertRuleLabelId] = rid
+			if alert.Labels[k8s.AlertSourceLabel] == "" {
+				if src := c.deriveAlertSource(existing.Labels); src != "" {
+					alert.Labels[k8s.AlertSourceLabel] = src
+				}
+			}
+			break
+		}
+	}
+	if alert.Labels[k8s.AlertSourceLabel] != "" {
+		return
+	}
+	if rid := alert.Labels[k8s.AlertRuleLabelId]; rid != "" {
+		if existing, ok := c.k8sClient.RelabeledRules().Get(ctx, rid); ok {
+			if src := c.deriveAlertSource(existing.Labels); src != "" {
+				alert.Labels[k8s.AlertSourceLabel] = src
+			}
+		}
+	}
+}
+
+func ruleMatchesAlert(existingRuleLabels, alertLabels map[string]string) bool {
+	existingBusiness := filterBusinessLabels(existingRuleLabels)
+	for k, v := range existingBusiness {
+		lv, ok := alertLabels[k]
+		if !ok || lv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// correlateAlertToRule tries to find the base alert rule for the given alert labels
+// by subset-matching against relabeled rules. Only rules with a matching alert
+// name are considered.
+func correlateAlertToRule(alertLabels map[string]string, rules []monitoringv1.Rule) (*monitoringv1.Rule, string) {
+	alertName := alertLabels[managementlabels.AlertNameLabel]
+
+	var (
+		bestId         string
+		bestRule       *monitoringv1.Rule
+		bestLabelCount int
+	)
+	for i := range rules {
+		rule := &rules[i]
+		if rule.Alert != alertName {
+			continue
+		}
+		ruleLabels := sanitizeRuleLabels(rule.Labels)
+		if isSubset(ruleLabels, alertLabels) {
+			if len(ruleLabels) > bestLabelCount {
+				bestLabelCount = len(ruleLabels)
+				bestRule = rule
+				bestId = rule.Labels[k8s.AlertRuleLabelId]
+			}
+		}
+	}
+	if bestRule == nil {
+		return nil, ""
+	}
+	return bestRule, bestId
+}
+
+// sanitizeRuleLabels removes meta labels that will not be present on alerts
+func sanitizeRuleLabels(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if k == k8s.PrometheusRuleLabelNamespace || k == k8s.PrometheusRuleLabelName || k == k8s.AlertRuleLabelId {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// isSubset returns true if all key/value pairs in sub are present in sup
+func isSubset(sub map[string]string, sup map[string]string) bool {
+	for k, v := range sub {
+		if sv, ok := sup[k]; !ok || sv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *client) deriveAlertSource(ruleLabels map[string]string) string {
+	ns := ruleLabels[k8s.PrometheusRuleLabelNamespace]
+	name := ruleLabels[k8s.PrometheusRuleLabelName]
+	if ns == "" || name == "" {
+		return ""
+	}
+	if c.isPlatformManagedPrometheusRule(types.NamespacedName{Namespace: ns, Name: name}) {
+		return k8s.AlertSourcePlatform
+	}
+	return k8s.AlertSourceUser
+}
+
+func classifyFromRule(rule *monitoringv1.Rule) (string, string) {
+	lbls := model.LabelSet{}
+	for k, v := range rule.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	if _, ok := lbls["namespace"]; !ok {
+		if ns := rule.Labels[k8s.PrometheusRuleLabelNamespace]; ns != "" {
+			lbls["namespace"] = model.LabelValue(ns)
+		}
+	}
+	if rule.Alert != "" {
+		lbls[model.LabelName(managementlabels.AlertNameLabel)] = model.LabelValue(rule.Alert)
+	}
+
+	layer, component := alertcomponent.DetermineComponent(lbls)
+	if component == "" || component == "Others" {
+		component = "Others"
+		layer = deriveLayerFromSource(rule.Labels)
+	}
+
+	component, layer = applyRuleScopedDefaults(rule.Labels, component, layer)
+	return component, layer
+}
+
+func classifyFromAlertLabels(alertLabels map[string]string) (string, string) {
+	lbls := model.LabelSet{}
+	for k, v := range alertLabels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	layer, component := alertcomponent.DetermineComponent(lbls)
+	if component == "" || component == "Others" {
+		component = "Others"
+		layer = deriveLayerFromSource(alertLabels)
+	}
+	component, layer = applyRuleScopedDefaults(alertLabels, component, layer)
+	return component, layer
+}
+
+func deriveLayerFromSource(labels map[string]string) string {
+	if labels[k8s.AlertSourceLabel] == k8s.AlertSourcePlatform {
+		return "cluster"
+	}
+	if labels[k8s.PrometheusRuleLabelNamespace] == k8s.ClusterMonitoringNamespace {
+		return "cluster"
+	}
+	promSrc := labels["prometheus"]
+	if strings.HasPrefix(promSrc, "openshift-monitoring/") {
+		return "cluster"
+	}
+	return "namespace"
+}
+
+// applyRuleScopedDefaults applies static classification labels from the rule.
+func applyRuleScopedDefaults(ruleLabels map[string]string, component, layer string) (string, string) {
+	if ruleLabels == nil {
+		return component, layer
+	}
+	if v := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationComponentKey]); v != "" {
+		if classification.ValidateComponent(v) {
+			component = v
+		}
+	}
+	if v := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationLayerKey]); v != "" {
+		if classification.ValidateLayer(v) {
+			layer = strings.ToLower(strings.TrimSpace(v))
+		}
+	}
+	return component, layer
+}
+
+// applyDynamicClassification handles _from labels: the rule label points to an
+// alert label whose runtime value becomes the classification. _from takes
+// precedence over static classification labels.
+func ApplyDynamicClassification(ruleLabels, alertLabels map[string]string, component, layer string) (string, string) {
+	if ruleLabels == nil {
+		return component, layer
+	}
+	if from := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationComponentFromKey]); from != "" {
+		if classification.ValidatePromLabelName(from) {
+			if v := strings.TrimSpace(alertLabels[from]); v != "" && classification.ValidateComponent(v) {
+				component = v
+			}
+		}
+	}
+	if from := strings.TrimSpace(ruleLabels[k8s.AlertRuleClassificationLayerFromKey]); from != "" {
+		if classification.ValidatePromLabelName(from) {
+			if v := strings.ToLower(strings.TrimSpace(alertLabels[from])); classification.ValidateLayer(v) {
+				layer = v
+			}
+		}
+	}
+	return component, layer
+}
+
+func classifyCvoAlert(alertLabels map[string]string) (string, string, bool) {
+	if _, ok := cvoAlertNames[alertLabels[managementlabels.AlertNameLabel]]; !ok {
+		return "", "", false
+	}
+	component := alertLabels["name"]
+	if component == "" {
+		component = "version"
+	}
+	return component, "cluster", true
+}

--- a/pkg/management/get_alerts_test.go
+++ b/pkg/management/get_alerts_test.go
@@ -1,0 +1,465 @@
+package management_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/management"
+	"github.com/openshift/monitoring-plugin/pkg/management/testutils"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+func TestGetAlerts_ErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return nil, errors.New("failed to get alerts")
+				},
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	_, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get prometheus alerts") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAlerts_ReturnsAllWithoutRelabelConfigs(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+	alert2 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert2", "severity": "critical", "namespace": "kube-system"},
+		State:  "pending",
+	}
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alert1, alert2}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(alerts))
+	}
+	if alerts[0].Labels[managementlabels.AlertNameLabel] != "Alert1" {
+		t.Errorf("alert[0] name mismatch")
+	}
+	if alerts[1].Labels[managementlabels.AlertNameLabel] != "Alert2" {
+		t.Errorf("alert[1] name mismatch")
+	}
+}
+
+func TestGetAlerts_AppliesStaticClassificationFromRelabeledRule(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "test-rule",
+			k8s.AlertRuleClassificationComponentKey: "networking",
+			k8s.AlertRuleClassificationLayerKey:     "cluster",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alert1}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "networking" {
+		t.Errorf("expected component=networking, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_DerivesComponentFromAlertLabel(t *testing.T) {
+	ctx := context.Background()
+	alertWithName := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel: "Alert1",
+			"severity":                      "warning",
+			"namespace":                     "default",
+			"name":                          "kube_apiserver",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                                  "warning",
+			"namespace":                                 "default",
+			k8s.PrometheusRuleLabelNamespace:            "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:                 "test-rule",
+			k8s.AlertRuleClassificationComponentFromKey: "name",
+			k8s.AlertRuleClassificationLayerKey:         "namespace",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alertWithName}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "kube_apiserver" {
+		t.Errorf("expected component=kube_apiserver, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_DerivesLayerFromAlertLabel(t *testing.T) {
+	ctx := context.Background()
+	alertWithLayer := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel: "Alert1",
+			"severity":                      "warning",
+			"namespace":                     "default",
+			"tier":                          "Cluster",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "test-rule",
+			k8s.AlertRuleClassificationComponentKey: "networking",
+			k8s.AlertRuleClassificationLayerFromKey: "tier",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alertWithLayer}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "networking" {
+		t.Errorf("expected component=networking, got %q", alerts[0].AlertComponent)
+	}
+	// "Cluster" from alert label lowercased to "cluster"
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_UsesRuleLabelsAsDefaults(t *testing.T) {
+	ctx := context.Background()
+	alert := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			"alertname":                             "AlertRuleDefaults",
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.AlertRuleClassificationComponentKey: "team_a",
+			k8s.AlertRuleClassificationLayerKey:     "namespace",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "AlertRuleDefaults",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.AlertRuleClassificationComponentKey: "team_a",
+			k8s.AlertRuleClassificationLayerKey:     "namespace",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "defaults-rule",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alert}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "team_a" {
+		t.Errorf("expected component=team_a, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_FallsBackToDefaultWhenNoMatchingRule(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alert1}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc:   func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{} },
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "other" {
+		t.Errorf("expected component=other, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_FallsBackToDefaultWithMatchingRuleNoLabels(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                       "warning",
+			"namespace":                      "default",
+			k8s.PrometheusRuleLabelNamespace: "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:      "default-rule",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{alert1}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "other" {
+		t.Errorf("expected component=other, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_ReturnsEmptyList(t *testing.T) {
+	ctx := context.Background()
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				GetAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+					return []k8s.PrometheusAlert{}, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, err := client.GetAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 0 {
+		t.Errorf("expected empty list, got %d", len(alerts))
+	}
+}

--- a/pkg/management/get_alerts_test.go
+++ b/pkg/management/get_alerts_test.go
@@ -1,0 +1,465 @@
+package management_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	alertrule "github.com/openshift/monitoring-plugin/pkg/alert_rule"
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/pkg/management"
+	"github.com/openshift/monitoring-plugin/pkg/management/testutils"
+	"github.com/openshift/monitoring-plugin/pkg/managementlabels"
+)
+
+func TestGetAlerts_ErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return nil, nil, errors.New("failed to get alerts")
+				},
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	_, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get prometheus alerts") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAlerts_ReturnsAllWithoutRelabelConfigs(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+	alert2 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert2", "severity": "critical", "namespace": "kube-system"},
+		State:  "pending",
+	}
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alert1, alert2}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(alerts))
+	}
+	if alerts[0].Labels[managementlabels.AlertNameLabel] != "Alert1" {
+		t.Errorf("alert[0] name mismatch")
+	}
+	if alerts[1].Labels[managementlabels.AlertNameLabel] != "Alert2" {
+		t.Errorf("alert[1] name mismatch")
+	}
+}
+
+func TestGetAlerts_AppliesStaticClassificationFromRelabeledRule(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "test-rule",
+			k8s.AlertRuleClassificationComponentKey: "networking",
+			k8s.AlertRuleClassificationLayerKey:     "cluster",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alert1}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "networking" {
+		t.Errorf("expected component=networking, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_DerivesComponentFromAlertLabel(t *testing.T) {
+	ctx := context.Background()
+	alertWithName := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel: "Alert1",
+			"severity":                      "warning",
+			"namespace":                     "default",
+			"name":                          "kube_apiserver",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                                  "warning",
+			"namespace":                                 "default",
+			k8s.PrometheusRuleLabelNamespace:            "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:                 "test-rule",
+			k8s.AlertRuleClassificationComponentFromKey: "name",
+			k8s.AlertRuleClassificationLayerKey:         "namespace",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alertWithName}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "kube_apiserver" {
+		t.Errorf("expected component=kube_apiserver, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_DerivesLayerFromAlertLabel(t *testing.T) {
+	ctx := context.Background()
+	alertWithLayer := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			managementlabels.AlertNameLabel: "Alert1",
+			"severity":                      "warning",
+			"namespace":                     "default",
+			"tier":                          "Cluster",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "test-rule",
+			k8s.AlertRuleClassificationComponentKey: "networking",
+			k8s.AlertRuleClassificationLayerFromKey: "tier",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alertWithLayer}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+		NamespaceFunc: func() k8s.NamespaceInterface {
+			ns := &testutils.MockNamespaceInterface{}
+			ns.SetMonitoringNamespaces(map[string]bool{"openshift-monitoring": true})
+			return ns
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "networking" {
+		t.Errorf("expected component=networking, got %q", alerts[0].AlertComponent)
+	}
+	// "Cluster" from alert label lowercased to "cluster"
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_UsesRuleLabelsAsDefaults(t *testing.T) {
+	ctx := context.Background()
+	alert := k8s.PrometheusAlert{
+		Labels: map[string]string{
+			"alertname":                             "AlertRuleDefaults",
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.AlertRuleClassificationComponentKey: "team_a",
+			k8s.AlertRuleClassificationLayerKey:     "namespace",
+		},
+		State: "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "AlertRuleDefaults",
+		Labels: map[string]string{
+			"severity":                              "warning",
+			"namespace":                             "default",
+			k8s.AlertRuleClassificationComponentKey: "team_a",
+			k8s.AlertRuleClassificationLayerKey:     "namespace",
+			k8s.PrometheusRuleLabelNamespace:        "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:             "defaults-rule",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alert}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "team_a" {
+		t.Errorf("expected component=team_a, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_FallsBackToDefaultWhenNoMatchingRule(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alert1}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc:   func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{} },
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "Others" {
+		t.Errorf("expected component=Others, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "namespace" {
+		t.Errorf("expected layer=namespace, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_FallsBackToDefaultWithMatchingRuleNoLabels(t *testing.T) {
+	ctx := context.Background()
+	alert1 := k8s.PrometheusAlert{
+		Labels: map[string]string{managementlabels.AlertNameLabel: "Alert1", "severity": "warning", "namespace": "default"},
+		State:  "firing",
+	}
+
+	rule := monitoringv1.Rule{
+		Alert: "Alert1",
+		Labels: map[string]string{
+			"severity":                       "warning",
+			"namespace":                      "default",
+			k8s.PrometheusRuleLabelNamespace: "openshift-monitoring",
+			k8s.PrometheusRuleLabelName:      "default-rule",
+		},
+	}
+	rule.Labels[k8s.AlertRuleLabelId] = alertrule.GetAlertingRuleId(&rule)
+
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{alert1}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ListFunc: func(_ context.Context) []monitoringv1.Rule { return []monitoringv1.Rule{rule} },
+				GetFunc: func(_ context.Context, id string) (monitoringv1.Rule, bool) {
+					if id == rule.Labels[k8s.AlertRuleLabelId] {
+						return rule, true
+					}
+					return monitoringv1.Rule{}, false
+				},
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].AlertComponent != "Others" {
+		t.Errorf("expected component=Others, got %q", alerts[0].AlertComponent)
+	}
+	if alerts[0].AlertLayer != "cluster" {
+		t.Errorf("expected layer=cluster, got %q", alerts[0].AlertLayer)
+	}
+}
+
+func TestGetAlerts_ReturnsEmptyList(t *testing.T) {
+	ctx := context.Background()
+	mockK8s := &testutils.MockClient{
+		PrometheusAlertsFunc: func() k8s.PrometheusAlertsInterface {
+			return &testutils.MockPrometheusAlertsInterface{
+				FetchAlertsFunc: func(_ context.Context, _ k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+					return []k8s.PrometheusAlert{}, nil, nil
+				},
+			}
+		},
+		RelabeledRulesFunc: func() k8s.RelabeledRulesInterface {
+			return &testutils.MockRelabeledRulesInterface{
+				ConfigFunc: func() []*relabel.Config { return []*relabel.Config{} },
+			}
+		},
+	}
+	client := management.New(ctx, mockK8s)
+
+	alerts, _, err := client.EnrichAlerts(ctx, k8s.GetAlertsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alerts) != 0 {
+		t.Errorf("expected empty list, got %d", len(alerts))
+	}
+}

--- a/pkg/management/management_suite_test.go
+++ b/pkg/management/management_suite_test.go
@@ -1,0 +1,15 @@
+package management_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestMain(m *testing.M) {
+	// LegacyValidation is required for tests that construct relabel configs
+	// containing label names with special characters (e.g. slashes).
+	model.NameValidationScheme = model.LegacyValidation //nolint:staticcheck
+	os.Exit(m.Run())
+}

--- a/pkg/management/testutils/k8s_client_mock.go
+++ b/pkg/management/testutils/k8s_client_mock.go
@@ -17,6 +17,8 @@ import (
 // by AlertingRules().Get) hit the same store.
 type MockClient struct {
 	TestConnectionFunc      func(ctx context.Context) error
+	AlertingHealthFunc      func(ctx context.Context) (k8s.AlertingHealth, error)
+	PrometheusAlertsFunc    func() k8s.PrometheusAlertsInterface
 	PrometheusRulesFunc     func() k8s.PrometheusRuleInterface
 	AlertRelabelConfigsFunc func() k8s.AlertRelabelConfigInterface
 	AlertingRulesFunc       func() k8s.AlertingRuleInterface
@@ -36,6 +38,20 @@ func (m *MockClient) TestConnection(ctx context.Context) error {
 		return m.TestConnectionFunc(ctx)
 	}
 	return nil
+}
+
+func (m *MockClient) AlertingHealth(ctx context.Context) (k8s.AlertingHealth, error) {
+	if m.AlertingHealthFunc != nil {
+		return m.AlertingHealthFunc(ctx)
+	}
+	return k8s.AlertingHealth{}, nil
+}
+
+func (m *MockClient) PrometheusAlerts() k8s.PrometheusAlertsInterface {
+	if m.PrometheusAlertsFunc != nil {
+		return m.PrometheusAlertsFunc()
+	}
+	return &MockPrometheusAlertsInterface{}
 }
 
 func (m *MockClient) PrometheusRules() k8s.PrometheusRuleInterface {
@@ -88,7 +104,42 @@ func (m *MockClient) Namespace() k8s.NamespaceInterface {
 	return m.namespace
 }
 
-// MockPrometheusRuleInterface is a mock implementation of k8s.PrometheusRuleInterface
+type MockPrometheusAlertsInterface struct {
+	GetAlertsFunc func(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error)
+	GetRulesFunc  func(ctx context.Context, req k8s.GetRulesRequest) ([]k8s.PrometheusRuleGroup, error)
+
+	ActiveAlerts []k8s.PrometheusAlert
+	RuleGroups   []k8s.PrometheusRuleGroup
+}
+
+func (m *MockPrometheusAlertsInterface) SetActiveAlerts(alerts []k8s.PrometheusAlert) {
+	m.ActiveAlerts = alerts
+}
+
+func (m *MockPrometheusAlertsInterface) SetRuleGroups(groups []k8s.PrometheusRuleGroup) {
+	m.RuleGroups = groups
+}
+
+func (m *MockPrometheusAlertsInterface) GetAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error) {
+	if m.GetAlertsFunc != nil {
+		return m.GetAlertsFunc(ctx, req)
+	}
+	if m.ActiveAlerts != nil {
+		return m.ActiveAlerts, nil
+	}
+	return []k8s.PrometheusAlert{}, nil
+}
+
+func (m *MockPrometheusAlertsInterface) GetRules(ctx context.Context, req k8s.GetRulesRequest) ([]k8s.PrometheusRuleGroup, error) {
+	if m.GetRulesFunc != nil {
+		return m.GetRulesFunc(ctx, req)
+	}
+	if m.RuleGroups != nil {
+		return m.RuleGroups, nil
+	}
+	return []k8s.PrometheusRuleGroup{}, nil
+}
+
 type MockPrometheusRuleInterface struct {
 	ListFunc    func() ([]monitoringv1.PrometheusRule, error)
 	GetFunc     func(ctx context.Context, namespace string, name string) (*monitoringv1.PrometheusRule, bool, error)

--- a/pkg/management/testutils/k8s_client_mock.go
+++ b/pkg/management/testutils/k8s_client_mock.go
@@ -17,6 +17,8 @@ import (
 // by AlertingRules().Get) hit the same store.
 type MockClient struct {
 	TestConnectionFunc      func(ctx context.Context) error
+	AlertingHealthFunc      func(ctx context.Context) (k8s.AlertingHealth, error)
+	PrometheusAlertsFunc    func() k8s.PrometheusAlertsInterface
 	PrometheusRulesFunc     func() k8s.PrometheusRuleInterface
 	AlertRelabelConfigsFunc func() k8s.AlertRelabelConfigInterface
 	AlertingRulesFunc       func() k8s.AlertingRuleInterface
@@ -28,6 +30,7 @@ type MockClient struct {
 	alertingRules       k8s.AlertingRuleInterface
 	relabeledRules      k8s.RelabeledRulesInterface
 	namespace           k8s.NamespaceInterface
+	prometheusAlerts    k8s.PrometheusAlertsInterface
 }
 
 // TestConnection mocks the TestConnection method
@@ -36,6 +39,23 @@ func (m *MockClient) TestConnection(ctx context.Context) error {
 		return m.TestConnectionFunc(ctx)
 	}
 	return nil
+}
+
+func (m *MockClient) AlertingHealth(ctx context.Context) (k8s.AlertingHealth, error) {
+	if m.AlertingHealthFunc != nil {
+		return m.AlertingHealthFunc(ctx)
+	}
+	return k8s.AlertingHealth{}, nil
+}
+
+func (m *MockClient) PrometheusAlerts() k8s.PrometheusAlertsInterface {
+	if m.PrometheusAlertsFunc != nil {
+		return m.PrometheusAlertsFunc()
+	}
+	if m.prometheusAlerts == nil {
+		m.prometheusAlerts = &MockPrometheusAlertsInterface{}
+	}
+	return m.prometheusAlerts
 }
 
 func (m *MockClient) PrometheusRules() k8s.PrometheusRuleInterface {
@@ -88,7 +108,42 @@ func (m *MockClient) Namespace() k8s.NamespaceInterface {
 	return m.namespace
 }
 
-// MockPrometheusRuleInterface is a mock implementation of k8s.PrometheusRuleInterface
+type MockPrometheusAlertsInterface struct {
+	FetchAlertsFunc func(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error)
+	GetRulesFunc    func(ctx context.Context, req k8s.GetRulesRequest) ([]k8s.PrometheusRuleGroup, error)
+
+	ActiveAlerts []k8s.PrometheusAlert
+	RuleGroups   []k8s.PrometheusRuleGroup
+}
+
+func (m *MockPrometheusAlertsInterface) SetActiveAlerts(alerts []k8s.PrometheusAlert) {
+	m.ActiveAlerts = alerts
+}
+
+func (m *MockPrometheusAlertsInterface) SetRuleGroups(groups []k8s.PrometheusRuleGroup) {
+	m.RuleGroups = groups
+}
+
+func (m *MockPrometheusAlertsInterface) FetchAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error) {
+	if m.FetchAlertsFunc != nil {
+		return m.FetchAlertsFunc(ctx, req)
+	}
+	if m.ActiveAlerts != nil {
+		return m.ActiveAlerts, nil, nil
+	}
+	return []k8s.PrometheusAlert{}, nil, nil
+}
+
+func (m *MockPrometheusAlertsInterface) GetRules(ctx context.Context, req k8s.GetRulesRequest) ([]k8s.PrometheusRuleGroup, error) {
+	if m.GetRulesFunc != nil {
+		return m.GetRulesFunc(ctx, req)
+	}
+	if m.RuleGroups != nil {
+		return m.RuleGroups, nil
+	}
+	return []k8s.PrometheusRuleGroup{}, nil
+}
+
 type MockPrometheusRuleInterface struct {
 	ListFunc    func() ([]monitoringv1.PrometheusRule, error)
 	GetFunc     func(ctx context.Context, namespace string, name string) (*monitoringv1.PrometheusRule, bool, error)

--- a/pkg/management/types.go
+++ b/pkg/management/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
 )
 
 // Client is the interface for managing alert rules
@@ -46,6 +48,12 @@ type Client interface {
 	UpdateAlertRuleClassification(ctx context.Context, req UpdateRuleClassificationRequest) error
 	// BulkUpdateAlertRuleClassification updates classification for multiple rule ids
 	BulkUpdateAlertRuleClassification(ctx context.Context, items []UpdateRuleClassificationRequest) []error
+
+	// GetAlerts retrieves Prometheus alerts
+	GetAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, error)
+
+	// GetAlertingHealth retrieves the alerting stack health status
+	GetAlertingHealth(ctx context.Context) (k8s.AlertingHealth, error)
 }
 
 // PrometheusRuleOptions specifies options for selecting PrometheusRule resources and groups

--- a/pkg/management/types.go
+++ b/pkg/management/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
 )
 
 // Client is the interface for managing alert rules
@@ -46,6 +48,13 @@ type Client interface {
 	UpdateAlertRuleClassification(ctx context.Context, req UpdateRuleClassificationRequest) error
 	// BulkUpdateAlertRuleClassification updates classification for multiple rule ids
 	BulkUpdateAlertRuleClassification(ctx context.Context, items []UpdateRuleClassificationRequest) []error
+
+	// EnrichAlerts retrieves and enriches Prometheus alerts with classification.
+	// Non-fatal endpoint failures are returned as warnings.
+	EnrichAlerts(ctx context.Context, req k8s.GetAlertsRequest) ([]k8s.PrometheusAlert, []string, error)
+
+	// GetAlertingHealth retrieves the alerting stack health status
+	GetAlertingHealth(ctx context.Context) (k8s.AlertingHealth, error)
 }
 
 // PrometheusRuleOptions specifies options for selecting PrometheusRule resources and groups

--- a/pkg/management/update_classification.go
+++ b/pkg/management/update_classification.go
@@ -434,28 +434,3 @@ func getOriginalPlatformRuleFromPR(pr *monitoringv1.PrometheusRule, namespace st
 		AdditionalInfo: fmt.Sprintf("in PrometheusRule %s/%s", namespace, name),
 	}
 }
-
-// ApplyDynamicClassification resolves the effective component and layer for an
-// alert by applying _from indirection. If a rule carries a component_from or
-// layer_from label, the corresponding alert label value is used instead of the
-// static default. Unresolvable or empty lookups fall back to the supplied
-// defaults.
-func ApplyDynamicClassification(ruleLabels, alertLabels map[string]string, defaultComponent, defaultLayer string) (string, string) {
-	component := defaultComponent
-	layer := defaultLayer
-
-	if ruleLabels != nil {
-		if fromKey := ruleLabels[k8s.AlertRuleClassificationComponentFromKey]; fromKey != "" {
-			if v, ok := alertLabels[fromKey]; ok && v != "" {
-				component = v
-			}
-		}
-		if fromKey := ruleLabels[k8s.AlertRuleClassificationLayerFromKey]; fromKey != "" {
-			if v, ok := alertLabels[fromKey]; ok && v != "" {
-				layer = strings.ToLower(v)
-			}
-		}
-	}
-
-	return component, layer
-}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -332,6 +332,64 @@ func (f *Framework) CreateScopedUser(ctx context.Context, name, namespace, apiGr
 	return &ScopedUser{Token: token, Cleanup: func() error { rollback(); return nil }}, nil
 }
 
+// CreateUserWithClusterRole creates a ServiceAccount in the given namespace and
+// binds an existing ClusterRole to it via a namespaced RoleBinding. Use this
+// for OpenShift built-in roles such as monitoring-rules-view (Thanos tenancy
+// on port 9093). API calls are retried to tolerate transient failures.
+func (f *Framework) CreateUserWithClusterRole(ctx context.Context, name, namespace, clusterRoleName string) (*ScopedUser, error) {
+	rollback := func() {
+		_ = f.Clientset.RbacV1().RoleBindings(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		_ = f.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	err := retry(3, func() error {
+		_, err := f.Clientset.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating service account %s/%s: %w", namespace, name, err)
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      name,
+			Namespace: namespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+	}
+	err = retry(3, func() error {
+		_, err := f.Clientset.RbacV1().RoleBindings(namespace).Create(ctx, rb, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("creating role binding %s/%s for cluster role %s: %w", namespace, name, clusterRoleName, err)
+	}
+
+	token, err := f.requestServiceAccountToken(ctx, namespace, name)
+	if err != nil {
+		rollback()
+		return nil, err
+	}
+
+	return &ScopedUser{Token: token, Cleanup: func() error { rollback(); return nil }}, nil
+}
+
 // CreateAnonymousUser creates a ServiceAccount with no RBAC permissions.
 // The whole setup is retried to tolerate transient API failures.
 func (f *Framework) CreateAnonymousUser(ctx context.Context, name, namespace string) (*ScopedUser, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -5,6 +5,7 @@ package framework
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -258,10 +259,18 @@ func (f *Framework) requestServiceAccountToken(ctx context.Context, namespace, n
 // and a cleanup function. The apiGroup should be e.g. "monitoring.coreos.com".
 // API calls are retried to tolerate transient failures.
 func (f *Framework) CreateScopedUser(ctx context.Context, name, namespace, apiGroup string, resources, verbs []string) (*ScopedUser, error) {
-	rollback := func() {
-		_ = f.Clientset.RbacV1().RoleBindings(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-		_ = f.Clientset.RbacV1().Roles(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-		_ = f.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	rollback := func() error {
+		var errs []error
+		if err := f.Clientset.RbacV1().RoleBindings(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting role binding %s/%s: %w", namespace, name, err))
+		}
+		if err := f.Clientset.RbacV1().Roles(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting role %s/%s: %w", namespace, name, err))
+		}
+		if err := f.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting service account %s/%s: %w", namespace, name, err))
+		}
+		return errors.Join(errs...)
 	}
 
 	sa := &corev1.ServiceAccount{
@@ -294,7 +303,7 @@ func (f *Framework) CreateScopedUser(ctx context.Context, name, namespace, apiGr
 		return err
 	})
 	if err != nil {
-		rollback()
+		_ = rollback()
 		return nil, fmt.Errorf("creating role %s/%s: %w", namespace, name, err)
 	}
 
@@ -319,17 +328,81 @@ func (f *Framework) CreateScopedUser(ctx context.Context, name, namespace, apiGr
 		return err
 	})
 	if err != nil {
-		rollback()
+		_ = rollback()
 		return nil, fmt.Errorf("creating role binding %s/%s: %w", namespace, name, err)
 	}
 
 	token, err := f.requestServiceAccountToken(ctx, namespace, name)
 	if err != nil {
-		rollback()
+		_ = rollback()
 		return nil, err
 	}
 
-	return &ScopedUser{Token: token, Cleanup: func() error { rollback(); return nil }}, nil
+	return &ScopedUser{Token: token, Cleanup: rollback}, nil
+}
+
+// CreateUserWithClusterRole creates a ServiceAccount in the given namespace and
+// binds an existing ClusterRole to it via a namespaced RoleBinding. Use this
+// for OpenShift built-in roles such as monitoring-rules-view (Thanos tenancy
+// on port 9093). API calls are retried to tolerate transient failures.
+func (f *Framework) CreateUserWithClusterRole(ctx context.Context, name, namespace, clusterRoleName string) (*ScopedUser, error) {
+	rollback := func() error {
+		var errs []error
+		if err := f.Clientset.RbacV1().RoleBindings(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting role binding %s/%s: %w", namespace, name, err))
+		}
+		if err := f.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting service account %s/%s: %w", namespace, name, err))
+		}
+		return errors.Join(errs...)
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	err := retry(3, func() error {
+		_, err := f.Clientset.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating service account %s/%s: %w", namespace, name, err)
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      name,
+			Namespace: namespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+	}
+	err = retry(3, func() error {
+		_, err := f.Clientset.RbacV1().RoleBindings(namespace).Create(ctx, rb, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		_ = rollback()
+		return nil, fmt.Errorf("creating role binding %s/%s for cluster role %s: %w", namespace, name, clusterRoleName, err)
+	}
+
+	token, err := f.requestServiceAccountToken(ctx, namespace, name)
+	if err != nil {
+		_ = rollback()
+		return nil, err
+	}
+
+	return &ScopedUser{Token: token, Cleanup: rollback}, nil
 }
 
 // CreateAnonymousUser creates a ServiceAccount with no RBAC permissions.

--- a/test/e2e/framework/framework_test.go
+++ b/test/e2e/framework/framework_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+
+package framework
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetry_SucceedsOnFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retry(3, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retry(3, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error after retry, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetry_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	err := retry(3, func() error {
+		calls++
+		return errors.New("persistent")
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetry_ZeroAttempts(t *testing.T) {
+	calls := 0
+	err := retry(0, func() error {
+		calls++
+		return errors.New("should not be called")
+	})
+	if err != nil {
+		t.Fatalf("expected nil with 0 attempts, got %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("expected 0 calls with n=0, got %d", calls)
+	}
+}
+
+func TestPoll_SucceedsImmediately(t *testing.T) {
+	err := Poll(time.Millisecond, 50*time.Millisecond, func() error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestPoll_FailsOnTimeout(t *testing.T) {
+	calls := 0
+	err := Poll(time.Millisecond, 50*time.Millisecond, func() error {
+		calls++
+		return errors.New("still failing")
+	})
+	if err == nil {
+		t.Fatal("expected error on timeout")
+	}
+}

--- a/test/e2e/framework/poll.go
+++ b/test/e2e/framework/poll.go
@@ -25,3 +25,14 @@ func Poll(interval, timeout time.Duration, f func() error) error {
 	}
 	return err
 }
+
+// retry calls f up to n times, returning the last error on failure.
+func retry(n int, f func() error) error {
+	var err error
+	for i := 0; i < n; i++ {
+		if err = f(); err == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/test/e2e/get_alerts_test.go
+++ b/test/e2e/get_alerts_test.go
@@ -1,0 +1,297 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/test/e2e/framework"
+)
+
+func TestGetAlerts(t *testing.T) {
+	f, err := framework.New()
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	ctx := context.Background()
+
+	testNamespace, cleanup, err := f.CreateUserNamespace(ctx, "test-get-alerts")
+	if err != nil {
+		t.Fatalf("Failed to create test namespace: %v", err)
+	}
+	defer cleanup()
+
+	forDuration := monitoringv1.Duration("1s")
+	alertName := "E2EGetAlertsTest"
+
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2e-get-alerts-rule",
+			Namespace: testNamespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "e2e-test-group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: alertName,
+							Expr:  intstr.FromString("vector(1)"),
+							For:   &forDuration,
+							Labels: map[string]string{
+								"severity": "none",
+								"team":     "e2e",
+							},
+							Annotations: map[string]string{
+								"summary": "E2E test alert for GET /alerts",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = f.Monitoringv1clientset.MonitoringV1().PrometheusRules(testNamespace).Create(
+		ctx, promRule, metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create PrometheusRule: %v", err)
+	}
+
+	httpClient := f.HTTPClient()
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		alertsURL := f.PluginURL + "/api/v1/alerting/alerts"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, alertsURL, nil)
+		if err != nil {
+			return false, err
+		}
+		if f.BearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+f.BearerToken)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Logf("Failed to query alerts: %v", err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("GET /alerts returned status %d, retrying", resp.StatusCode)
+			return false, nil
+		}
+
+		var alertsResp struct {
+			Data struct {
+				Alerts []k8s.PrometheusAlert `json:"alerts"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&alertsResp); err != nil {
+			t.Logf("Failed to decode alerts response: %v", err)
+			return false, nil
+		}
+
+		for _, alert := range alertsResp.Data.Alerts {
+			if alert.Labels["alertname"] == alertName {
+				if alert.State != "firing" && alert.State != "pending" {
+					t.Logf("Found alert %s but state is %q, waiting for firing/pending", alertName, alert.State)
+					return false, nil
+				}
+				if alert.Labels["severity"] != "none" {
+					t.Errorf("Expected severity=none, got %q", alert.Labels["severity"])
+				}
+				t.Logf("Found alert %s in state %q", alertName, alert.State)
+				return true, nil
+			}
+		}
+
+		t.Logf("Alert %s not found yet (got %d alerts total)", alertName, len(alertsResp.Data.Alerts))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timeout waiting for alert to appear: %v", err)
+	}
+
+	t.Log("GET /alerts e2e test passed successfully")
+}
+
+// TestRBAC_GetAlerts verifies Thanos-tenancy RBAC for GET /alerts.
+//
+// With ?namespace=: User A (no perms) gets HTTP 200 without the UWM alert in
+// ns Y; User B (monitoring-rules-view in Y) sees Y but not Z; cluster-admin
+// sees Y.
+//
+// Without ?namespace=: fan-out must not leak the alert to unprivileged users
+// and must still return it for namespace-scoped viewers.
+func TestRBAC_GetAlerts(t *testing.T) {
+	f, err := framework.New()
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	ctx := context.Background()
+
+	nsY, cleanupY, err := f.CreateUserNamespace(ctx, "test-rbac-get-alerts-y")
+	if err != nil {
+		t.Fatalf("Failed to create namespace Y: %v", err)
+	}
+	defer func() { _ = cleanupY() }()
+
+	nsZ, cleanupZ, err := f.CreateUserNamespace(ctx, "test-rbac-get-alerts-z")
+	if err != nil {
+		t.Fatalf("Failed to create namespace Z: %v", err)
+	}
+	defer func() { _ = cleanupZ() }()
+
+	userA, err := f.CreateAnonymousUser(ctx, "e2e-rbac-get-a", "default")
+	if err != nil {
+		t.Fatalf("Failed to create unprivileged user A: %v", err)
+	}
+	defer func() { _ = userA.Cleanup() }()
+
+	userB, err := f.CreateUserWithClusterRole(ctx, "e2e-rbac-get-b", nsY, "monitoring-rules-view")
+	if err != nil {
+		t.Fatalf("Failed to create scoped user B: %v", err)
+	}
+	defer func() { _ = userB.Cleanup() }()
+
+	alertName := "E2ERBACGetAlertsTest"
+	if err := createFiringPrometheusRule(ctx, f, nsY, "e2e-rbac-get-alerts-rule", alertName); err != nil {
+		t.Fatalf("Failed to create PrometheusRule: %v", err)
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		alerts, status, err := getAlertsWithToken(f, ctx, f.BearerToken, nsY)
+		if err != nil {
+			t.Logf("Admin GET /alerts failed: %v", err)
+			return false, nil
+		}
+		if status != http.StatusOK {
+			t.Logf("Admin GET /alerts returned status %d, retrying", status)
+			return false, nil
+		}
+		if containsAlert(alerts, alertName) {
+			t.Logf("Admin sees alert %s", alertName)
+			return true, nil
+		}
+		t.Logf("Waiting for alert %s (admin sees %d alerts)", alertName, len(alerts))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timeout waiting for admin to see alert: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		token     string
+		namespace string
+		wantAlert bool
+	}{
+		{"UserA_NoPerms_NamespaceY", userA.Token, nsY, false},
+		{"UserA_NoPerms_NoNamespace", userA.Token, "", false},
+		{"UserB_RulesView_NamespaceY", userB.Token, nsY, true},
+		{"UserB_RulesView_NamespaceZ", userB.Token, nsZ, false},
+		{"UserB_RulesView_NoNamespace", userB.Token, "", true},
+		{"UserC_ClusterAdmin_NamespaceY", f.BearerToken, nsY, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alerts, status, err := getAlertsWithToken(f, ctx, tc.token, tc.namespace)
+			if err != nil {
+				t.Fatalf("GET /alerts request failed: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("Expected status %d, got %d", http.StatusOK, status)
+			}
+			got := containsAlert(alerts, alertName)
+			if got != tc.wantAlert {
+				t.Fatalf("Alert %s visibility: want %v, got %v (%d alerts returned)", alertName, tc.wantAlert, got, len(alerts))
+			}
+		})
+	}
+}
+
+func createFiringPrometheusRule(ctx context.Context, f *framework.Framework, namespace, name, alertName string) error {
+	forDuration := monitoringv1.Duration("1s")
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{{
+				Name: "e2e-rbac-group",
+				Rules: []monitoringv1.Rule{{
+					Alert: alertName,
+					Expr:  intstr.FromString("vector(1)"),
+					For:   &forDuration,
+					Labels: map[string]string{
+						"severity": "none",
+						"e2e_test": "rbac_get",
+					},
+				}},
+			}},
+		},
+	}
+	_, err := f.Monitoringv1clientset.MonitoringV1().PrometheusRules(namespace).Create(ctx, promRule, metav1.CreateOptions{})
+	return err
+}
+
+func containsAlert(alerts []k8s.PrometheusAlert, alertName string) bool {
+	for _, a := range alerts {
+		if a.Labels["alertname"] == alertName {
+			return true
+		}
+	}
+	return false
+}
+
+// getAlertsWithToken calls GET /alerts with an optional namespace query param.
+// It returns the decoded alerts and HTTP status. A non-OK status is not an
+// error — callers must assert on status explicitly.
+func getAlertsWithToken(f *framework.Framework, ctx context.Context, token, namespace string) ([]k8s.PrometheusAlert, int, error) {
+	alertsURL := f.PluginURL + "/api/v1/alerting/alerts"
+	if namespace != "" {
+		alertsURL += "?" + url.Values{"namespace": {namespace}}.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, alertsURL, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := f.HTTPClient().Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+
+	var alertsResp struct {
+		Data struct {
+			Alerts []k8s.PrometheusAlert `json:"alerts"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&alertsResp); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("decoding response: %w", err)
+	}
+	return alertsResp.Data.Alerts, resp.StatusCode, nil
+}

--- a/test/e2e/get_alerts_test.go
+++ b/test/e2e/get_alerts_test.go
@@ -1,0 +1,317 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/monitoring-plugin/pkg/k8s"
+	"github.com/openshift/monitoring-plugin/test/e2e/framework"
+)
+
+func TestGetAlerts(t *testing.T) {
+	f, err := framework.New()
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	ctx := context.Background()
+
+	testNamespace, cleanup, err := f.CreateUserNamespace(ctx, "test-get-alerts")
+	if err != nil {
+		t.Fatalf("Failed to create test namespace: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Logf("cleanup failed: %v", err)
+		}
+	}()
+
+	forDuration := monitoringv1.Duration("1s")
+	alertName := "E2EGetAlertsTest"
+
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2e-get-alerts-rule",
+			Namespace: testNamespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "e2e-test-group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: alertName,
+							Expr:  intstr.FromString("vector(1)"),
+							For:   &forDuration,
+							Labels: map[string]string{
+								"severity": "none",
+								"team":     "e2e",
+							},
+							Annotations: map[string]string{
+								"summary": "E2E test alert for GET /alerts",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = f.Monitoringv1clientset.MonitoringV1().PrometheusRules(testNamespace).Create(
+		ctx, promRule, metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create PrometheusRule: %v", err)
+	}
+
+	httpClient := f.HTTPClient()
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		alertsURL := f.PluginURL + "/api/v1/alerting/alerts"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, alertsURL, nil)
+		if err != nil {
+			return false, err
+		}
+		if f.BearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+f.BearerToken)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Logf("Failed to query alerts: %v", err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("GET /alerts returned status %d, retrying", resp.StatusCode)
+			return false, nil
+		}
+
+		var alertsResp struct {
+			Data struct {
+				Alerts []k8s.PrometheusAlert `json:"alerts"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&alertsResp); err != nil {
+			t.Logf("Failed to decode alerts response: %v", err)
+			return false, nil
+		}
+
+		for _, alert := range alertsResp.Data.Alerts {
+			if alert.Labels["alertname"] == alertName {
+				if alert.State != "firing" && alert.State != "pending" {
+					t.Logf("Found alert %s but state is %q, waiting for firing/pending", alertName, alert.State)
+					return false, nil
+				}
+				if alert.Labels["severity"] != "none" {
+					t.Errorf("Expected severity=none, got %q", alert.Labels["severity"])
+				}
+				t.Logf("Found alert %s in state %q", alertName, alert.State)
+				return true, nil
+			}
+		}
+
+		t.Logf("Alert %s not found yet (got %d alerts total)", alertName, len(alertsResp.Data.Alerts))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timeout waiting for alert to appear: %v", err)
+	}
+
+	t.Log("GET /alerts e2e test passed successfully")
+}
+
+// TestRBAC_GetAlerts verifies Thanos-tenancy RBAC for GET /alerts.
+//
+// With ?namespace=: User A (no perms) gets HTTP 200 without the UWM alert in
+// ns Y; User B (monitoring-rules-view in Y) sees Y but not Z; cluster-admin
+// sees Y.
+//
+// Without ?namespace=: fan-out must not leak the alert to unprivileged users
+// and must still return it for namespace-scoped viewers.
+func TestRBAC_GetAlerts(t *testing.T) {
+	f, err := framework.New()
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	ctx := context.Background()
+
+	nsY, cleanupY, err := f.CreateUserNamespace(ctx, "test-rbac-get-alerts-y")
+	if err != nil {
+		t.Fatalf("Failed to create namespace Y: %v", err)
+	}
+	defer func() {
+		if err := cleanupY(); err != nil {
+			t.Logf("cleanup namespace Y failed: %v", err)
+		}
+	}()
+
+	nsZ, cleanupZ, err := f.CreateUserNamespace(ctx, "test-rbac-get-alerts-z")
+	if err != nil {
+		t.Fatalf("Failed to create namespace Z: %v", err)
+	}
+	defer func() {
+		if err := cleanupZ(); err != nil {
+			t.Logf("cleanup namespace Z failed: %v", err)
+		}
+	}()
+
+	userA, err := f.CreateAnonymousUser(ctx, "e2e-rbac-get-a", "default")
+	if err != nil {
+		t.Fatalf("Failed to create unprivileged user A: %v", err)
+	}
+	defer func() {
+		if err := userA.Cleanup(); err != nil {
+			t.Logf("cleanup user A failed: %v", err)
+		}
+	}()
+
+	userB, err := f.CreateUserWithClusterRole(ctx, "e2e-rbac-get-b", nsY, "monitoring-rules-view")
+	if err != nil {
+		t.Fatalf("Failed to create scoped user B: %v", err)
+	}
+	defer func() {
+		if err := userB.Cleanup(); err != nil {
+			t.Logf("cleanup user B failed: %v", err)
+		}
+	}()
+
+	alertName := "E2ERBACGetAlertsTest"
+	if err := createFiringPrometheusRule(ctx, f, nsY, "e2e-rbac-get-alerts-rule", alertName); err != nil {
+		t.Fatalf("Failed to create PrometheusRule: %v", err)
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		alerts, status, err := getAlertsWithToken(f, ctx, f.BearerToken, nsY)
+		if err != nil {
+			t.Logf("Admin GET /alerts failed: %v", err)
+			return false, nil
+		}
+		if status != http.StatusOK {
+			t.Logf("Admin GET /alerts returned status %d, retrying", status)
+			return false, nil
+		}
+		if containsAlert(alerts, alertName) {
+			t.Logf("Admin sees alert %s", alertName)
+			return true, nil
+		}
+		t.Logf("Waiting for alert %s (admin sees %d alerts)", alertName, len(alerts))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timeout waiting for admin to see alert: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		token     string
+		namespace string
+		wantAlert bool
+	}{
+		{"UserA_NoPerms_NamespaceY", userA.Token, nsY, false},
+		{"UserA_NoPerms_NoNamespace", userA.Token, "", false},
+		{"UserB_RulesView_NamespaceY", userB.Token, nsY, true},
+		{"UserB_RulesView_NamespaceZ", userB.Token, nsZ, false},
+		{"UserB_RulesView_NoNamespace", userB.Token, "", true},
+		{"UserC_ClusterAdmin_NamespaceY", f.BearerToken, nsY, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alerts, status, err := getAlertsWithToken(f, ctx, tc.token, tc.namespace)
+			if err != nil {
+				t.Fatalf("GET /alerts request failed: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("Expected status %d, got %d", http.StatusOK, status)
+			}
+			got := containsAlert(alerts, alertName)
+			if got != tc.wantAlert {
+				t.Fatalf("Alert %s visibility: want %v, got %v (%d alerts returned)", alertName, tc.wantAlert, got, len(alerts))
+			}
+		})
+	}
+}
+
+func createFiringPrometheusRule(ctx context.Context, f *framework.Framework, namespace, name, alertName string) error {
+	forDuration := monitoringv1.Duration("1s")
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{{
+				Name: "e2e-rbac-group",
+				Rules: []monitoringv1.Rule{{
+					Alert: alertName,
+					Expr:  intstr.FromString("vector(1)"),
+					For:   &forDuration,
+					Labels: map[string]string{
+						"severity": "none",
+						"e2e_test": "rbac_get",
+					},
+				}},
+			}},
+		},
+	}
+	_, err := f.Monitoringv1clientset.MonitoringV1().PrometheusRules(namespace).Create(ctx, promRule, metav1.CreateOptions{})
+	return err
+}
+
+func containsAlert(alerts []k8s.PrometheusAlert, alertName string) bool {
+	for _, a := range alerts {
+		if a.Labels["alertname"] == alertName {
+			return true
+		}
+	}
+	return false
+}
+
+// getAlertsWithToken calls GET /alerts with an optional namespace query param.
+// It returns the decoded alerts and HTTP status. A non-OK status is not an
+// error — callers must assert on status explicitly.
+func getAlertsWithToken(f *framework.Framework, ctx context.Context, token, namespace string) ([]k8s.PrometheusAlert, int, error) {
+	alertsURL := f.PluginURL + "/api/v1/alerting/alerts"
+	if namespace != "" {
+		alertsURL += "?" + url.Values{"namespace": {namespace}}.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, alertsURL, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := f.HTTPClient().Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+
+	var alertsResp struct {
+		Data struct {
+			Alerts []k8s.PrometheusAlert `json:"alerts"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&alertsResp); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("decoding response: %w", err)
+	}
+	return alertsResp.Data.Alerts, resp.StatusCode, nil
+}


### PR DESCRIPTION
Add Prometheus, Thanos, and Alertmanager
query support with GET /api/v1/alerting/
alerts endpoint including alert component
matching and alerting health status.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Signed-off-by: João Vilaça <jvilaca@redhat.com>
Signed-off-by: Aviv Litman <alitman@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `GET /api/v1/alerting/alerts` endpoint for retrieving alerts.
  - Supports filtering by alert state, labels, and namespace-scoped results.
  - Enriches alerts with rule details, source, severity, component, and layer information.
  - Added alerting health reporting for monitoring routes and workload monitoring.
- **Bug Fixes**
  - Added validation and clear warnings for invalid filters, unavailable monitoring routes, and configuration issues.
  - Improved alert and rule retrieval across platform and workload monitoring sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->