### PR TITLE
OU-1417: Fix Perses tooltips background color in OCP 5

### DIFF
--- a/web/src/features/perses-dashboards/components/PersesWrapper.tsx
+++ b/web/src/features/perses-dashboards/components/PersesWrapper.tsx
@@ -6,6 +6,8 @@ import {
   chart_color_blue_300,
   chart_color_blue_400,
   chart_color_blue_500,
+  t_color_gray_10,
+  t_color_gray_90,
   t_color_gray_95,
   t_color_white,
   t_global_background_color_100,
@@ -373,6 +375,7 @@ export function useRemotePluginLoader(): PluginLoader {
 export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
   const navigate = useNavigate();
+  const isDark = theme === 'dark';
 
   const muiTheme = getTheme(theme, {
     shape: {
@@ -384,6 +387,13 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {
     echartsTheme: {
       color: patternflyChartsMultiUnorderedPalette,
+      tooltip: {
+        backgroundColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        borderColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        textStyle: {
+          color: isDark ? t_color_gray_90.value : t_color_white.value,
+        },
+      },
     },
     thresholds: {
       defaultColor: patternflyBlue300,


### PR DESCRIPTION
### JIRA 
[OU-1417](https://redhat.atlassian.net/browse/OU-1417)

### Image 
quay.io/jezhu/monitoring-console-plugin:ou1417-aug26-2026


### Description 
Fix the background color of the tooltip from transparent to a black background in light mode and a white background in dark mode. 

The issue was reported for OCP 5 in light + glass contrast mode. Below is the fix in light + glass contrast mode for scatter chart, bar chart, and pie chart

<img width="760" height="315" alt="Screenshot 2026-08-24 at 5 59 57 PM" src="https://github.com/user-attachments/assets/7856c15d-da8c-45e2-90cb-52e9f10d1cd2" />
<img width="777" height="253" alt="Screenshot 2026-08-24 at 6 00 10 PM" src="https://github.com/user-attachments/assets/f57db183-0826-4f1d-8ef1-c2ed4aa7d376" />

<img width="771" height="243" alt="Screenshot 2026-08-24 at 6 00 40 PM" src="https://github.com/user-attachments/assets/6737d33f-a281-48aa-a0e4-e929e522ab0a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard chart readability in dark mode by adapting tooltip backgrounds, borders, and text colors to the active theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->