### PR TITLE
NO-JIRA: Add dchromik to observability-ui aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,8 +3,10 @@ aliases:
     - jgbernalp
     - zhuje
     - peteryurkovich
+    - dchromik
   observability-ui:
     - jgbernalp
     - zhuje
     - peteryurkovich
     - etmurasaki
+    - dchromik


### PR DESCRIPTION
Updated observability-ui and observability-ui-dev aliases, added dchromik.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership metadata to include an additional maintainer for observability UI development and maintenance.
  * No user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->