### PR TITLE
OCPBUGS-119714, OCPBUGS-119717: fix: upgrade fast-uri to 3.1.7

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11559,9 +11559,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -173,7 +173,7 @@
     "echarts": "^5.6.0",
     "qs": "6.16.0",
     "dompurify": "3.4.13",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.15.1"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `fast-uri` component to version 3.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->