### PR TITLE
OU-1423: fix: adjust perses mui theme to patternfly glass mode

### DIFF
--- a/web/src/features/perses-dashboards/components/PersesWrapper.tsx
+++ b/web/src/features/perses-dashboards/components/PersesWrapper.tsx
@@ -156,6 +156,7 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
           root: {
             borderRadius: 'var(--pf-t--global--border--radius--medium)',
             borderColor: 'var(--pf-t--global--border--color--default)',
+            backgroundColor: 'var(--pf-t--global--background--color--primary--default)',
           },
         },
       },
@@ -189,15 +190,16 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
       MuiOutlinedInput: {
         styleOverrides: {
           notchedOutline: {
-            borderColor: 'var(--pf-t--global--border--color--default)',
+            borderColor: 'var(--pf-t--global--border--color--control--default)',
           },
           root: {
             '&:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'var(--pf-t--global--border--color--default)',
+              borderColor: 'var(--pf-t--global--border--color--clicked)',
             },
             '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'var(--pf-t--global--border--color--default)',
+              borderColor: 'var(--pf-t--global--border--color--clicked)',
             },
+            backgroundColor: 'var(--pf-t--global--background--color--control--default)',
           },
           input: {
             // Dashboard Variables >> Text Variable
@@ -224,6 +226,11 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
             '&.MuiButton-contained.MuiButton-colorPrimary': {
               color: t_color_white.value,
             },
+          },
+          outlinedSecondary: {
+            borderColor: 'var(--pf-t--global--border--color--default)',
+            borderRadius: 'var(--pf-t--global--border--radius--pill)',
+            color: isDark ? patternflyBlue100 : patternflyBlue300,
           },
         },
       },
@@ -300,6 +307,8 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
             '& .MuiButton-colorSecondary': {
               borderRadius: 'var(--pf-t--global--border--radius--pill) !important',
             },
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            backgroundImage: 'none',
           },
         },
       },
@@ -352,6 +361,21 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
           root: {
             // Uniform font weight in all table cells
             fontWeight: 'var(--pf-t--global--font--weight--body--default) !important',
+          },
+        },
+      },
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: 'transparent !important',
+          },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            backgroundImage: 'none',
           },
         },
       },


### PR DESCRIPTION
<img width="1430" height="559" alt="Screenshot 2026-08-27 at 11 53 24" src="https://github.com/user-attachments/assets/46d8c256-6460-4a10-acbe-65bbbe5756b2" />
<img width="842" height="530" alt="Screenshot 2026-08-27 at 11 53 31" src="https://github.com/user-attachments/assets/b2e5cf24-d454-4d9e-a37f-91329bfefae0" />
<img width="1765" height="1010" alt="Screenshot 2026-08-27 at 11 54 27" src="https://github.com/user-attachments/assets/8e1fc9ea-d3de-4b42-a730-3620ec552be9" />
<img width="1493" height="775" alt="Screenshot 2026-08-27 at 11 54 48" src="https://github.com/user-attachments/assets/386444e9-3e8d-4daa-ab4d-514de8391d54" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard components to better match the application theme.
  * Improved card, input, button, drawer, app bar, and dialog styling.
  * Refined hover and focus states for outlined inputs.
  * Added consistent background colors and removed unwanted background images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->