### PR TITLE
OLS-3921: disable button shrink

### DIFF
--- a/web/src/features/perses-dashboards/ols-tool-ui/helpers/AddToDashboardButton.tsx
+++ b/web/src/features/perses-dashboards/ols-tool-ui/helpers/AddToDashboardButton.tsx
@@ -16,6 +16,7 @@ export const HeaderIconButton: StyledComponent<IconButtonProps & { theme?: Theme
 )(({ theme }) => ({
   borderRadius: theme.shape.borderRadius,
   padding: '4px',
+  flexShrink: 0,
 }));
 
 function createPanelDefinition(query: string, name: string, description: string): PanelDefinition {


### PR DESCRIPTION
The button will keep its size even if there is a large title:

<img width="609" height="253" alt="Screenshot 2026-08-26 at 12 53 33" src="https://github.com/user-attachments/assets/f6225b42-f234-4e6c-bce0-2cec0f7e4aa2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dashboard header button layout to prevent unwanted shrinking and maintain consistent sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->