### PR TITLE
OU-1417:: [release-coo-ocp-4.22] Fix Perses tooltips background color

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -43,6 +43,8 @@ import {
   chart_color_blue_300,
   chart_color_blue_400,
   chart_color_blue_500,
+  t_color_gray_10,
+  t_color_gray_90,
   t_color_gray_95,
   t_color_white,
   t_global_background_color_100,
@@ -393,6 +395,7 @@ export function useRemotePluginLoader(): PluginLoader {
 export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
   const navigate = useNavigate();
+  const isDark = theme === 'dark';
 
   const muiTheme = getTheme(theme, {
     shape: {
@@ -404,6 +407,13 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {
     echartsTheme: {
       color: patternflyChartsMultiUnorderedPalette,
+      tooltip: {
+        backgroundColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        borderColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        textStyle: {
+          color: isDark ? t_color_gray_90.value : t_color_white.value,
+        },
+      },
     },
     thresholds: {
       defaultColor: patternflyBlue300,


### PR DESCRIPTION
## Backport of #1178

### Original Change

Fix Perses tooltips background color so they match the PatternFly theme in both light and dark modes (OCP 5).

### Backport Target

- Branch: `release-coo-ocp-4.22`
- COO Fast

### Adaptations Made

- [x] No adaptations needed — PF v6 tokens used directly
- [x] Glass mode fix (PR #1195) already present on this branch; only tooltip fix applied

### Testing

- [ ] `npm run lint` passes
- [ ] `npm run lint:tsc` passes
- [ ] `npm run test:unit` passes