### PR TITLE
[release-coo-ocp-4.15] Fix Perses tooltips background color

### DIFF
--- a/web/src/components/dashboards/perses/PersesWrapper.tsx
+++ b/web/src/components/dashboards/perses/PersesWrapper.tsx
@@ -315,6 +315,7 @@ const mapPatternFlyThemeToMUI = (theme: 'light' | 'dark'): ThemeOptions => {
 export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
   const [dashboardName] = useQueryParam(QueryParams.Dashboard, StringParam);
+  const isDark = theme === 'dark';
 
   const muiTheme = getTheme(theme, {
     typography: {
@@ -330,6 +331,13 @@ export function PersesWrapper({ children, project }: PersesWrapperProps) {
   const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {
     echartsTheme: {
       color: patternflyChartsMultiUnorderedPalette,
+      tooltip: {
+        backgroundColor: isDark ? '#f0f0f0' : '#212427',
+        borderColor: isDark ? '#f0f0f0' : '#212427',
+        textStyle: {
+          color: isDark ? '#151515' : '#ffffff',
+        },
+      },
     },
     thresholds: {
       defaultColor: patternflyBlue300,


### PR DESCRIPTION
## Backport of #1178

### Original Change

Fix Perses tooltips background color so they match the PatternFly theme in both light and dark modes.

### Backport Target

- Branch: `release-coo-ocp-4.15`
- COO Fast

### Adaptations Made

- [x] PF v6 tokens adapted to hardcoded hex values for PF v5 compatibility
- [x] Glass mode fix skipped (PF v5 does not support glass mode)

### Testing

- [ ] `npm run lint` passes
- [ ] `npm run lint:tsc` passes
- [ ] `npm run test:unit` passes