### PR TITLE
OCPBUGS-114795, OCPBUGS-114776: fix: upgrade vulnerable dompurify dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10927,9 +10927,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -174,7 +174,7 @@
   "overrides": {
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
-    "dompurify": "^3.4.11",
+    "dompurify": "3.4.13",
     "fast-uri": "3.1.4"
   },
   "consolePlugin": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web application’s security package to a specific version for more consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->