### PR TITLE
OCPBUGS-114789, OCPBUGS-114792, OCPBUGS-114786: fix: upgrade vulnerable fast-uri dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12979,9 +12979,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -175,7 +175,7 @@
     "echarts": "^5.6.0",
     "qs": "^6.14.1",
     "dompurify": "3.4.13",
-    "fast-uri": "3.1.4"
+    "fast-uri": "3.1.6"
   },
   "consolePlugin": {
     "name": "monitoring-plugin",


### PR DESCRIPTION
Fixes also: 

- https://redhat.atlassian.net/browse/OCPBUGS-114792
- https://redhat.atlassian.net/browse/OCPBUGS-114786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `fast-uri` version to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->