### PR TITLE
[release-coo-1.5-ocp-4.19] Fix Perses tooltips background color

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -42,6 +42,8 @@ import {
   chart_color_blue_300,
   chart_color_blue_400,
   chart_color_blue_500,
+  t_color_gray_10,
+  t_color_gray_90,
   t_color_gray_95,
   t_color_white,
   t_global_background_color_100,
@@ -148,6 +150,7 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
           root: {
             borderRadius: 'var(--pf-t--global--border--radius--medium)',
             borderColor: 'var(--pf-t--global--border--color--default)',
+            backgroundColor: 'var(--pf-t--global--background--color--primary--default)',
           },
         },
       },
@@ -181,15 +184,16 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
       MuiOutlinedInput: {
         styleOverrides: {
           notchedOutline: {
-            borderColor: 'var(--pf-t--global--border--color--default)',
+            borderColor: 'var(--pf-t--global--border--color--control--default)',
           },
           root: {
             '&:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'var(--pf-t--global--border--color--default)',
+              borderColor: 'var(--pf-t--global--border--color--clicked)',
             },
             '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'var(--pf-t--global--border--color--default)',
+              borderColor: 'var(--pf-t--global--border--color--clicked)',
             },
+            backgroundColor: 'var(--pf-t--global--background--color--control--default)',
           },
           input: {
             // Dashboard Variables >> Text Variable
@@ -216,6 +220,11 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
             '&.MuiButton-contained.MuiButton-colorPrimary': {
               color: t_color_white.value,
             },
+          },
+          outlinedSecondary: {
+            borderColor: 'var(--pf-t--global--border--color--default)',
+            borderRadius: 'var(--pf-t--global--border--radius--pill)',
+            color: isDark ? patternflyBlue100 : patternflyBlue300,
           },
         },
       },
@@ -270,6 +279,8 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
             '& .MuiButton-colorSecondary': {
               borderRadius: 'var(--pf-t--global--border--radius--pill) !important',
             },
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            backgroundImage: 'none',
           },
         },
       },
@@ -325,6 +336,21 @@ const mapPatterflyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
           },
         },
       },
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: 'transparent !important',
+          },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            backgroundImage: 'none',
+          },
+        },
+      },
     },
   };
 };
@@ -345,6 +371,8 @@ export function useRemotePluginLoader(): PluginLoader {
 export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
   const [dashboardName] = useQueryParam(QueryParams.Dashboard, StringParam);
+  const isDark = theme === 'dark';
+
   const muiTheme = getTheme(theme, {
     shape: {
       borderRadius: 6,
@@ -355,6 +383,13 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {
     echartsTheme: {
       color: patternflyChartsMultiUnorderedPalette,
+      tooltip: {
+        backgroundColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        borderColor: isDark ? t_color_gray_10.value : t_global_background_color_400.value,
+        textStyle: {
+          color: isDark ? t_color_gray_90.value : t_color_white.value,
+        },
+      },
     },
     thresholds: {
       defaultColor: patternflyBlue300,


### PR DESCRIPTION
## Backport of #1178

### Original Change

Fix Perses tooltips background color so they match the PatternFly theme in both light and dark modes.

### Backport Target

- Branch: `release-coo-1.5-ocp-4.19`
- COO LTS

### Adaptations Made

- [x] No adaptations needed — PF v6 tokens used directly
- [x] Pre-existing lint errors in dashboard-api.ts and dashboard-list.tsx fixed

### Testing

- [ ] `npm run lint` passes
- [ ] `npm run lint:tsc` passes
- [ ] `npm run test:unit` passes