### PR TITLE
OU-791: hide Export as CSV link on empty Alerts page

### DIFF
--- a/web/cypress/views/list-page.ts
+++ b/web/cypress/views/list-page.ts
@@ -287,5 +287,6 @@ export const listPage = {
     cy.log('listPage.emptyState');
     cy.byTestID(DataTestIDs.EmptyBoxBody).contains('No alerts found').should('be.visible');
     cy.byOUIAID(DataTestIDs.Table).should('not.exist');
+    cy.byTestID(DataTestIDs.DownloadCSVButton).should('not.exist');
   },
 };

--- a/web/src/features/alerts/pages/alerts-page/AlertsPage.tsx
+++ b/web/src/features/alerts/pages/alerts-page/AlertsPage.tsx
@@ -280,7 +280,11 @@ const AlertsPage_: FC = () => {
                   ))}
                 </TableFilters>
               }
-              actions={<DownloadCSVButton loaded={loaded} filteredData={aggregatedAlerts} />}
+              actions={
+                aggregatedAlerts?.length > 0 && (
+                  <DownloadCSVButton loaded={loaded} filteredData={aggregatedAlerts} />
+                )
+              }
               pagination={
                 <TablePagination
                   variant={PaginationVariant.top}


### PR DESCRIPTION
**JIRA** 
https://redhat.atlassian.net/browse/OU-791

**Image** 
quay.io/jezhu/monitoring-plugin:ou791-alerts-fix-csv-link-sep9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The CSV download option is now hidden when no alerts are available.
  - Empty alert states now correctly reflect that downloads are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->